### PR TITLE
Implement HTTPS and update environment URLs

### DIFF
--- a/.github/actions/deploy-oracle/action.yml
+++ b/.github/actions/deploy-oracle/action.yml
@@ -47,7 +47,7 @@ runs:
           docker run -d \
             --name fiforesight \
             --restart always \
-            -p 80:3000 \
+            -p 3000:3000 \
             -e GOOGLE_GENAI_API_KEY=${{ env.GOOGLE_GENAI_API_KEY }} \
             -e FINNHUB_API_KEY=${{ env.FINNHUB_API_KEY }} \
             -e INFLUXDB_BUCKET=${{ env.INFLUXDB_BUCKET }} \

--- a/.github/actions/setup-https/action.yml
+++ b/.github/actions/setup-https/action.yml
@@ -1,0 +1,96 @@
+name: Setup HTTPS
+description: "Setup HTTPS and Nginx"
+runs:
+  using: "composite"
+  steps:
+    - name: Copy Nginx config
+      uses: appleboy/scp-action@v1
+      with:
+        host: ${{ env.VM_IP_ADDRESS }}
+        username: ubuntu
+        key: ${{ env.VM_SSH_PRIVATE_KEY }}
+        source: nginx/
+        target: /home/ubuntu/
+
+    - name: Setup iptables, Nginx + Certbot
+      uses: appleboy/ssh-action@v1
+      with:
+        host: ${{ env.VM_IP_ADDRESS }}
+        username: ubuntu
+        key: ${{ env.VM_SSH_PRIVATE_KEY }}
+        script: |
+          set -e
+          
+          DOMAIN="${{ env.DOMAIN }}"
+          EMAIL="${{ env.EMAIL }}"
+          DUCK_DNS_TOKEN="${{ env.DUCK_DNS_TOKEN }}"
+          NGINX_CONF=/etc/nginx/sites-available/fiforesight
+          CERT_PATH=/etc/letsencrypt/live/$DOMAIN/fullchain.pem
+          
+          # ---- iptables — 443 ----
+          if ! sudo iptables -C INPUT -p tcp --dport 443 -j ACCEPT 2>/dev/null; then
+            sudo iptables -I INPUT -p tcp --dport 443 -j ACCEPT
+          fi
+          
+          # ---- iptables — remove port 80 if exists----
+          if sudo iptables -C INPUT -p tcp --dport 80 -j ACCEPT 2>/dev/null; then
+            sudo iptables -D INPUT -p tcp --dport 80 -j ACCEPT
+            echo "Removed port 80"
+          else
+            echo "Port 80 not found, nothing to remove"
+          fi
+          
+          if ! dpkg -l iptables-persistent &>/dev/null; then
+            sudo apt-get install -y iptables-persistent
+          fi
+          sudo netfilter-persistent save
+          
+          # ---- Install Nginx + Certbot + DuckDNS plugin ----
+          sudo apt-get update -qq
+          sudo apt-get install -y nginx certbot python3-pip
+          sudo pip3 install certbot-dns-duckdns
+          
+          # ---- Write DuckDNS token config ----
+          sudo mkdir -p /etc/letsencrypt
+          printf 'dns_duckdns_token = %s\n' "$DUCK_DNS_TOKEN" | sudo tee /etc/letsencrypt/duckdns.ini > /dev/null
+          sudo chmod 600 /etc/letsencrypt/duckdns.ini
+          
+          # ---- Deploy Nginx config ----
+          sudo cp /home/ubuntu/nginx/app.conf $NGINX_CONF
+          sudo sed -i "s|YOUR_DOMAIN|$DOMAIN|g" $NGINX_CONF
+          sudo sed -i "s|YOUR_CERT_PATH|/etc/letsencrypt/live/$DOMAIN/fullchain.pem|g" $NGINX_CONF
+          sudo sed -i "s|YOUR_CERT_KEY_PATH|/etc/letsencrypt/live/$DOMAIN/privkey.pem|g" $NGINX_CONF
+          sudo ln -sf $NGINX_CONF /etc/nginx/sites-enabled/fiforesight
+          sudo rm -f /etc/nginx/sites-enabled/default
+          
+          # ---- Issue cert via DNS challenge ----
+          if [ ! -f "$CERT_PATH" ]; then
+            echo "Certificate not found, issuing new cert..."
+            sudo certbot certonly \
+              --authenticator dns-duckdns \
+              --dns-duckdns-credentials /etc/letsencrypt/duckdns.ini \
+              --dns-duckdns-propagation-seconds 60 \
+              -d $DOMAIN \
+              --email $EMAIL \
+              --agree-tos \
+              --no-eff-email \
+              --non-interactive \
+              --deploy-hook "systemctl reload nginx"
+          else
+            echo "Certificate already exists, running renew check..."
+            sudo certbot renew --dry-run
+            sudo certbot renew --deploy-hook "systemctl reload nginx"
+          fi
+          
+          # ---- Start Nginx after cert is in place ----
+          sudo nginx -t
+          sudo systemctl enable nginx
+          sudo systemctl restart nginx
+          
+          # ---- Enable renewal timer ----
+          sudo systemctl enable certbot.timer
+          sudo systemctl start certbot.timer
+          
+          # ---- Logrotate ----
+          sudo cp /home/ubuntu/nginx/logrotate /etc/logrotate.d/nginx
+          sudo logrotate --debug /etc/logrotate.d/nginx

--- a/.github/scripts/daily_train.py
+++ b/.github/scripts/daily_train.py
@@ -36,7 +36,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="FiForesight daily RL training")
     parser.add_argument(
         "--url",
-        default="http://fiforesight.duckdns.org",
+        default="https://fiforesight.duckdns.org",
         help="Base URL of the deployed app (default: prod)",
     )
     parser.add_argument(

--- a/.github/workflows/daily-train.yml
+++ b/.github/workflows/daily-train.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run daily training (20 tickers)
         run: |
-          URL="${{ inputs.target_url || vars.TRAIN_URL || 'http://fiforesight.duckdns.org' }}"
+          URL="${{ inputs.target_url || vars.TRAIN_URL || 'https://fiforesight.duckdns.org' }}"
           python .github/scripts/daily_train.py --url "$URL" --delay 8
         env:
           PYTHONUNBUFFERED: "1"

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -7,6 +7,7 @@ on:
 env:
   GH_TOKEN: ${{ github.token }}
   IMAGE_NAME: ghcr.io/weekenddevelopment/fiforesight
+  EMAIL: ${{ secrets.CERTBOT_EMAIL }}
 permissions:
   contents: write
   id-token: write
@@ -196,6 +197,25 @@ jobs:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
 
+  deploy-nginx:
+    needs:
+      - terraform
+    runs-on: ubuntu-latest
+    environment:
+      name: live
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup HTTPS
+        uses: ./.github/actions/setup-https
+        env:
+          VM_IP_ADDRESS: ${{ needs.terraform.outputs.vm_host }}
+          VM_SSH_PRIVATE_KEY: ${{ secrets.VM_SSH_PRIVATE_KEY }}
+          DOMAIN: "fiforesight.duckdns.org"
+          DUCK_DNS_TOKEN: ${{ secrets.DUCK_DNS_TOKEN }}
+          EMAIL: ${{ env.EMAIL }}
+
   deploy-oracle:
     needs:
       - create-release
@@ -203,10 +223,11 @@ jobs:
       - build-backend
       - build-image
       - terraform
+      - deploy-nginx
     runs-on: ubuntu-latest
     environment:
       name: live
-      url: http://fiforesight.duckdns.org
+      url: https://fiforesight.duckdns.org
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,6 +10,7 @@ permissions:
   pull-requests: write
 env:
   IMAGE_NAME: ghcr.io/weekenddevelopment/fiforesight
+  EMAIL: ${{ secrets.CERTBOT_EMAIL }}
 jobs:
   terraform:
     runs-on: ubuntu-latest
@@ -168,17 +169,37 @@ jobs:
       - name: Cleanup
         if: always()
         run: docker rm -f fi-foresight-test
+  deploy-nginx:
+    needs:
+      - terraform-preview
+    runs-on: ubuntu-latest
+    environment:
+      name: preview
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup HTTPS
+        uses: ./.github/actions/setup-https
+        env:
+          VM_IP_ADDRESS: ${{ needs.terraform-preview.outputs.vm_host }}
+          VM_SSH_PRIVATE_KEY: ${{ secrets.VM_SSH_PRIVATE_KEY }}
+          DOMAIN: "fiforesight-preview.duckdns.org"
+          DUCK_DNS_TOKEN: ${{ secrets.DUCK_DNS_TOKEN }}
+          EMAIL: ${{ env.EMAIL }}
+
   deploy-preview:
     needs:
       - build-image
       - terraform-preview
+      - deploy-nginx
     runs-on: ubuntu-latest
     concurrency:
       group: pr-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     environment:
       name: preview
-      url: http://fiforesight-preview.duckdns.org
+      url: https://fiforesight-preview.duckdns.org
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -213,7 +234,7 @@ jobs:
       - name: Create Comment
         if: github.actor != 'dependabot[bot]'
         run: |
-          gh pr comment $PR_NUM --body "Deployed to preview env 🚀. Preview URL: http://fiforesight-preview.duckdns.org"
+          gh pr comment $PR_NUM --body "Deployed to preview env 🚀. Preview URL: https://fiforesight-preview.duckdns.org"
         env:
           PR_NUM: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dockerfile
+++ b/dockerfile
@@ -19,15 +19,13 @@ FROM node:25-slim
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    python3-pip \
+    python3-venv \
     make \
     gcc \
-    g++
-
-# Install Python and build dependencies
-RUN apt install python3 python3-pip python3-venv -y
-
-# This deletes the index — not needed anymore
-RUN rm -rf /var/lib/apt/lists/*
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
 
 # Create a virtual environment for Python to keep it clean and set PATH
 ENV VIRTUAL_ENV=/opt/venv
@@ -54,6 +52,13 @@ COPY backend/ ./backend/
 COPY --from=frontend-builder /app/frontend/.next/standalone ./
 COPY --from=frontend-builder /app/frontend/.next/static ./frontend/.next/static
 COPY --from=frontend-builder /app/frontend/public ./frontend/public
+
+# ---- Non-root user ----
+RUN groupadd --gid 1001 appuser && \
+    useradd --uid 1001 --gid appuser --shell /bin/bash --create-home appuser && \
+    chown -R appuser:appuser /app /opt/venv
+
+USER appuser
 
 EXPOSE 3000
 CMD ["pnpm", "run", "app:start"]

--- a/nginx/app.conf
+++ b/nginx/app.conf
@@ -1,0 +1,15 @@
+server {
+    listen 443 ssl;
+    server_name YOUR_DOMAIN;
+
+    ssl_certificate YOUR_CERT_PATH;
+    ssl_certificate_key YOUR_CERT_KEY_PATH;
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/nginx/logrotate
+++ b/nginx/logrotate
@@ -1,0 +1,14 @@
+/var/log/nginx/*.log {
+    daily
+    missingok
+    rotate 7
+    compress
+    delaycompress
+    notifempty
+    sharedscripts
+    postrotate
+        if pidof nginx > /dev/null 2>&1; then
+            nginx -s reopen || true
+        fi
+    endscript
+}

--- a/terraform-preview/main.tf
+++ b/terraform-preview/main.tf
@@ -68,8 +68,8 @@ resource "oci_core_security_list" "sl" {
     protocol = "6" # TCP
     source   = "0.0.0.0/0"
     tcp_options {
-      min = 80
-      max = 80
+      min = 443
+      max = 443
     }
   }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -68,8 +68,8 @@ resource "oci_core_security_list" "sl" {
     protocol = "6" # TCP
     source   = "0.0.0.0/0"
     tcp_options {
-      min = 80
-      max = 80
+      min = 443
+      max = 443
     }
   }
 


### PR DESCRIPTION
- Add `.github/actions/setup-https/action.yml` to automate Nginx and Certbot setup using DuckDNS.
- Add Nginx server configuration in `nginx/app.conf` and log rotation in `nginx/logrotate`.
- Update Terraform security rules in `terraform/main.tf` and `terraform-preview/main.tf` to open port 443 and remove port 80.
- Update GitHub workflows and `.github/scripts/daily_train.py` to use `https://` for environment and target URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated HTTPS provisioning and renewal during deployments, including an nginx deploy step and HTTPS-enabled per-PR previews; automated certificate provisioning via DNS.

* **Chores**
  * Switched service endpoints and CI/deployment outputs to HTTPS.
  * Added Nginx server configuration and log rotation.
  * Updated infrastructure and deployment to allow inbound HTTPS (port 443) traffic.
  * Updated scheduled job defaults to use the HTTPS preview URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->