### PR TITLE
(github): fix redis url propagation

### DIFF
--- a/.github/actions/setup-redis/action.yml
+++ b/.github/actions/setup-redis/action.yml
@@ -1,0 +1,26 @@
+name: Setup Redis
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v4
+      with:
+        terraform_version: 1.14.8
+        cli_config_credentials_token: ${{ env.TF_API_TOKEN }}
+
+    - name: Terraform Init
+      working-directory: ${{ env.WORKING_DIR }}
+      shell: bash
+      run: terraform init
+
+    - name: Get Redis URL from terraform outputs
+      working-directory: ${{ env.WORKING_DIR }}
+      shell: bash
+      run: |
+        REDIS_URL="$(terraform output -raw redis_url)"
+        if [ -z "$REDIS_URL" ] || [ "$REDIS_URL" = "null" ]; then
+          echo "Error: terraform output 'redis_url' is empty or null" >> $GITHUB_STEP_SUMMARY
+          exit 1
+        fi
+        echo "::add-mask::$REDIS_URL"
+        echo "UPSTASH_REDIS_URL=$REDIS_URL" >> "$GITHUB_ENV"

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -55,7 +55,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       vm_host: ${{ steps.tf_outputs.outputs.public_ip }}
-      upstash_redis_url: ${{ steps.tf_outputs.outputs.upstash_redis_url }}
     environment:
       name: "terraform.apply"
     steps:
@@ -75,9 +74,6 @@ jobs:
         working-directory: terraform
         run: |
           PUBLIC_IP=$(terraform output -raw public_ip)
-          UPSTASH_REDIS_URL=$(terraform output -raw redis_url)
-          echo "::add-mask::$UPSTASH_REDIS_URL"
-          echo "upstash_redis_url=$UPSTASH_REDIS_URL" >> $GITHUB_OUTPUT
           echo "public_ip=$PUBLIC_IP" >> $GITHUB_OUTPUT
 
   build-frontend:
@@ -184,6 +180,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Setup Redis
+        uses: ./.github/actions/setup-redis
+        env:
+          TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
+          WORKING_DIR: "terraform"
+
       - name: Deploy to Koyeb
         uses: ./.github/actions/deploy-koyeb
         env:
@@ -238,6 +240,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Setup Redis
+        uses: ./.github/actions/setup-redis
+        env:
+          TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
+          WORKING_DIR: "terraform"
+
       - name: Deploy to Oracle
         uses: ./.github/actions/deploy-oracle
         env:
@@ -257,7 +265,7 @@ jobs:
           SERP_API_KEY: ${{ secrets.SERP_API_KEY }}
           X_AI_API_KEY: ${{ secrets.X_AI_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-          UPSTASH_REDIS_URL: ${{ needs.terraform.outputs.upstash_redis_url }}
+          UPSTASH_REDIS_URL: ${{ env.UPSTASH_REDIS_URL }}
           APP_ENV: "live"
           NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
           LINUX_NEW_RELIC_LICENSE_KEY: ${{ secrets.LINUX_NEW_RELIC_LICENSE_KEY }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,8 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: "terraform.plan"
-    outputs:
-      upstash_redis_url: ${{ steps.tf_outputs.outputs.upstash_redis_url }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
@@ -27,14 +25,6 @@ jobs:
         env:
           TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
           WORKING_DIR: "terraform"
-
-      - name: Get Terraform Outputs
-        id: tf_outputs
-        working-directory: terraform
-        run: |
-          UPSTASH_REDIS_URL=$(terraform output -raw redis_url)
-          echo "::add-mask::$UPSTASH_REDIS_URL"
-          echo "upstash_redis_url=$UPSTASH_REDIS_URL" >> $GITHUB_OUTPUT
   terraform-preview:
     runs-on: ubuntu-latest
     environment:
@@ -203,7 +193,6 @@ jobs:
       - build-image
       - terraform-preview
       - deploy-nginx
-      - terraform
     runs-on: ubuntu-latest
     concurrency:
       group: pr-${{ github.event.pull_request.number }}
@@ -214,6 +203,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Setup Redis
+        uses: ./.github/actions/setup-redis
+        env:
+          TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
+          WORKING_DIR: "terraform"
 
       - name: Deploy to Oracle
         if: github.actor != 'dependabot[bot]'
@@ -235,7 +230,7 @@ jobs:
           SERP_API_KEY: ${{ secrets.SERP_API_KEY }}
           X_AI_API_KEY: ${{ secrets.X_AI_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-          UPSTASH_REDIS_URL: ${{ needs.terraform.outputs.upstash_redis_url }}
+          UPSTASH_REDIS_URL: ${{ env.UPSTASH_REDIS_URL }}
           APP_ENV: "preview"
           NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
           LINUX_NEW_RELIC_LICENSE_KEY: ${{ secrets.LINUX_NEW_RELIC_LICENSE_KEY }}


### PR DESCRIPTION
- Add secret masking for inherited `upstash_redis_url` outputs in deploy jobs.
- Add validation check to ensure terraform `redis_url` is not empty or null.
- Update `merge.yml` to source the redis URL directly from terraform outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable "Setup Redis" step that prepares Redis configuration and exposes a consolidated environment variable for deployments.

* **Chores**
  * Removed Redis URL from job outputs; deployments now consume the scoped environment variable.
  * Improved security by validating and masking sensitive Redis values before they reach deployment steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->