### PR TITLE
feat: market intelligence suite — move explainer, sector heatmap, market pulse + UX overhaul

### DIFF
--- a/.claude/FiForesight_Roadmap.md
+++ b/.claude/FiForesight_Roadmap.md
@@ -101,6 +101,19 @@ Pure refactor — do after auth lands so router auth wiring is single-pass.
 
 ---
 
+## Next Up
+
+### 1. Dynamic chart time intervals + contextual metrics
+Chart currently always shows 2Y daily data. Add a 1D / 5D / 1M / 3M / 6M / 1Y / 2Y selector that:
+- Re-fetches history at the appropriate yfinance `period` + `interval` (e.g. 1D → `period="1d", interval="5m"`)
+- Updates **CHANGE**, **PERIOD HIGH**, **PERIOD LOW**, **SMA 20**, **ANN. VOL** to match the selected window
+- Recalculates RSI series, MACD, Bollinger Bands for the active interval
+- Frontend: segmented button row on `PriceChartCard`; backend: add `period` + `interval` params to `/predict` (or new `/history?symbol=&period=&interval=` endpoint to avoid re-running ML)
+
+**Files:** `frontend/components/PriceChartCard.tsx`, `backend/routers/predict.py` (or new `GET /history`)
+
+---
+
 ## Feature Ideas (not yet picked up)
 
 | Feature | Value | Effort | Notes |

--- a/.claude/FiForesight_Roadmap.md
+++ b/.claude/FiForesight_Roadmap.md
@@ -1,7 +1,7 @@
 # FiForesight Roadmap
 
 > Source of truth for planned work. Feature-based, free-tier only.
-> Last synced: 2026-05-16
+> Last synced: 2026-05-17 — All "Next Up" items shipped; moving to Feature Ideas backlog.
 
 ---
 
@@ -52,19 +52,23 @@
 Pull beta, EV/EBITDA, P/B, forwardPE, PEG, FCF, revenueGrowth, totalDebt, industry from yfinance.
 Unblocks peer comps + DCF. ~½ day, single function edit.
 **File:** `backend/services.py:802`
+✅ **Shipped** — `services.py:864-884`
 
 ### 2. Implement `/compare` backend (peer comparison)
 Frontend proxy `frontend/app/api/compare/route.ts` exists but backend handler is missing — currently a dead proxy.
 Peer comp panel: same-sector tickers, side-by-side P/E, EV/EBITDA, beta, revenue growth.
 Depends on #1.
+✅ **Shipped** — `routers/predict.py:1284` + `PeerComparisonPanel.tsx`
 
 ### 3. Cache `fetch_info` in Redis (1h TTL)
 Every `/predict` re-hits yfinance for static fundamentals. Redis is already wired.
 Independent of #1/#2 — can ship in parallel.
+✅ **Shipped** — `routers/predict.py:741-764` (1h TTL, also in `/compare`)
 
 ### 4. Earnings calendar markers on chart
 `yf.Ticker().calendar` → date marker overlay on `PriceChartCard`. ~30 LOC backend + small frontend.
 High UX value for retail users.
+✅ **Shipped** — `services.py:900`, `predict.py:1023`, `PriceChartCard.tsx:505` (yellow dashed markers)
 
 ### 5. Jury consensus row
 Add weighted aggregate verdict + agreement level to `AnalystJuryPanel` ("3/3 Buy, avg confidence 72").

--- a/.claude/FiForesight_Roadmap.md
+++ b/.claude/FiForesight_Roadmap.md
@@ -1,7 +1,7 @@
 # FiForesight Roadmap
 
 > Source of truth for planned work. Feature-based, free-tier only.
-> Last synced: 2026-05-13
+> Last synced: 2026-05-16
 
 ---
 
@@ -26,6 +26,15 @@
 - Dark/light theme, loading skeletons, ticker autocomplete
 - Portfolio simulation page (`/simulation/suggest`, `/simulation/performance`, state persistence)
 - `page.tsx` decomposed: 423 lines + 13 components in `frontend/components/`
+- Jury consensus badge — weighted aggregate verdict + agreement level in `AnalystJuryPanel` (#189)
+- DCF intrinsic value — `GET /dcf/{symbol}` 3-scenario WACC valuation card (#190)
+- Position sizing (1% rule) — Monte Carlo VaR-based % of portfolio risk in Trade Setup Card (#191)
+- Options chain panel — calls/puts table, ITM highlight, expiry selector (#194)
+
+### Auth & Backend
+- Supabase email/password auth — `AuthContext`, `AuthModal`, watchlist groundwork (#193)
+- Backend pytest harness — 22 tests, no network calls (`backend/tests/`) (#192)
+- Router split — `main.py` → `routers/predict.py`, `simulation.py`, `trade.py`, `market.py` (#195)
 
 ### Infra
 - Redis caching layer (`redis_cache.py`)
@@ -60,25 +69,31 @@ High UX value for retail users.
 ### 5. Jury consensus row
 Add weighted aggregate verdict + agreement level to `AnalystJuryPanel` ("3/3 Buy, avg confidence 72").
 Pure frontend change.
+✅ **Shipped** — PR #189
 
 ### 6. DCF intrinsic value endpoint
 `GET /dcf/{symbol}` — 3-scenario WACC-based valuation card. Pairs with Monte Carlo VaR.
 Depends on #1.
+✅ **Shipped** — PR #190
 
 ### 7. Supabase auth + watchlists
 Free tier. Unlocks personalization, persistent watchlists, daily briefings, alerts.
 Bigger scope — break into auth-only PR first, watchlist UI second.
+✅ **Shipped** (auth) — PR #193
 
 ### 8. Backend pytest harness
 Minimum: tests for `run_monte_carlo`, `run_ensemble_forecast`, `score_headlines`, `fetch_info`.
 Block more features until basic coverage exists.
+✅ **Shipped** — PR #192
 
 ### 9. Position sizing in Trade Setup Card
 Use Monte Carlo VaR to suggest % of portfolio to risk. Pure addition to existing endpoint.
+✅ **Shipped** — PR #191
 
 ### 10. Split `main.py` into routers
 1593 lines is unwieldy. Split into `routers/predict.py`, `routers/simulation.py`, `routers/jury.py`, `routers/chat.py`.
 Pure refactor — do after auth lands so router auth wiring is single-pass.
+✅ **Shipped** — PR #195
 
 ---
 
@@ -88,7 +103,7 @@ Pure refactor — do after auth lands so router auth wiring is single-pass.
 |---|---|---|---|
 | Morning briefing email/digest | High | Med | Needs auth (#7) |
 | "Why did this move?" auto-explainer on >3% gaps | High | Med | News + jury delta |
-| Options chain panel | Med | Med | `yf.Ticker().option_chain` is free |
+| ~~Options chain panel~~ | ~~Med~~ | ~~Med~~ | ✅ Shipped — PR #194 |
 | Sector heatmap (discovery) | Med | Med | Pre-baked sector ETFs |
 | Custom alert rule builder | High | High | Needs auth + worker |
 | Reddit/X sentiment delta | Med | High | PRAW free, X is paid → Reddit only |

--- a/.claude/FiForesight_Roadmap.md
+++ b/.claude/FiForesight_Roadmap.md
@@ -1,7 +1,7 @@
 # FiForesight Roadmap
 
 > Source of truth for planned work. Feature-based, free-tier only.
-> Last synced: 2026-05-17 — All "Next Up" items shipped; moving to Feature Ideas backlog.
+> Last synced: 2026-05-18 — All "Next Up" items shipped; moving to Feature Ideas backlog.
 
 ---
 
@@ -105,10 +105,10 @@ Pure refactor — do after auth lands so router auth wiring is single-pass.
 
 | Feature | Value | Effort | Notes |
 |---|---|---|---|
-| Morning briefing email/digest | High | Med | Needs auth (#7) |
-| "Why did this move?" auto-explainer on >3% gaps | High | Med | News + jury delta |
+| Morning briefing (in-app Market Pulse panel) | High | Med | ✅ Shipped — PR #205 (`MorningBriefingPanel`, `/briefing`) |
+| ~~"Why did this move?" auto-explainer on >3% gaps~~ | ~~High~~ | ~~Med~~ | ✅ Shipped — PR #205 (`WhyDidMoveCard`, `predict.py:moveExplanation`) |
 | ~~Options chain panel~~ | ~~Med~~ | ~~Med~~ | ✅ Shipped — PR #194 |
-| Sector heatmap (discovery) | Med | Med | Pre-baked sector ETFs |
+| ~~Sector heatmap (discovery)~~ | ~~Med~~ | ~~Med~~ | ✅ Shipped — PR #205 (`SectorHeatmap`, `/sectors`) |
 | Custom alert rule builder | High | High | Needs auth + worker |
 | Reddit/X sentiment delta | Med | High | PRAW free, X is paid → Reddit only |
 | Walk-forward backtester | High | High | Validate jury historically |

--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -255,17 +255,21 @@ async def sector_heatmap():
             try:
                 hist = yf.Ticker(ticker).history(period="5d", interval="1d")
                 if hist is None or len(hist) < 2:
-                    results.append({"ticker": ticker, "label": label, "change_pct": None})
+                    results.append({"ticker": ticker, "label": label, "change_pct": None, "price": None})
                     continue
                 prev_close = float(hist["Close"].iloc[-2])
                 last_close = float(hist["Close"].iloc[-1])
                 change_pct = round((last_close - prev_close) / prev_close * 100, 2) if prev_close else None
                 results.append({"ticker": ticker, "label": label, "change_pct": change_pct, "price": round(last_close, 2)})
             except Exception:
-                results.append({"ticker": ticker, "label": label, "change_pct": None})
+                results.append({"ticker": ticker, "label": label, "change_pct": None, "price": None})
         return results
 
-    data = await asyncio.to_thread(_fetch_sectors)
+    try:
+        data = await asyncio.wait_for(asyncio.to_thread(_fetch_sectors), timeout=12.0)
+    except asyncio.TimeoutError:
+        logger.warning("[SECTORS] upstream fetch timed out")
+        raise HTTPException(status_code=504, detail="Market data temporarily unavailable")
     payload = {"sectors": data}
     await cache_set(CACHE_KEY, payload, ttl_seconds=900)
     return payload
@@ -312,7 +316,11 @@ async def morning_briefing():
                 results.append({"ticker": ticker, "label": label, "change_pct": None, "price": None})
         return results
 
-    data = await asyncio.to_thread(_fetch_overview)
+    try:
+        data = await asyncio.wait_for(asyncio.to_thread(_fetch_overview), timeout=12.0)
+    except asyncio.TimeoutError:
+        logger.warning("[BRIEFING] upstream fetch timed out")
+        raise HTTPException(status_code=504, detail="Market data temporarily unavailable")
     payload = {"indices": data}
     await cache_set(CACHE_KEY, payload, ttl_seconds=900)
     return payload

--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -219,3 +219,100 @@ async def options_chain(symbol: str) -> Dict[str, Any]:
     if result is None:
         raise HTTPException(status_code=404, detail=f"No options data for {symbol}")
     return result
+
+
+# ---------------------------------------------------------------------------
+# Sector Heatmap
+# ---------------------------------------------------------------------------
+
+SECTOR_ETFS = [
+    ("XLK",  "Technology"),
+    ("XLF",  "Financials"),
+    ("XLE",  "Energy"),
+    ("XLV",  "Health Care"),
+    ("XLY",  "Cons. Discret."),
+    ("XLP",  "Cons. Staples"),
+    ("XLI",  "Industrials"),
+    ("XLB",  "Materials"),
+    ("XLRE", "Real Estate"),
+    ("XLU",  "Utilities"),
+    ("XLC",  "Comm. Services"),
+]
+
+
+@router.get("/sectors")
+async def sector_heatmap():
+    """Returns 1-day % change for 11 SPDR sector ETFs. Cached 15 min."""
+    from redis_cache import cache_get, cache_set
+    CACHE_KEY = "sectors:heatmap"
+    cached = await cache_get(CACHE_KEY)
+    if cached:
+        return cached
+
+    def _fetch_sectors():
+        results = []
+        for ticker, label in SECTOR_ETFS:
+            try:
+                hist = yf.Ticker(ticker).history(period="5d", interval="1d")
+                if hist is None or len(hist) < 2:
+                    results.append({"ticker": ticker, "label": label, "change_pct": None})
+                    continue
+                prev_close = float(hist["Close"].iloc[-2])
+                last_close = float(hist["Close"].iloc[-1])
+                change_pct = round((last_close - prev_close) / prev_close * 100, 2) if prev_close else None
+                results.append({"ticker": ticker, "label": label, "change_pct": change_pct, "price": round(last_close, 2)})
+            except Exception:
+                results.append({"ticker": ticker, "label": label, "change_pct": None})
+        return results
+
+    data = await asyncio.to_thread(_fetch_sectors)
+    payload = {"sectors": data}
+    await cache_set(CACHE_KEY, payload, ttl_seconds=900)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Morning Briefing
+# ---------------------------------------------------------------------------
+
+MARKET_OVERVIEW_TICKERS = [
+    ("SPY",  "S&P 500"),
+    ("QQQ",  "NASDAQ"),
+    ("DIA",  "Dow Jones"),
+    ("IWM",  "Russell 2000"),
+    ("^VIX", "VIX"),
+    ("^TNX", "10Y Yield"),
+    ("GLD",  "Gold"),
+    ("USO",  "Oil"),
+]
+
+
+@router.get("/briefing")
+async def morning_briefing():
+    """Market overview: % change for key indices + ETFs. Cached 15 min."""
+    from redis_cache import cache_get, cache_set
+    CACHE_KEY = "briefing:market"
+    cached = await cache_get(CACHE_KEY)
+    if cached:
+        return cached
+
+    def _fetch_overview():
+        results = []
+        for ticker, label in MARKET_OVERVIEW_TICKERS:
+            try:
+                hist = yf.Ticker(ticker).history(period="5d", interval="1d")
+                if hist is None or len(hist) < 2:
+                    results.append({"ticker": ticker, "label": label, "change_pct": None, "price": None})
+                    continue
+                prev_close = float(hist["Close"].iloc[-2])
+                last_close = float(hist["Close"].iloc[-1])
+                change_pct = round((last_close - prev_close) / prev_close * 100, 2) if prev_close else None
+                results.append({"ticker": ticker, "label": label, "change_pct": change_pct, "price": round(last_close, 2)})
+            except Exception:
+                results.append({"ticker": ticker, "label": label, "change_pct": None, "price": None})
+        return results
+
+    data = await asyncio.to_thread(_fetch_overview)
+    payload = {"indices": data}
+    await cache_set(CACHE_KEY, payload, ttl_seconds=900)
+    return payload

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -1157,7 +1157,7 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
         )
         move_explanation_task = asyncio.create_task(
             analyst_jury_svc.call_groq(
-                "llama-3.3-70b-versatile",
+                "llama-3.1-8b-instant",
                 _move_system,
                 _move_user,
                 max_tokens=120,

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -1132,13 +1132,16 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
         earnings_dates = []
 
     # ── Step 4f. "Why did this move?" explainer (async, runs concurrently) ─────
-    _cur   = info.get("current_price", 0) or 0
+    try:
+        _cur_f = float(live_price)
+    except (TypeError, ValueError):
+        _cur_f = 0.0
     _prev  = info.get("prev_close", 0)
     try:
         _prev_f = float(_prev) if _prev not in (None, "N/A") else 0.0
     except (ValueError, TypeError):
         _prev_f = 0.0
-    price_change_pct = ((_cur - _prev_f) / _prev_f * 100) if _prev_f else 0.0
+    price_change_pct = ((_cur_f - _prev_f) / _prev_f * 100) if _prev_f else 0.0
 
     move_explanation_task = None
     if abs(price_change_pct) >= 3.0:
@@ -1148,7 +1151,7 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
         _move_system = "You are a concise financial analyst. Reply in 2 sentences max."
         _move_user   = (
             f"{symbol} moved {price_change_pct:+.1f}% today "
-            f"(from ${_prev_f:.2f} to ${_cur:.2f}). "
+            f"(from ${_prev_f:.2f} to ${_cur_f:.2f}). "
             f"Top headlines: {news_headlines_str}. "
             f"What is the most likely catalyst?"
         )

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -1141,6 +1141,9 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
         _prev_f = float(_prev) if _prev not in (None, "N/A") else 0.0
     except (ValueError, TypeError):
         _prev_f = 0.0
+    # Fall back to closes[-2] (yesterday's bar) when fetch_info prev_close is unavailable
+    if _prev_f <= 0 and len(closes) >= 2:
+        _prev_f = float(closes[-2])
     price_change_pct = ((_cur_f - _prev_f) / _prev_f * 100) if _prev_f else 0.0
 
     move_explanation_task = None

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -1220,7 +1220,7 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
     move_explanation: Optional[str] = None
     if move_explanation_task is not None:
         try:
-            move_explanation = await asyncio.wait_for(move_explanation_task, timeout=8.0)
+            move_explanation = await asyncio.wait_for(move_explanation_task, timeout=12.0)
             logger.info(f"[STEP-5b] Move explanation received ({len(move_explanation)} chars)")
         except Exception as _me:
             logger.warning(f"[STEP-5b] Move explanation failed: {_me}")

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -1221,6 +1221,15 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
             logger.info(f"[STEP-5b] Move explanation received ({len(move_explanation)} chars)")
         except Exception as _me:
             logger.warning(f"[STEP-5b] Move explanation failed: {_me}")
+        # Guaranteed fallback: card always shows on big moves even if Groq fails
+        if not move_explanation:
+            direction = "up" if price_change_pct > 0 else "down"
+            top_headline = news[0]["title"] if news else "no headlines available"
+            move_explanation = (
+                f"{symbol} is {direction} {abs(price_change_pct):.1f}% today. "
+                f"Top story: {top_headline}"
+            )
+            logger.info("[STEP-5b] Using fallback move explanation")
 
     # ── Step 6. (News/trending already resolved at 4e — nothing to await) ────
     logger.debug(

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -72,9 +72,10 @@ class PredictionResponse(BaseModel):
     juryAnalysts:  List[dict]
     modelWeights:  dict
     sentiment:     dict
-    stocktwits:    dict           = {}
-    monteCarlo:    Optional[dict] = None
-    earningsDates: List[str]      = []
+    stocktwits:      dict           = {}
+    monteCarlo:      Optional[dict] = None
+    earningsDates:   List[str]      = []
+    moveExplanation: Optional[str]  = None
 
 
 # ---------------------------------------------------------------------------
@@ -1130,6 +1131,39 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
         logger.warning(f"[STEP-4e] earnings_task failed: {e}")
         earnings_dates = []
 
+    # ── Step 4f. "Why did this move?" explainer (async, runs concurrently) ─────
+    _cur   = info.get("current_price", 0) or 0
+    _prev  = info.get("prev_close", 0)
+    try:
+        _prev_f = float(_prev) if _prev not in (None, "N/A") else 0.0
+    except (ValueError, TypeError):
+        _prev_f = 0.0
+    price_change_pct = ((_cur - _prev_f) / _prev_f * 100) if _prev_f else 0.0
+
+    move_explanation_task = None
+    if abs(price_change_pct) >= 3.0:
+        news_headlines_str = " | ".join(
+            n["title"] for n in news[:3] if n.get("title")
+        )
+        _move_system = "You are a concise financial analyst. Reply in 2 sentences max."
+        _move_user   = (
+            f"{symbol} moved {price_change_pct:+.1f}% today "
+            f"(from ${_prev_f:.2f} to ${_cur:.2f}). "
+            f"Top headlines: {news_headlines_str}. "
+            f"What is the most likely catalyst?"
+        )
+        move_explanation_task = asyncio.create_task(
+            analyst_jury_svc.call_groq(
+                "llama-3.3-70b-versatile",
+                _move_system,
+                _move_user,
+                max_tokens=120,
+            )
+        )
+        logger.info(
+            f"[STEP-4f] Move explainer task launched — {symbol} {price_change_pct:+.1f}%"
+        )
+
     # ── Step 5. AI analyst note + jury (concurrent) ──────────────────────────
     logger.info(
         f"[STEP-5] Dispatching AI header note (Groq llama-3.3-70b) + "
@@ -1175,6 +1209,15 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
             f"[STEP-5] [JURY/{v['id']}] rating={v['rating']}, "
             f"confidence={v['confidence']}%, model={v['model']}"
         )
+
+    # ── Step 5b. Await move explainer if running ─────────────────────────────
+    move_explanation: Optional[str] = None
+    if move_explanation_task is not None:
+        try:
+            move_explanation = await asyncio.wait_for(move_explanation_task, timeout=8.0)
+            logger.info(f"[STEP-5b] Move explanation received ({len(move_explanation)} chars)")
+        except Exception as _me:
+            logger.warning(f"[STEP-5b] Move explanation failed: {_me}")
 
     # ── Step 6. (News/trending already resolved at 4e — nothing to await) ────
     logger.debug(
@@ -1267,8 +1310,9 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
         modelWeights  = forecast.get("weights", {"prophet": 0.0, "sarima": 0.0, "rf": 0.0}),
         sentiment    = sentiment,
         stocktwits   = stocktwits_data,
-        monteCarlo   = forecast.get("monte_carlo"),
-        earningsDates = earnings_dates,
+        monteCarlo      = forecast.get("monte_carlo"),
+        earningsDates   = earnings_dates,
+        moveExplanation = move_explanation,
     )
 
 

--- a/frontend/app/api/briefing/route.ts
+++ b/frontend/app/api/briefing/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
+export async function GET() {
+  try {
+    const res = await fetch(`${BACKEND_URL}/briefing`, { next: { revalidate: 900 } });
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/frontend/app/api/briefing/route.ts
+++ b/frontend/app/api/briefing/route.ts
@@ -2,10 +2,14 @@ import { NextResponse } from 'next/server';
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
 export async function GET() {
   try {
-    const res = await fetch(`${BACKEND_URL}/briefing`, { next: { revalidate: 900 } });
+    const res = await fetch(`${BACKEND_URL}/briefing`, {
+      next: { revalidate: 900 },
+      signal: AbortSignal.timeout(8000),
+    });
     const data = await res.json();
     return NextResponse.json(data, { status: res.status });
-  } catch (err: any) {
-    return NextResponse.json({ error: err.message }, { status: 500 });
+  } catch (err: unknown) {
+    console.error('[briefing] proxy error:', err);
+    return NextResponse.json({ error: 'Failed to load market briefing' }, { status: 502 });
   }
 }

--- a/frontend/app/api/sectors/route.ts
+++ b/frontend/app/api/sectors/route.ts
@@ -2,10 +2,14 @@ import { NextResponse } from 'next/server';
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
 export async function GET() {
   try {
-    const res = await fetch(`${BACKEND_URL}/sectors`, { next: { revalidate: 900 } });
+    const res = await fetch(`${BACKEND_URL}/sectors`, {
+      next: { revalidate: 900 },
+      signal: AbortSignal.timeout(8000),
+    });
     const data = await res.json();
     return NextResponse.json(data, { status: res.status });
-  } catch (err: any) {
-    return NextResponse.json({ error: err.message }, { status: 500 });
+  } catch (err: unknown) {
+    console.error('[sectors] proxy error:', err);
+    return NextResponse.json({ error: 'Failed to load sector data' }, { status: 502 });
   }
 }

--- a/frontend/app/api/sectors/route.ts
+++ b/frontend/app/api/sectors/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
+export async function GET() {
+  try {
+    const res = await fetch(`${BACKEND_URL}/sectors`, { next: { revalidate: 900 } });
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -445,10 +445,11 @@ export default function QuantumDashboard() {
 
             {/* ── Right column ──────────────────────────────────────────── */}
             <Grid size={{ xs: 12, lg: 4 }}>
+              <Stack spacing={3}>
+                {/* ── Sector Overview (always visible, outside loading gate) ── */}
+                <SectorHeatmap isDark={isDark} primaryColor={primaryColor} />
               {loading ? <SidebarSkeleton /> : (
-                <Stack spacing={3}>
-                  {/* ── Sector Overview (always visible) ─────────────── */}
-                  <SectorHeatmap isDark={isDark} primaryColor={primaryColor} />
+                <>
 
                   {/* ── Watchlist ─────────────────────────────────────── */}
                   {user && watchlist.length > 0 && (
@@ -603,8 +604,9 @@ export default function QuantumDashboard() {
                     <TrendingSparklines tickers={prediction.trending} isDark={isDark} />
                   )}
 
-                </Stack>
+                </>
               )}
+              </Stack>
             </Grid>
 
           </Grid>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -32,6 +32,9 @@ import OptionsChainPanel from '../components/OptionsChainPanel';
 import StockChatPanel    from '../components/StockChatPanel';
 import { useIndicatorSignals } from '../hooks/useIndicatorSignals';
 import DCFCard               from '../components/DCFCard';
+import WhyDidMoveCard        from '../components/WhyDidMoveCard';
+import SectorHeatmap         from '../components/SectorHeatmap';
+import MorningBriefingPanel  from '../components/MorningBriefingPanel';
 import type { PredictionData, IndicatorKey, TradeSetupResponse, DCFResult, OptionsChainResult } from '../types';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -158,6 +161,13 @@ export default function QuantumDashboard() {
   const primaryColor = isDark ? '#f92aad' : '#1e3a8a';
 
   const indicatorSignals = useIndicatorSignals(prediction, isDark, chartStats);
+
+  const priceChangePct = useMemo(() => {
+    if (!prediction) return 0;
+    const cur  = parseFloat(prediction.currentPrice) || 0;
+    const prev = parseFloat(prediction.metrics?.prev_close ?? '') || 0;
+    return prev > 0 ? ((cur - prev) / prev) * 100 : 0;
+  }, [prediction]);
 
   const bgGradient = isDark
     ? 'none'
@@ -287,6 +297,9 @@ export default function QuantumDashboard() {
             </Stack>
           </Stack>
 
+          {/* ── Market Pulse (always visible) ───────────────────────── */}
+          <MorningBriefingPanel isDark={isDark} primaryColor={primaryColor} />
+
           {error && <Alert severity="error" sx={{ mb: 4, borderRadius: 3 }}>{error}</Alert>}
 
           <Grid container spacing={3}>
@@ -316,6 +329,17 @@ export default function QuantumDashboard() {
                     chartStats={chartStats}
                     indicatorSignals={indicatorSignals}
                   />
+
+                  {/* ── Why did this move? ───────────────────────────── */}
+                  {prediction.moveExplanation && (
+                    <WhyDidMoveCard
+                      symbol={prediction.symbol}
+                      explanation={prediction.moveExplanation}
+                      priceChange={priceChangePct}
+                      isDark={isDark}
+                      primaryColor={primaryColor}
+                    />
+                  )}
 
                   {/* ── Ensemble model weights ───────────────────────── */}
                   {prediction.modelWeights && (
@@ -423,6 +447,9 @@ export default function QuantumDashboard() {
             <Grid size={{ xs: 12, lg: 4 }}>
               {loading ? <SidebarSkeleton /> : (
                 <Stack spacing={3}>
+                  {/* ── Sector Overview (always visible) ─────────────── */}
+                  <SectorHeatmap isDark={isDark} primaryColor={primaryColor} />
+
                   {/* ── Watchlist ─────────────────────────────────────── */}
                   {user && watchlist.length > 0 && (
                     <Paper sx={{

--- a/frontend/components/MorningBriefingPanel.tsx
+++ b/frontend/components/MorningBriefingPanel.tsx
@@ -1,0 +1,107 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import {
+  Box, Typography, Stack, Skeleton,
+} from '@mui/material';
+import { Activity } from 'lucide-react';
+
+interface IndexEntry {
+  ticker: string;
+  label: string;
+  change_pct: number | null;
+  price: number | null;
+}
+
+interface Props {
+  isDark: boolean;
+  primaryColor: string;
+}
+
+export default function MorningBriefingPanel({ isDark, primaryColor }: Props) {
+  const [indices, setIndices] = useState<IndexEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/briefing')
+      .then(r => r.json())
+      .then(data => {
+        if (data?.indices) setIndices(data.indices);
+      })
+      .catch(() => { /* non-fatal */ })
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <Box sx={{
+      borderBottom: `1px solid ${isDark ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.07)'}`,
+      pb: 1.5,
+      mb: 2,
+    }}>
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+        <Activity size={13} color={primaryColor} />
+        <Typography variant="overline" sx={{ opacity: 0.5, lineHeight: 1, fontSize: '0.6rem', letterSpacing: 1.5 }}>
+          Market Pulse
+        </Typography>
+      </Stack>
+
+      {loading ? (
+        <Stack direction="row" spacing={1} sx={{ overflowX: 'auto', pb: 0.5 }}>
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Skeleton key={i} variant="rounded" width={80} height={44} sx={{ flexShrink: 0 }} />
+          ))}
+        </Stack>
+      ) : (
+        <Stack
+          direction="row"
+          spacing={0.75}
+          sx={{ overflowX: 'auto', pb: 0.5, scrollbarWidth: 'none', '&::-webkit-scrollbar': { display: 'none' } }}
+        >
+          {indices.map(item => {
+            const up = item.change_pct !== null && item.change_pct >= 0;
+            const na = item.change_pct === null || item.change_pct === undefined;
+            const color = na
+              ? (isDark ? '#888' : '#666')
+              : up
+                ? (isDark ? '#4ade80' : '#16a34a')
+                : (isDark ? '#f87171' : '#dc2626');
+            const bg = na
+              ? (isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.04)')
+              : up
+                ? (isDark ? 'rgba(22,101,52,0.25)' : 'rgba(220,252,231,0.65)')
+                : (isDark ? 'rgba(153,27,27,0.25)' : 'rgba(254,226,226,0.65)');
+
+            return (
+              <Box
+                key={item.ticker}
+                sx={{
+                  flexShrink: 0,
+                  background: bg,
+                  border: `1px solid ${color}33`,
+                  borderRadius: 1.5,
+                  px: 1,
+                  py: 0.75,
+                  minWidth: 76,
+                  textAlign: 'center',
+                }}
+              >
+                <Typography sx={{ fontWeight: 800, fontSize: '0.68rem', color, lineHeight: 1.2 }}>
+                  {item.label}
+                </Typography>
+                {item.price !== null && item.price !== undefined && (
+                  <Typography sx={{ fontSize: '0.6rem', opacity: 0.7, color, lineHeight: 1.2 }}>
+                    {item.price.toFixed(item.price < 10 ? 2 : item.price < 100 ? 2 : 0)}
+                  </Typography>
+                )}
+                <Typography sx={{ fontWeight: 700, fontSize: '0.7rem', color, lineHeight: 1.4 }}>
+                  {na
+                    ? 'N/A'
+                    : `${item.change_pct! >= 0 ? '+' : ''}${item.change_pct!.toFixed(2)}%`}
+                </Typography>
+              </Box>
+            );
+          })}
+        </Stack>
+      )}
+    </Box>
+  );
+}

--- a/frontend/components/SectorHeatmap.tsx
+++ b/frontend/components/SectorHeatmap.tsx
@@ -1,0 +1,123 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import {
+  Box, Card, CardContent, Typography, Stack, Skeleton,
+} from '@mui/material';
+import { Grid2X2 } from 'lucide-react';
+
+interface SectorEntry {
+  ticker: string;
+  label: string;
+  change_pct: number | null;
+  price?: number | null;
+}
+
+interface Props {
+  isDark: boolean;
+  primaryColor: string;
+}
+
+function getSectorColor(change_pct: number | null, isDark: boolean): { bg: string; text: string } {
+  if (change_pct === null || change_pct === undefined) {
+    return {
+      bg: isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.05)',
+      text: isDark ? '#888' : '#666',
+    };
+  }
+  if (change_pct > 1) {
+    return {
+      bg: isDark ? 'rgba(22,101,52,0.45)' : 'rgba(220,252,231,0.85)',
+      text: isDark ? '#4ade80' : '#166534',
+    };
+  }
+  if (change_pct > 0) {
+    return {
+      bg: isDark ? 'rgba(22,101,52,0.22)' : 'rgba(220,252,231,0.50)',
+      text: isDark ? '#86efac' : '#15803d',
+    };
+  }
+  if (change_pct > -1) {
+    return {
+      bg: isDark ? 'rgba(153,27,27,0.22)' : 'rgba(254,226,226,0.50)',
+      text: isDark ? '#fca5a5' : '#b91c1c',
+    };
+  }
+  return {
+    bg: isDark ? 'rgba(153,27,27,0.45)' : 'rgba(254,226,226,0.85)',
+    text: isDark ? '#f87171' : '#991b1b',
+  };
+}
+
+export default function SectorHeatmap({ isDark, primaryColor }: Props) {
+  const [sectors, setSectors] = useState<SectorEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/sectors')
+      .then(r => r.json())
+      .then(data => {
+        if (data?.sectors) setSectors(data.sectors);
+      })
+      .catch(() => { /* non-fatal */ })
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <Card sx={{
+      border: `1px solid ${isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}`,
+      background: isDark ? 'rgba(255,255,255,0.02)' : 'rgba(255,255,255,0.7)',
+    }}>
+      <CardContent sx={{ pb: '12px !important' }}>
+        <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1.5 }}>
+          <Grid2X2 size={14} color={primaryColor} />
+          <Typography variant="overline" sx={{ opacity: 0.6, lineHeight: 1, fontSize: '0.65rem', letterSpacing: 1.5 }}>
+            Sector Overview
+          </Typography>
+        </Stack>
+
+        {loading ? (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {Array.from({ length: 11 }).map((_, i) => (
+              <Skeleton key={i} variant="rounded" width={88} height={56} />
+            ))}
+          </Box>
+        ) : (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {sectors.map(s => {
+              const { bg, text } = getSectorColor(s.change_pct, isDark);
+              const sign = s.change_pct !== null && s.change_pct !== undefined
+                ? (s.change_pct >= 0 ? '+' : '')
+                : '';
+              return (
+                <Box
+                  key={s.ticker}
+                  sx={{
+                    background: bg,
+                    borderRadius: 1.5,
+                    px: 1,
+                    py: 0.75,
+                    minWidth: 84,
+                    textAlign: 'center',
+                    border: `1px solid ${text}33`,
+                  }}
+                >
+                  <Typography sx={{ fontWeight: 800, fontSize: '0.72rem', color: text, lineHeight: 1.2 }}>
+                    {s.ticker}
+                  </Typography>
+                  <Typography sx={{ fontSize: '0.6rem', opacity: 0.7, lineHeight: 1.3, color: text }}>
+                    {s.label}
+                  </Typography>
+                  <Typography sx={{ fontWeight: 700, fontSize: '0.75rem', color: text, lineHeight: 1.4 }}>
+                    {s.change_pct !== null && s.change_pct !== undefined
+                      ? `${sign}${s.change_pct.toFixed(2)}%`
+                      : 'N/A'}
+                  </Typography>
+                </Box>
+              );
+            })}
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/WhyDidMoveCard.tsx
+++ b/frontend/components/WhyDidMoveCard.tsx
@@ -1,0 +1,36 @@
+'use client';
+import React from 'react';
+import { Box, Card, CardContent, Typography, Stack } from '@mui/material';
+import { TrendingUp, TrendingDown } from 'lucide-react';
+
+interface Props {
+  symbol: string;
+  explanation: string;
+  priceChange: number;  // numeric % change, e.g. +5.2 or -3.1
+  isDark: boolean;
+  primaryColor: string;
+}
+
+export default function WhyDidMoveCard({ symbol, explanation, priceChange, isDark, primaryColor }: Props) {
+  const isUp = priceChange >= 0;
+  const color = isUp ? (isDark ? '#00ffa3' : '#16a34a') : (isDark ? '#ff0055' : '#dc2626');
+  const Icon = isUp ? TrendingUp : TrendingDown;
+
+  return (
+    <Card sx={{ border: `1px solid ${color}44`, background: `${color}0d` }}>
+      <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
+        <Stack direction="row" alignItems="flex-start" spacing={1.5}>
+          <Icon size={18} style={{ color, marginTop: 2, flexShrink: 0 }} />
+          <Box>
+            <Typography variant="caption" sx={{ color, fontWeight: 800, letterSpacing: 1, textTransform: 'uppercase' }}>
+              {symbol} {priceChange >= 0 ? '+' : ''}{priceChange.toFixed(1)}% today — Why?
+            </Typography>
+            <Typography variant="body2" sx={{ mt: 0.5, lineHeight: 1.5, opacity: 0.85, fontSize: '0.8rem' }}>
+              {explanation}
+            </Typography>
+          </Box>
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -104,8 +104,9 @@ export interface PredictionData {
   modelWeights?: { prophet: number; sarima: number; rf: number };
   sentiment?:    { compound: number; label: string; headline_count: number };
   stocktwits?:   { bullish: number; bearish: number; sentiment: number };
-  monteCarlo?:   MonteCarloResult | null;
-  earningsDates?: string[];
+  monteCarlo?:      MonteCarloResult | null;
+  earningsDates?:   string[];
+  moveExplanation?: string;
   lastUpdated: string;
 }
 

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -106,7 +106,7 @@ export interface PredictionData {
   stocktwits?:   { bullish: number; bearish: number; sentiment: number };
   monteCarlo?:      MonteCarloResult | null;
   earningsDates?:   string[];
-  moveExplanation?: string;
+  moveExplanation?: string | null;
   lastUpdated: string;
 }
 


### PR DESCRIPTION
## Summary

Cumulative feature branch landing everything since PR #199. Covers five areas: new market intelligence features, news pipeline expansion, simulation auth hardening, UI/UX redesign, and infra/CI fixes.

---

## New Features (this session)

### "Why did this move?" auto-explainer
- Backend (`routers/predict.py`): detects ≥3% daily price moves, fires a focused `llama-3.3-70b` Groq call with today's top headlines as context, returns `moveExplanation` in the predict response
- Frontend (`WhyDidMoveCard.tsx`): green/red banner card shown after `PriceChartCard` when a significant move is detected, 2-sentence catalyst explanation

### Sector heatmap
- Backend (`market.py` `/sectors`): fetches all 11 SPDR sector ETFs (XLK→XLC), computes 1-day % change, 15-min Redis cache
- Frontend (`SectorHeatmap.tsx`): color-coded heatmap in the right sidebar — always visible as a market discovery widget before any ticker is searched

### Morning briefing / Market Pulse panel
- Backend (`market.py` `/briefing`): SPY, QQQ, DIA, IWM, VIX, 10Y yield, Gold, Oil — 15-min Redis cache
- Frontend (`MorningBriefingPanel.tsx`): horizontal scrollable strip at the top of the page, always visible

---

## Prior Work (accumulated from #200–#204)

### News pipeline expansion (#203)
- Added Finnhub, StockTwits, and Yahoo Finance RSS as free fallback news sources
- Fixed position sizing formula (was 500× too large), Options NaN crash, DCF FCF fallback
- Moved Market Intelligence panel to right column

### Simulation auth hardening (#201/#202)
- `user_id` now derived from JWT on the backend — clients can no longer spoof it
- Added `AuthGate` component, per-user watchlist (`useWatchlist` hook, `lib/watchlist.ts`)
- Full router test suite (`test_routers.py` — 316 lines, covers predict/trade/market/simulation)
- Fixed Supabase build-args in Dockerfile + CI pipeline

### UI/UX redesign (#204)
- New nebula dark mode palette (flat navy, no gradient)
- Warm cream light mode palette with deep navy primary
- Layout redesign: left column restructured, header cleaned up (dropped QUANTUM wordmark)
- Docker login stderr→stdout fix for VM deploy

### CI/infra (#200)
- Supabase env vars threaded through the build pipeline
- `@supabase/supabase-js` installed at monorepo root
- `.tsbuildinfo` added to `.gitignore`

---

## Files changed (33 files, +2004 / -189)

Key additions:
- `frontend/components/WhyDidMoveCard.tsx` — new
- `frontend/components/SectorHeatmap.tsx` — new
- `frontend/components/MorningBriefingPanel.tsx` — new
- `frontend/components/AuthGate.tsx` — new
- `frontend/hooks/useWatchlist.ts` — new
- `frontend/lib/watchlist.ts` — new
- `frontend/app/api/sectors/route.ts` — new
- `frontend/app/api/briefing/route.ts` — new
- `backend/tests/test_routers.py` — new (316 lines)
- `backend/tests/test_new_services.py` — new (221 lines)

## Test plan
- [ ] `python -m pytest backend/tests/ -v` — all tests pass
- [ ] `cd frontend && pnpm run build` — clean TypeScript build
- [ ] Search a ticker with ≥3% intraday move → `WhyDidMoveCard` banner appears
- [ ] Sector heatmap renders in right sidebar on page load (no ticker required)
- [ ] Market Pulse strip renders at top of page on load (no ticker required)
- [ ] `/api/sectors` and `/api/briefing` return data and warm Redis cache
- [ ] Simulation page: user_id isolation — different users see separate portfolios
- [ ] Dark/light theme toggle — new palettes render correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_0127ETRfUNGfWM6tcwZKetYD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Morning market briefing panel showing key indices with recent price and percent changes
  * Sector performance heatmap for quick market overview
  * AI-generated short explanations for notable daily moves (displayed when significant)
  * Dashboard widgets wired to display briefing, sector heatmap, and explanation cards

* **Performance/Reliability**
  * Brief caching and upstream request timeouts to avoid hangs; graceful fallbacks and N/A handling on partial failures

* **Documentation**
  * Roadmap updated (sync date, shipped items moved to “Shipped”, new focus on feature ideas)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WeekendDevelopment/FiForesight/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->