### PR TITLE
Change Dependabot directory for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
       interval: "daily"
   - package-ecosystem: "github-actions"
     directories: 
-      - "/.github"
+      - "/"
     schedule:
       interval: "daily"
   - package-ecosystem: "docker"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions dependency monitoring configuration to scan the entire repository instead of just the `.github` directory, ensuring broader coverage of action dependencies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WeekendDevelopment/FiForesight/pull/171)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->