### PR TITLE
fix: restore /options/{symbol} and trade-setup position sizing lost in router split

### DIFF
--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -1,7 +1,9 @@
 # backend/routers/market.py
 import asyncio
 import logging
+from typing import Any, Dict, List, Optional
 
+import yfinance as yf
 from fastapi import APIRouter, HTTPException
 
 from dependencies import yf_svc
@@ -103,3 +105,75 @@ async def dcf_valuation(symbol: str):
         "growth_rate_base":   round(g * 100, 2),
         "method":             "FCF",
     }
+
+
+# ---------------------------------------------------------------------------
+# Options Chain
+# ---------------------------------------------------------------------------
+
+@router.get("/options/{symbol}")
+async def options_chain(symbol: str) -> Dict[str, Any]:
+    """
+    Returns the nearest-expiry options chain (calls + puts) for the given symbol.
+    Filters to strikes within ±25% of current price to keep payload small.
+    """
+
+    def _fetch() -> Optional[Dict[str, Any]]:
+        ticker = yf.Ticker(symbol.upper())
+        expirations = ticker.options
+        if not expirations:
+            return None
+        expiry = expirations[0]
+        chain  = ticker.option_chain(expiry)
+        price  = (
+            ticker.info.get("currentPrice")
+            or ticker.info.get("regularMarketPrice")
+            or ticker.info.get("previousClose")
+            or 0.0
+        )
+        price = float(price)
+        if price <= 0:
+            logger.warning("[OPTIONS] Unable to retrieve price for %s", symbol)
+            return None
+
+        def _clean(df: Any, is_call: bool) -> List[Dict[str, Any]]:
+            rows = []
+            for _, r in df.iterrows():
+                strike = float(r.get("strike", 0))
+                if abs(strike - price) / price > 0.25:
+                    continue
+                rows.append({
+                    "strike":        round(strike, 2),
+                    "last":          round(float(r.get("lastPrice",        0)), 2),
+                    "bid":           round(float(r.get("bid",              0)), 2),
+                    "ask":           round(float(r.get("ask",              0)), 2),
+                    "change":        round(float(r.get("change",           0)), 2),
+                    "change_pct":    round(float(r.get("percentChange",    0)), 2),
+                    "volume":        int(r.get("volume",       0) or 0),
+                    "open_interest": int(r.get("openInterest", 0) or 0),
+                    "implied_vol":   round(float(r.get("impliedVolatility", 0)) * 100, 1),
+                    "in_the_money":  bool(r.get("inTheMoney", False)),
+                    "type":          "call" if is_call else "put",
+                })
+            return rows
+
+        return {
+            "symbol":        symbol.upper(),
+            "expiry":        expiry,
+            "expirations":   list(expirations[:8]),
+            "current_price": round(price, 2),
+            "calls":         _clean(chain.calls, True),
+            "puts":          _clean(chain.puts,  False),
+        }
+
+    try:
+        result = await asyncio.wait_for(asyncio.to_thread(_fetch), timeout=12.0)
+    except asyncio.TimeoutError:
+        logger.warning("[OPTIONS] timeout fetching chain for %s", symbol)
+        raise HTTPException(status_code=504, detail=f"Options fetch timed out for {symbol}")
+    except Exception as exc:
+        logger.warning("[OPTIONS] fetch failed for %s: %s", symbol, exc, exc_info=True)
+        raise HTTPException(status_code=502, detail=f"Options provider error for {symbol}")
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"No options data for {symbol}")
+    return result

--- a/backend/routers/trade.py
+++ b/backend/routers/trade.py
@@ -1,7 +1,7 @@
 # backend/routers/trade.py
 import json
 import logging
-from typing import Any, List
+from typing import Any, List, Optional
 
 import httpx
 from fastapi import APIRouter
@@ -29,6 +29,7 @@ class TradeSetupRequest(BaseModel):
     resistance: List[float] = []
     trend: str = "Bullish"
     sentiment_label: str = "Neutral"
+    var_95: Optional[float] = None
 
     @field_validator("current_price")
     @classmethod
@@ -70,6 +71,9 @@ class TradeSetupResponse(BaseModel):
     risk_reward: str
     setup_type: str
     rationale: str
+    risk_per_share: float
+    risk_pct: float
+    suggested_position_pct: float
 
 
 @router.post("/trade-setup", response_model=TradeSetupResponse)
@@ -183,6 +187,12 @@ async def trade_setup(req: TradeSetupRequest):
     except Exception as exc:
         logger.warning("[TRADE-SETUP] Groq rationale failed: %s", exc)
 
+    # Position sizing — 1% portfolio-risk rule
+    entry_mid_final = (entry_low + entry_high) / 2
+    risk_ps  = round(max(abs(entry_mid_final - stop_loss), 0.01), 4)
+    risk_pct_val = round(risk_ps / entry_mid_final * 100, 2)
+    suggested_pct = round(min(1.0 / (risk_pct_val / 100), 5.0) * 100, 1)
+
     return TradeSetupResponse(
         entry_low=entry_low,
         entry_high=entry_high,
@@ -193,6 +203,9 @@ async def trade_setup(req: TradeSetupRequest):
         risk_reward=risk_reward,
         setup_type=setup_type,
         rationale=rationale,
+        risk_per_share=risk_ps,
+        risk_pct=risk_pct_val,
+        suggested_position_pct=suggested_pct,
     )
 
 


### PR DESCRIPTION
## Summary

Two endpoints were silently broken after the router-split merge (PR #195 created `market.py` from the state _before_ the options-chain PR #194 and position-sizing PR #191 landed).

### Bugs fixed

| Endpoint | What was wrong | Fix |
|----------|---------------|-----|
| `GET /options/{symbol}` | **404** — endpoint existed in old `main.py` but was never ported into `routers/market.py` | Added full implementation: `asyncio.wait_for` timeout, 502/504 error mapping, price-guard early-return, ±25% strike filter |
| `POST /trade-setup` | **Missing fields** — `risk_per_share`, `risk_pct`, `suggested_position_pct` were in old `main.py` (PR #191) but lost in router split | Added 1%-rule position sizing computation + fields to both `TradeSetupRequest` (`var_95`) and `TradeSetupResponse` |

### Root cause
Both PRs (#194 options-chain, #191 position-sizing) added to the monolithic `main.py`. PR #195 router-split created fresh router files from an older snapshot, so those additions were never ported.

### Verified
- `GET /options/{symbol}` and `POST /trade-setup` both registered: confirmed via router introspection
- `pytest backend/tests/ -v` → 22/22 passed
- `pnpm run build` → clean

https://claude.ai/code/session_01LaF1yEae2g9CwVgTosFPVE

---
_Generated by [Claude Code](https://claude.ai/code/session_01LaF1yEae2g9CwVgTosFPVE)_