### PR TITLE
feat: options chain panel — GET /options/{symbol} + OptionsChainPanel UI

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1681,5 +1681,65 @@ async def compare_peers(symbols: str = Query(..., description="Comma-separated t
     return {"peers": peers}
 
 
+@app.get("/options/{symbol}")
+async def options_chain(symbol: str):
+    """
+    Returns the nearest-expiry options chain (calls + puts) for the given symbol.
+    Filters to strikes within ±25% of current price to keep payload small.
+    """
+    import yfinance as yf
+
+    def _fetch():
+        ticker = yf.Ticker(symbol.upper())
+        expirations = ticker.options
+        if not expirations:
+            return None
+        # Use the nearest expiry
+        expiry = expirations[0]
+        chain  = ticker.option_chain(expiry)
+        price  = (
+            ticker.info.get("currentPrice")
+            or ticker.info.get("regularMarketPrice")
+            or ticker.info.get("previousClose")
+            or 0.0
+        )
+        price = float(price)
+
+        def _clean(df, is_call: bool):
+            rows = []
+            for _, r in df.iterrows():
+                strike = float(r.get("strike", 0))
+                if price > 0 and abs(strike - price) / price > 0.25:
+                    continue  # filter far OTM
+                rows.append({
+                    "strike":        round(strike, 2),
+                    "last":          round(float(r.get("lastPrice",        0)), 2),
+                    "bid":           round(float(r.get("bid",              0)), 2),
+                    "ask":           round(float(r.get("ask",              0)), 2),
+                    "change":        round(float(r.get("change",           0)), 2),
+                    "change_pct":    round(float(r.get("percentChange",    0)), 2),
+                    "volume":        int(r.get("volume",       0) or 0),
+                    "open_interest": int(r.get("openInterest", 0) or 0),
+                    "implied_vol":   round(float(r.get("impliedVolatility", 0)) * 100, 1),
+                    "in_the_money":  bool(r.get("inTheMoney", False)),
+                    "type":          "call" if is_call else "put",
+                })
+            return rows
+
+        return {
+            "symbol":        symbol.upper(),
+            "expiry":        expiry,
+            "expirations":   list(expirations[:8]),  # first 8 expiries
+            "current_price": round(price, 2),
+            "calls":         _clean(chain.calls, True),
+            "puts":          _clean(chain.puts,  False),
+        }
+
+    result = await asyncio.to_thread(_fetch)
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"No options data for {symbol}")
+    return result
+
+
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=Config.PORT)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1693,14 +1693,14 @@ async def compare_peers(symbols: str = Query(..., description="Comma-separated t
 
 
 @app.get("/options/{symbol}")
-async def options_chain(symbol: str):
+async def options_chain(symbol: str) -> Dict[str, Any]:
     """
     Returns the nearest-expiry options chain (calls + puts) for the given symbol.
     Filters to strikes within ±25% of current price to keep payload small.
     """
     import yfinance as yf
 
-    def _fetch():
+    def _fetch() -> Optional[Dict[str, Any]]:
         ticker = yf.Ticker(symbol.upper())
         expirations = ticker.options
         if not expirations:
@@ -1715,8 +1715,11 @@ async def options_chain(symbol: str):
             or 0.0
         )
         price = float(price)
+        if price <= 0:
+            logger.warning("[OPTIONS] Unable to retrieve price for %s", symbol)
+            return None
 
-        def _clean(df, is_call: bool):
+        def _clean(df: Any, is_call: bool) -> List[Dict[str, Any]]:
             rows = []
             for _, r in df.iterrows():
                 strike = float(r.get("strike", 0))
@@ -1746,7 +1749,14 @@ async def options_chain(symbol: str):
             "puts":          _clean(chain.puts,  False),
         }
 
-    result = await asyncio.to_thread(_fetch)
+    try:
+        result = await asyncio.wait_for(asyncio.to_thread(_fetch), timeout=12.0)
+    except asyncio.TimeoutError:
+        logger.warning("[OPTIONS] timeout fetching chain for %s", symbol)
+        raise HTTPException(status_code=504, detail=f"Options fetch timed out for {symbol}")
+    except Exception as exc:
+        logger.warning("[OPTIONS] fetch failed for %s: %s", symbol, exc, exc_info=True)
+        raise HTTPException(status_code=502, detail=f"Options provider error for {symbol}")
     if result is None:
         raise HTTPException(status_code=404, detail=f"No options data for {symbol}")
     return result

--- a/frontend/app/api/options/[symbol]/route.ts
+++ b/frontend/app/api/options/[symbol]/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+import axios from 'axios';
+
+const BACKEND = process.env.BACKEND_URL ?? 'http://localhost:8000';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ symbol: string }> },
+) {
+  const { symbol } = await params;
+  try {
+    const { data } = await axios.get(`${BACKEND}/options/${symbol}`);
+    return NextResponse.json(data);
+  } catch (err: unknown) {
+    const status = (err as { response?: { status?: number } })?.response?.status ?? 500;
+    return NextResponse.json({ error: 'Options fetch failed' }, { status });
+  }
+}

--- a/frontend/app/api/options/[symbol]/route.ts
+++ b/frontend/app/api/options/[symbol]/route.ts
@@ -9,7 +9,7 @@ export async function GET(
 ) {
   const { symbol } = await params;
   try {
-    const { data } = await axios.get(`${BACKEND}/options/${symbol}`);
+    const { data } = await axios.get(`${BACKEND}/options/${symbol}`, { timeout: 10000 });
     return NextResponse.json(data);
   } catch (err: unknown) {
     const status = (err as { response?: { status?: number } })?.response?.status ?? 500;

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -106,7 +106,8 @@ export default function QuantumDashboard() {
       setPrediction(response.data);
       fetchTradeSetup(response.data);
       // Fire-and-forget options chain fetch (non-blocking)
-      axios.get(`/api/options/${ticker}`)
+      const optionsSymbol = response.data?.symbol ?? fullSymbol;
+      axios.get(`/api/options/${encodeURIComponent(optionsSymbol)}`)
         .then(r => setOptionsData(r.data))
         .catch(() => setOptionsData(null));
       // Fire-and-forget DCF fetch (non-blocking)

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -23,9 +23,10 @@ import PriceChartCard    from '../components/PriceChartCard';
 import FundamentalsPanel      from '../components/FundamentalsPanel';
 import PeerComparisonPanel    from '../components/PeerComparisonPanel';
 import TradeSetupCard         from '../components/TradeSetupCard';
+import OptionsChainPanel from '../components/OptionsChainPanel';
 import StockChatPanel    from '../components/StockChatPanel';
 import { useIndicatorSignals } from '../hooks/useIndicatorSignals';
-import type { PredictionData, IndicatorKey, TradeSetupResponse } from '../types';
+import type { PredictionData, IndicatorKey, TradeSetupResponse, OptionsChainResult } from '../types';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -58,6 +59,7 @@ export default function QuantumDashboard() {
   const [chartEngine,      setChartEngine]      = useState<'classic' | 'pro'>('classic');
   const [tradeSetup,       setTradeSetup]       = useState<TradeSetupResponse | null>(null);
   const [tradeSetupLoading, setTradeSetupLoading] = useState(false);
+  const [optionsData,      setOptionsData]      = useState<OptionsChainResult | null>(null);
   const [chatOpen,         setChatOpen]         = useState(false);
 
   const theme = useMemo(() => buildTheme(themeMode), [themeMode]);
@@ -87,12 +89,17 @@ export default function QuantumDashboard() {
     setLoading(true);
     setError(null);
     setTradeSetup(null);
+    setOptionsData(null);
     setChatOpen(false);
     try {
       const fullSymbol = exchange ? `${ticker}:${exchange}` : ticker;
       const response   = await axios.post('/api/predict', { data: fullSymbol });
       setPrediction(response.data);
       fetchTradeSetup(response.data);
+      // Fire-and-forget options chain fetch (non-blocking)
+      axios.get(`/api/options/${ticker}`)
+        .then(r => setOptionsData(r.data))
+        .catch(() => setOptionsData(null));
     } catch (err: any) {
       setError(err.response?.data?.error || 'Quantum analysis failed.');
     } finally {
@@ -266,6 +273,15 @@ export default function QuantumDashboard() {
                     isDark={isDark}
                     primaryColor={primaryColor}
                   />
+
+                  {/* ── Options Chain ─────────────────────────────────── */}
+                  {optionsData && (
+                    <OptionsChainPanel
+                      data={optionsData}
+                      isDark={isDark}
+                      primaryColor={primaryColor}
+                    />
+                  )}
 
                   {/* ── 5-Day forecast table ──────────────────────────── */}
                   {prediction.forecastDays?.length > 0 && (

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -311,6 +311,11 @@ export default function QuantumDashboard() {
                   {optionsData && (
                     <OptionsChainPanel
                       data={optionsData}
+                      isDark={isDark}
+                      primaryColor={primaryColor}
+                    />
+                  )}
+
                   {/* ── DCF Intrinsic Value ───────────────────────────── */}
                   {dcfData && (
                     <DCFCard

--- a/frontend/components/OptionsChainPanel.tsx
+++ b/frontend/components/OptionsChainPanel.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Box, Card, CardContent, Chip, MenuItem, Select, Stack,
+  Table, TableBody, TableCell, TableHead, TableRow, Tabs, Tab, Typography,
+} from '@mui/material';
+import { Activity } from 'lucide-react';
+import type { OptionsChainResult, OptionContract } from '../types';
+
+interface Props {
+  data:            OptionsChainResult;
+  isDark:          boolean;
+  primaryColor:    string;
+  onExpiryChange?: (expiry: string) => void;
+}
+
+const cell = { fontSize: '0.68rem', py: 0.5, px: 1 };
+
+function ContractRow({ c, isDark }: { c: OptionContract; isDark: boolean }) {
+  const itm   = c.in_the_money;
+  const green = isDark ? '#00ffa3' : '#16a34a';
+  const red   = isDark ? '#ff0055' : '#dc2626';
+  const itmBg = c.type === 'call'
+    ? (itm ? `${green}10` : 'transparent')
+    : (itm ? `${red}10`   : 'transparent');
+
+  return (
+    <TableRow sx={{ background: itmBg, '&:hover': { opacity: 0.85 } }}>
+      <TableCell sx={{ ...cell, fontWeight: itm ? 800 : 400, color: c.type === 'call' ? green : red }}>
+        {c.strike.toFixed(2)}
+      </TableCell>
+      <TableCell sx={cell}>{c.last.toFixed(2)}</TableCell>
+      <TableCell sx={cell}>{c.bid.toFixed(2)}</TableCell>
+      <TableCell sx={cell}>{c.ask.toFixed(2)}</TableCell>
+      <TableCell sx={{ ...cell, color: c.change >= 0 ? green : red }}>
+        {c.change >= 0 ? '+' : ''}{c.change.toFixed(2)}
+      </TableCell>
+      <TableCell sx={cell}>{c.volume.toLocaleString()}</TableCell>
+      <TableCell sx={cell}>{c.open_interest.toLocaleString()}</TableCell>
+      <TableCell sx={{ ...cell, fontFamily: 'monospace' }}>{c.implied_vol.toFixed(1)}%</TableCell>
+    </TableRow>
+  );
+}
+
+export default function OptionsChainPanel({ data, isDark, primaryColor, onExpiryChange }: Props) {
+  const [tab, setTab] = useState<0 | 1>(0); // 0=calls 1=puts
+
+  const contracts = tab === 0 ? data.calls : data.puts;
+
+  return (
+    <Card>
+      <CardContent sx={{ p: '16px !important' }}>
+        {/* Header */}
+        <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1.5 }}>
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <Activity size={16} color={primaryColor} />
+            <Typography variant="overline" sx={{ opacity: 0.5, lineHeight: 1 }}>
+              Options Chain
+            </Typography>
+          </Stack>
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <Chip
+              label={`$${data.current_price.toFixed(2)}`}
+              size="small"
+              sx={{
+                fontSize: '0.62rem', fontWeight: 700,
+                background: `${primaryColor}18`, color: primaryColor,
+                border: `1px solid ${primaryColor}44`,
+              }}
+            />
+            <Select
+              value={data.expiry}
+              size="small"
+              onChange={e => onExpiryChange?.(e.target.value)}
+              sx={{ fontSize: '0.65rem', height: 26, '.MuiSelect-select': { py: 0.25, px: 1 } }}
+            >
+              {data.expirations.map(exp => (
+                <MenuItem key={exp} value={exp} sx={{ fontSize: '0.65rem' }}>{exp}</MenuItem>
+              ))}
+            </Select>
+          </Stack>
+        </Stack>
+
+        <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 1, minHeight: 32 }}>
+          <Tab label={`Calls (${data.calls.length})`} sx={{ fontSize: '0.7rem', minHeight: 32, py: 0 }} />
+          <Tab label={`Puts (${data.puts.length})`}   sx={{ fontSize: '0.7rem', minHeight: 32, py: 0 }} />
+        </Tabs>
+
+        <Box sx={{ overflowX: 'auto', maxHeight: 320, overflowY: 'auto' }}>
+          <Table size="small" stickyHeader>
+            <TableHead>
+              <TableRow>
+                {['Strike', 'Last', 'Bid', 'Ask', 'Chg', 'Vol', 'OI', 'IV%'].map(h => (
+                  <TableCell
+                    key={h}
+                    sx={{
+                      ...cell, fontWeight: 700, opacity: 0.5,
+                      fontSize: '0.6rem', letterSpacing: '0.05em', background: 'inherit',
+                    }}
+                  >
+                    {h}
+                  </TableCell>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {contracts.map((c, i) => (
+                <ContractRow key={i} c={c} isDark={isDark} />
+              ))}
+              {contracts.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={8} sx={{ textAlign: 'center', opacity: 0.4, fontSize: '0.7rem' }}>
+                    No contracts
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/OptionsChainPanel.tsx
+++ b/frontend/components/OptionsChainPanel.tsx
@@ -33,8 +33,8 @@ function ContractRow({ c, isDark }: { c: OptionContract; isDark: boolean }) {
       <TableCell sx={cell}>{c.last.toFixed(2)}</TableCell>
       <TableCell sx={cell}>{c.bid.toFixed(2)}</TableCell>
       <TableCell sx={cell}>{c.ask.toFixed(2)}</TableCell>
-      <TableCell sx={{ ...cell, color: c.change >= 0 ? green : red }}>
-        {c.change >= 0 ? '+' : ''}{c.change.toFixed(2)}
+      <TableCell sx={{ ...cell, color: c.change_pct >= 0 ? green : red }}>
+        {c.change_pct >= 0 ? '+' : ''}{c.change_pct.toFixed(2)}%
       </TableCell>
       <TableCell sx={cell}>{c.volume.toLocaleString()}</TableCell>
       <TableCell sx={cell}>{c.open_interest.toLocaleString()}</TableCell>
@@ -91,7 +91,7 @@ export default function OptionsChainPanel({ data, isDark, primaryColor, onExpiry
           <Table size="small" stickyHeader>
             <TableHead>
               <TableRow>
-                {['Strike', 'Last', 'Bid', 'Ask', 'Chg', 'Vol', 'OI', 'IV%'].map(h => (
+                {['Strike', 'Last', 'Bid', 'Ask', 'Chg%', 'Vol', 'OI', 'IV%'].map(h => (
                   <TableCell
                     key={h}
                     sx={{

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -170,6 +170,8 @@ export interface OptionsChainResult {
   current_price: number;
   calls:         OptionContract[];
   puts:          OptionContract[];
+}
+
 export interface DCFScenario {
   wacc:            number;
   growth_rate:     number;

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -145,3 +145,26 @@ export interface IndicatorSignal {
 }
 
 export type IndicatorSignals = Record<string, IndicatorSignal | null>;
+
+export interface OptionContract {
+  strike:        number;
+  last:          number;
+  bid:           number;
+  ask:           number;
+  change:        number;
+  change_pct:    number;
+  volume:        number;
+  open_interest: number;
+  implied_vol:   number;
+  in_the_money:  boolean;
+  type:          'call' | 'put';
+}
+
+export interface OptionsChainResult {
+  symbol:        string;
+  expiry:        string;
+  expirations:   string[];
+  current_price: number;
+  calls:         OptionContract[];
+  puts:          OptionContract[];
+}


### PR DESCRIPTION
## Summary

- `GET /options/{symbol}` — fetches nearest-expiry options chain via yfinance, filters to strikes within ±25% of spot price, returns calls + puts + up to 8 expiry dates
- `OptionsChainPanel` — MUI table with Calls/Puts tabs, ITM rows highlighted, columns: Strike, Last, Bid, Ask, Chg%, Vol, OI, IV%
- Fire-and-forget fetch on predict so options load without blocking the main response
- Expiry selector shows first 8 available dates (future: make interactive)

## Files added

```
frontend/components/OptionsChainPanel.tsx      — calls/puts table with ITM highlight
frontend/app/api/options/[symbol]/route.ts     — Next.js proxy → FastAPI /options/{symbol}
```

## Files modified

```
backend/main.py            — GET /options/{symbol} endpoint
frontend/types/index.ts    — OptionContract + OptionsChainResult interfaces
frontend/app/page.tsx      — optionsData state + fire-and-forget fetch + OptionsChainPanel render
```

## Test plan

- [ ] `GET /options/AAPL` returns calls + puts arrays with strike, IV, volume
- [ ] OTM strikes beyond ±25% of spot are filtered out
- [ ] Panel renders with Calls tab active by default; ITM rows are highlighted
- [ ] Missing options data (e.g. crypto) renders nothing (null state)

https://claude.ai/code/session_01LaF1yEae2g9CwVgTosFPVE

---
_Generated by [Claude Code](https://claude.ai/code/session_01LaF1yEae2g9CwVgTosFPVE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Options Chain feature displaying calls and puts for selected stocks. Users can view detailed option contracts with pricing, volume, and implied volatility information. Features include expiry selection, in-the-money highlighting, and automatic filtering to show relevant strikes near the current price.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WeekendDevelopment/FiForesight/pull/194)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->