### PR TITLE
(github): fix default prod url

### DIFF
--- a/.github/scripts/daily_train.py
+++ b/.github/scripts/daily_train.py
@@ -36,7 +36,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="FiForesight daily RL training")
     parser.add_argument(
         "--url",
-        default="https://fiforesight.duckdns.org",
+        default="http://fiforesight.duckdns.org",
         help="Base URL of the deployed app (default: prod)",
     )
     parser.add_argument(

--- a/.github/workflows/daily-train.yml
+++ b/.github/workflows/daily-train.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run daily training (20 tickers)
         run: |
-          URL="${{ inputs.target_url || vars.TRAIN_URL || 'https://fiforesight.duckdns.org' }}"
+          URL="${{ inputs.target_url || vars.TRAIN_URL || 'http://fiforesight.duckdns.org' }}"
           python .github/scripts/daily_train.py --url "$URL" --delay 8
         env:
           PYTHONUNBUFFERED: "1"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default endpoint URL scheme for automated training operations from HTTPS to HTTP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->