### PR TITLE
Refactor New Relic installation logic in oracle deploy action

### DIFF
--- a/.github/actions/deploy-oracle/action.yml
+++ b/.github/actions/deploy-oracle/action.yml
@@ -37,6 +37,14 @@ runs:
           sudo apt-get install -y nri-nginx
           sudo cp /home/ubuntu/nginx/newrelic-nginx-log.yml /etc/newrelic-infra/logging.d/nginx-log.yml
           sudo cp /home/ubuntu/nginx/newrelic-nginx.yml /etc/newrelic-infra/integrations.d/nginx-config.yml
+          
+          # ---- New Relic display name ----
+          echo "${{ env.NEW_RELIC_APP_NAME }}"
+          if sudo grep -q '^display_name:' /etc/newrelic-infra.yml; then
+            sudo sed -i "s/^display_name:.*$/display_name: ${{ env.NEW_RELIC_APP_NAME }}/" /etc/newrelic-infra.yml
+          else
+            echo "display_name: ${{ env.NEW_RELIC_APP_NAME }}" | sudo tee -a /etc/newrelic-infra.yml
+          fi
           sudo systemctl restart newrelic-infra
 
     - name: SSH and Deploy

--- a/.github/actions/deploy-oracle/action.yml
+++ b/.github/actions/deploy-oracle/action.yml
@@ -27,16 +27,11 @@ runs:
           # Skip if already installed
           if systemctl is-active --quiet newrelic-infra; then
             echo "New Relic already running, skipping install"
-            # ---- New Relic Nginx integration ----
-            sudo apt-get install -y nri-nginx
-            sudo cp /home/ubuntu/nginx/newrelic-nginx-log.yml /etc/newrelic-infra/logging.d/nginx-log.yml
-            sudo cp /home/ubuntu/nginx/newrelic-nginx.yml /etc/newrelic-infra/integrations.d/nginx-config.yml
-            sudo systemctl restart newrelic-infra
-            exit 0
+          else
+            echo "Installing New Relic"
+            curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash
+            sudo NEW_RELIC_API_KEY=${{ env.LINUX_NEW_RELIC_LICENSE_KEY }} NEW_RELIC_ACCOUNT_ID=7918507 NEW_RELIC_REGION=EU /usr/local/bin/newrelic install -y --tag environment:${{ env.APP_ENV }}
           fi
-          
-          curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash
-          sudo NEW_RELIC_API_KEY=${{ env.LINUX_NEW_RELIC_LICENSE_KEY }} NEW_RELIC_ACCOUNT_ID=7918507 NEW_RELIC_REGION=EU /usr/local/bin/newrelic install -y --tag environment:${{ env.APP_ENV }}
           
           # ---- New Relic Nginx integration ----
           sudo apt-get install -y nri-nginx

--- a/nginx/newrelic-nginx.yml
+++ b/nginx/newrelic-nginx.yml
@@ -3,10 +3,11 @@ integrations:
     env:
       METRICS: "true"
       INVENTORY: "true"
-      STATUS_URL: http://127.0.0.1/nginx_status
+      STATUS_URL: https://127.0.0.1/nginx_status
       STATUS_MODULE: discover
+      VALIDATE_CERTS: false
       CONFIG_PATH: /etc/nginx/nginx.conf
-      REMOTE_MONITORING: "true"
+      REMOTE_MONITORING: true
     interval: 30s
     labels:
       role: web_server


### PR DESCRIPTION
This change reorganizes the installation script to ensure the Nginx integration is applied consistently. It removes redundant code blocks and a premature exit, ensuring the integration setup runs whether the New Relic agent is freshly installed or already active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved monitoring agent installation flow to skip redundant installation when the agent is already active, while ensuring integration packages, configuration updates (including synchronizing the display name), and a restart still run.
  * Updated NGINX monitoring settings to use HTTPS for the status endpoint, added an option to disable certificate validation, and changed the remote monitoring flag to a boolean.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->