### PR TITLE
remove dependency groups to allow non breaking changes to be merged

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,20 +11,11 @@ updates:
       - "/frontend"
     schedule:
       interval: "daily"
-    groups:
-      pnpm-dependencies:
-        dependency-type: "production"
-      pnpm-dev-dependencies:
-        dependency-type: "development"
   - package-ecosystem: "pip"
     directories: 
       - "/backend"
     schedule:
       interval: "daily"
-    groups:
-      pip-dependencies:
-        patterns:
-          - "*"
   - package-ecosystem: "github-actions"
     directories: 
       - "/.github"


### PR DESCRIPTION
Removed groups for pnpm and pip dependencies in dependabot configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated update configuration for backend systems to streamline the update schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->