### PR TITLE
(terraform): fix upstash redis region config

### DIFF
--- a/terraform/redis.tf
+++ b/terraform/redis.tf
@@ -1,7 +1,8 @@
 resource "upstash_redis_database" "redis" {
-  database_name = "fiforesight-redis"
-  region        = "eu-west-2"
-  tls           = true
+  database_name  = "fiforesight-redis"
+  primary_region = "eu-west-2"
+  tls            = true
+  region         = "global"
 }
 
 output "redis_endpoint" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Redis infrastructure configuration to use current naming standards while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->