### PR TITLE
(github): add redis url to preview

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -55,6 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       vm_host: ${{ steps.tf_outputs.outputs.public_ip }}
+      upstash_redis_url: ${{ steps.tf_outputs.outputs.upstash_redis_url }}
     environment:
       name: "terraform.apply"
     steps:
@@ -74,7 +75,9 @@ jobs:
         working-directory: terraform
         run: |
           PUBLIC_IP=$(terraform output -raw public_ip)
-          echo "UPSTASH_REDIS_URL=$(terraform output -raw redis_url)" >> $GITHUB_ENV
+          UPSTASH_REDIS_URL=$(terraform output -raw redis_url)
+          echo "::add-mask::$UPSTASH_REDIS_URL"
+          echo "upstash_redis_url=$UPSTASH_REDIS_URL" >> $GITHUB_OUTPUT
           echo "public_ip=$PUBLIC_IP" >> $GITHUB_OUTPUT
 
   build-frontend:
@@ -254,7 +257,7 @@ jobs:
           SERP_API_KEY: ${{ secrets.SERP_API_KEY }}
           X_AI_API_KEY: ${{ secrets.X_AI_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-          UPSTASH_REDIS_URL: ${{ env.UPSTASH_REDIS_URL }}
+          UPSTASH_REDIS_URL: ${{ needs.terraform.outputs.upstash_redis_url }}
           APP_ENV: "live"
           NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
           LINUX_NEW_RELIC_LICENSE_KEY: ${{ secrets.LINUX_NEW_RELIC_LICENSE_KEY }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: "terraform.plan"
+    outputs:
+      upstash_redis_url: ${{ steps.tf_outputs.outputs.upstash_redis_url }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
@@ -25,6 +27,14 @@ jobs:
         env:
           TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
           WORKING_DIR: "terraform"
+
+      - name: Get Terraform Outputs
+        id: tf_outputs
+        working-directory: terraform
+        run: |
+          UPSTASH_REDIS_URL=$(terraform output -raw redis_url)
+          echo "::add-mask::$UPSTASH_REDIS_URL"
+          echo "upstash_redis_url=$UPSTASH_REDIS_URL" >> $GITHUB_OUTPUT
   terraform-preview:
     runs-on: ubuntu-latest
     environment:
@@ -193,6 +203,7 @@ jobs:
       - build-image
       - terraform-preview
       - deploy-nginx
+      - terraform
     runs-on: ubuntu-latest
     concurrency:
       group: pr-${{ github.event.pull_request.number }}
@@ -224,6 +235,7 @@ jobs:
           SERP_API_KEY: ${{ secrets.SERP_API_KEY }}
           X_AI_API_KEY: ${{ secrets.X_AI_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          UPSTASH_REDIS_URL: ${{ needs.terraform.outputs.upstash_redis_url }}
           APP_ENV: "preview"
           NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
           LINUX_NEW_RELIC_LICENSE_KEY: ${{ secrets.LINUX_NEW_RELIC_LICENSE_KEY }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows updated to capture the Redis connection URL from Terraform, mask it in logs, and expose it as a workflow output.
  * Preview and merge deployment steps now receive the secured Redis URL via the workflow output, improving safety and reliability of preview and production deploys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->