### PR TITLE
feat: show analyst agreement count in jury consensus badge

### DIFF
--- a/frontend/components/AnalystJuryPanel.tsx
+++ b/frontend/components/AnalystJuryPanel.tsx
@@ -33,31 +33,27 @@ export default function AnalystJuryPanel({ analysts }: { analysts: AnalystJuror[
   }, {} as Record<string, number>);
   const consensus = RATING_ORDER.find(r => ratingCounts[r]) ?? analysts[0]?.rating ?? 'Hold';
   const avgConf   = Math.round(analysts.reduce((s, a) => s + a.confidence, 0) / Math.max(analysts.length, 1));
-  const divergent = new Set(analysts.map(a => a.rating)).size > 1;
-
   return (
     <Stack spacing={1.5}>
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: 0.5 }}>
         <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, fontSize: '1rem' }}>
           <Scale size={18} /> Analyst Jury
         </Typography>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
-          {divergent && (
-            <Typography sx={{ fontSize: '0.58rem', opacity: 0.3, letterSpacing: '0.07em' }}>SPLIT</Typography>
-          )}
-          <Box sx={{
-            px: 1.2, py: 0.3, borderRadius: 1,
-            background: ratingColor(consensus).bg,
-            border: `1px solid ${ratingColor(consensus).text}44`,
-            display: 'flex', alignItems: 'center', gap: 0.6,
-          }}>
-            <Typography sx={{ fontSize: '0.62rem', fontWeight: 900, color: ratingColor(consensus).text, letterSpacing: '0.07em' }}>
-              {consensus.toUpperCase()}
-            </Typography>
-            <Typography sx={{ fontSize: '0.56rem', opacity: 0.55, color: ratingColor(consensus).text }}>
-              {avgConf}%
-            </Typography>
-          </Box>
+        <Box sx={{
+          px: 1.2, py: 0.3, borderRadius: 1,
+          background: ratingColor(consensus).bg,
+          border: `1px solid ${ratingColor(consensus).text}44`,
+          display: 'flex', alignItems: 'center', gap: 0.6,
+        }}>
+          <Typography sx={{ fontSize: '0.62rem', fontWeight: 900, color: ratingColor(consensus).text, letterSpacing: '0.07em' }}>
+            {consensus.toUpperCase()}
+          </Typography>
+          <Typography sx={{ fontSize: '0.56rem', opacity: 0.55, color: ratingColor(consensus).text }}>
+            {avgConf}%
+          </Typography>
+          <Typography sx={{ fontSize: '0.5rem', opacity: 0.35, color: ratingColor(consensus).text, fontFamily: 'monospace' }}>
+            {ratingCounts[consensus] ?? analysts.length}/{analysts.length}
+          </Typography>
         </Box>
       </Box>
 


### PR DESCRIPTION
## Summary

- Adds an agreement fraction (e.g. `2/3`, `3/3`) to the jury consensus badge in `AnalystJuryPanel`
- Removes the separate "SPLIT" label — the fraction makes it self-evident when analysts disagree
- Badge now reads: `BUY  72%  2/3` inline, all in the same colored chip

## Changes

- `frontend/components/AnalystJuryPanel.tsx`: dropped unused `divergent` var + SPLIT Typography; added `{ratingCounts[consensus] ?? analysts.length}/{analysts.length}` as a dim monospace `0.5rem` Typography inside the existing badge Box

## Test plan

- [ ] Search any ticker → jury panel header badge shows rating + confidence + fraction
- [ ] With a 3/3 unanimous jury: badge shows `BUY  72%  3/3`
- [ ] With a split jury (e.g. 2 Buy + 1 Hold): badge shows `BUY  65%  2/3`
- [ ] No TypeScript errors (`pnpm run build` clean)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LaF1yEae2g9CwVgTosFPVE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Analyst Jury Panel header to consistently display consensus information including the label, average confidence level, and count of analysts agreeing with the consensus rating. Removed the SPLIT indicator from the display and simplified the header layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WeekendDevelopment/FiForesight/pull/189)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->