### PR TITLE
(terraform): fix cloud-init script

### DIFF
--- a/.github/actions/deploy-oracle/action.yml
+++ b/.github/actions/deploy-oracle/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Update IP in DNS Entry
       shell: bash
       run: |
-        curl https://www.duckdns.org/update?domains=${{ env.DOMAIN }}&token=${{ env.DUCK_DNS_TOKEN }}&ip=${{ env.VM_IP_ADDRESS }}&verbose=true
+        curl "https://www.duckdns.org/update?domains=${{ env.DOMAIN }}&token=${{ env.DUCK_DNS_TOKEN }}&ip=${{ env.VM_IP_ADDRESS }}&verbose=true"
 
     - name: Copy Nginx config
       uses: appleboy/scp-action@v1
@@ -53,6 +53,7 @@ runs:
         host: ${{ env.VM_IP_ADDRESS }}
         username: ubuntu
         key: ${{ env.VM_SSH_PRIVATE_KEY }}
+        command_timeout: "30m"
         script: |
           # Lowercase the image name for compatibility
           IMAGE_LOWER=$(echo "${{ env.IMAGE_NAME }}" | tr '[:upper:]' '[:lower:]')

--- a/terraform-preview/scripts/setup.sh
+++ b/terraform-preview/scripts/setup.sh
@@ -11,11 +11,12 @@ if [ ! -f /swapfile ]; then
 fi
 
 # Install Docker
-apt-get update
+apt-get update -y
 apt-get install -y apt-transport-https ca-certificates curl software-properties-common
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-apt-get update
+ARCH="$(dpkg --print-architecture)"
+add-apt-repository -y "deb [arch=${ARCH}] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+apt-get update -y
 apt-get install -y docker-ce docker-ce-cli containerd.io
 
 # Enable Docker and allow current user

--- a/terraform/scripts/setup.sh
+++ b/terraform/scripts/setup.sh
@@ -11,11 +11,12 @@ if [ ! -f /swapfile ]; then
 fi
 
 # Install Docker
-apt-get update
+apt-get update -y
 apt-get install -y apt-transport-https ca-certificates curl software-properties-common
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-apt-get update
+ARCH="$(dpkg --print-architecture)"
+add-apt-repository -y "deb [arch=${ARCH}] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+apt-get update -y
 apt-get install -y docker-ce docker-ce-cli containerd.io
 
 # Enable Docker and allow current user


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made Docker installation fully non-interactive to improve automation.
  * Generalized Docker repository architecture detection for multi-arch hosts.
  * Fixed file formatting and ensured a proper trailing newline.
  * Quoted the DuckDNS update URL to preserve runtime substitution.
  * Increased deploy SSH command timeout to support longer-running operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->