### PR TITLE
Add multi-timeframe history endpoint & interval selector to charts

### DIFF
--- a/backend/jury_graph.py
+++ b/backend/jury_graph.py
@@ -58,6 +58,12 @@ def _make_analyst_node(persona: dict, analyst_jury_svc):
             return {"verdicts": {pid: verdict}}
         except Exception as exc:
             logger.error(f"[JURY-GRAPH/{pid}] ✗ node failed: {exc}", exc_info=True)
+            # Surface a useful message: 429 = daily quota exhausted, else generic
+            exc_str = str(exc)
+            if "429" in exc_str or "rate_limit" in exc_str.lower() or "rate limit" in exc_str.lower():
+                fallback_note = "Rate limit reached — daily Groq quota exhausted."
+            else:
+                fallback_note = "Analysis unavailable."
             fallback = {
                 "id":          persona["id"],
                 "avatar":      persona["avatar"],
@@ -65,7 +71,7 @@ def _make_analyst_node(persona: dict, analyst_jury_svc):
                 "model_label": persona["model_label"],
                 "color":       persona["color"],
                 "rating":      "Hold",
-                "note":        "Analysis unavailable.",
+                "note":        fallback_note,
                 "confidence":  25,
                 "model":       "error",
             }

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,7 +10,7 @@ from fastapi.responses import JSONResponse
 
 from config import Config, SanitizeHttpxFilter
 from redis_cache import init_redis, close_redis
-from routers import predict, simulation, trade, market
+from routers import predict, simulation, trade, market, history
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -45,6 +45,7 @@ app.include_router(predict.router)
 app.include_router(simulation.router)
 app.include_router(trade.router)
 app.include_router(market.router)
+app.include_router(history.router)
 
 
 if __name__ == "__main__":

--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -13,6 +13,7 @@ from models import (
     calculate_rsi_series,
     calculate_sma_series,
 )
+from dependencies import influx_svc
 from redis_cache import cache_get, cache_set
 
 router = APIRouter()
@@ -38,9 +39,16 @@ PERIODS_PER_YEAR: dict[str, int] = {
 }
 
 INTRADAY_INTERVALS = {"5m", "15m", "1h"}
-INTRADAY_PERIODS   = {"1d", "5d"}
 INTRADAY_TTL       = 300   # 5 min
 DAILY_TTL          = 900   # 15 min
+
+# Minimum bar count needed to accept InfluxDB data as "sufficient" for each period
+_INFLUX_MIN_ROWS: dict[str, int] = {
+    "3mo": 50,
+    "6mo": 110,
+    "1y":  220,
+    "2y":  450,
+}
 
 
 def _compute_vwap(df: pd.DataFrame) -> list:
@@ -135,16 +143,48 @@ async def get_history(
         return cached
 
     logger.info(f"[HISTORY] Cache MISS — fetching {symbol} {period}/{interval}")
-    try:
-        df = await asyncio.wait_for(
-            asyncio.to_thread(_fetch_df, symbol, period, interval),
-            timeout=25,
-        )
-    except asyncio.TimeoutError:
-        raise HTTPException(status_code=504, detail="History fetch timed out.")
-    except Exception as exc:
-        logger.error(f"[HISTORY] unexpected error for {symbol}: {exc}")
-        raise HTTPException(status_code=502, detail="Failed to fetch historical data.")
+
+    ticker = symbol.split(":")[0].upper()
+
+    # InfluxDB-first for daily-interval requests (intraday bars not stored in Influx)
+    df = pd.DataFrame()
+    if not is_intraday:
+        period_to_days = {"3mo": 93, "6mo": 183, "1y": 365, "2y": 730}
+        days = period_to_days.get(period, 730)
+        try:
+            influx_rows = await asyncio.to_thread(influx_svc.query_history, ticker, days)
+            min_rows    = _INFLUX_MIN_ROWS.get(period, 0)
+            if len(influx_rows) >= min_rows:
+                tmp = pd.DataFrame(influx_rows)
+                tmp["_time"] = pd.to_datetime(tmp["_time"])
+                tmp = tmp.set_index("_time").rename(columns={
+                    "close": "Close", "open": "Open",
+                    "high": "High", "low": "Low", "volume": "Volume",
+                })
+                if tmp.index.tz is None:
+                    tmp.index = tmp.index.tz_localize("UTC")
+                df = tmp.dropna(subset=["Close"])
+                logger.info(f"[HISTORY] InfluxDB HIT — {len(df)} rows for {symbol} ({period})")
+            else:
+                logger.info(
+                    f"[HISTORY] InfluxDB insufficient ({len(influx_rows)} rows, "
+                    f"need ≥{min_rows}) — falling back to yfinance"
+                )
+        except Exception as exc:
+            logger.warning(f"[HISTORY] InfluxDB query failed for {ticker}: {exc} — falling back to yfinance")
+
+    # yfinance fallback — always used for intraday; fallback for daily when Influx data is sparse
+    if df.empty:
+        try:
+            df = await asyncio.wait_for(
+                asyncio.to_thread(_fetch_df, ticker, period, interval),
+                timeout=12,
+            )
+        except asyncio.TimeoutError:
+            raise HTTPException(status_code=504, detail="History fetch timed out.")
+        except Exception as exc:
+            logger.error(f"[HISTORY] yfinance error for {ticker}: {exc}")
+            raise HTTPException(status_code=502, detail="Failed to fetch historical data.")
 
     if df.empty:
         raise HTTPException(status_code=404, detail=f"No data for symbol '{symbol}'.")
@@ -161,7 +201,7 @@ async def get_history(
     sma20_s  = calculate_sma_series(closes, 20)
 
     vwap_s: list = []
-    if period in INTRADAY_PERIODS:
+    if is_intraday:
         vwap_s = _compute_vwap(df)
 
     # Date strings — intraday uses Eastern, daily stays UTC date

--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -236,6 +236,9 @@ async def get_history(
             bar["vwap"] = vwap_s[i]
         history_bars.append(bar)
 
+    valid_highs = [v for v in highs if np.isfinite(v) and v > 0]
+    valid_lows  = [v for v in lows  if np.isfinite(v) and v > 0]
+
     log_returns = [
         float(np.log(closes[i] / closes[i - 1]))
         for i in range(1, len(closes))
@@ -249,8 +252,8 @@ async def get_history(
 
     stats: dict[str, Any] = {
         "change_pct":  round((last - first) / first * 100, 4) if first > 0 else 0.0,
-        "period_high": round(max(highs), 4),
-        "period_low":  round(min(lows),  4),
+        "period_high": round(max(valid_highs), 4) if valid_highs else None,
+        "period_low":  round(min(valid_lows),  4) if valid_lows  else None,
         "sma20":       round(sma20_last, 4) if sma20_last is not None else None,
         "ann_vol":     round(ann_vol, 2),
     }

--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -1,0 +1,229 @@
+# backend/routers/history.py
+import asyncio
+import logging
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from fastapi import APIRouter, HTTPException, Query
+
+from models import (
+    calculate_bollinger_bands,
+    calculate_macd,
+    calculate_rsi_series,
+    calculate_sma_series,
+)
+from redis_cache import cache_get, cache_set
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+# Valid period → required interval
+VALID_COMBINATIONS: dict[str, str] = {
+    "1d":  "5m",
+    "5d":  "15m",
+    "1mo": "1h",
+    "3mo": "1d",
+    "6mo": "1d",
+    "1y":  "1d",
+    "2y":  "1d",
+}
+
+# Approximate trading periods per year per interval (for annualised vol)
+PERIODS_PER_YEAR: dict[str, int] = {
+    "5m":  252 * 78,
+    "15m": 252 * 26,
+    "1h":  252 * 7,
+    "1d":  252,
+}
+
+INTRADAY_INTERVALS = {"5m", "15m", "1h"}
+INTRADAY_PERIODS   = {"1d", "5d"}
+INTRADAY_TTL       = 300   # 5 min
+DAILY_TTL          = 900   # 15 min
+
+
+def _compute_vwap(df: pd.DataFrame) -> list:
+    """Per-bar VWAP that resets at each calendar-day boundary."""
+    required = {"High", "Low", "Close", "Volume"}
+    if not required.issubset(df.columns):
+        return [None] * len(df)
+    typical = (df["High"] + df["Low"] + df["Close"]) / 3
+    vol     = df["Volume"]
+    result: list = []
+    cum_tv, cum_v = 0.0, 0.0
+    prev_date = None
+    for i in range(len(df)):
+        d = df.index[i].date()
+        if d != prev_date:
+            cum_tv = cum_v = 0.0
+            prev_date = d
+        cum_tv += float(typical.iloc[i]) * float(vol.iloc[i])
+        cum_v  += float(vol.iloc[i])
+        result.append(round(cum_tv / cum_v, 4) if cum_v > 0 else None)
+    return result
+
+
+def _fetch_df(symbol: str, period: str, interval: str) -> pd.DataFrame:
+    """Blocking yfinance download — wrapped by asyncio.to_thread."""
+    try:
+        import yfinance as yf
+    except ImportError:
+        logger.error("[HISTORY] yfinance not installed")
+        return pd.DataFrame()
+
+    ticker = symbol.split(":")[0].upper()
+    try:
+        df = yf.download(
+            ticker,
+            period=period,
+            interval=interval,
+            progress=False,
+            auto_adjust=True,
+            timeout=20,
+        )
+    except Exception as exc:
+        logger.error(f"[HISTORY] yf.download failed for {ticker}: {exc}")
+        return pd.DataFrame()
+
+    if df.empty:
+        return df
+
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = df.columns.get_level_values(0)
+        df = df.loc[:, ~df.columns.duplicated(keep="first")]
+
+    df.index = pd.to_datetime(df.index)
+    if df.index.tz is None:
+        df.index = df.index.tz_localize("UTC")
+    else:
+        df.index = df.index.tz_convert("UTC")
+
+    keep = [c for c in ["Open", "High", "Low", "Close", "Volume"] if c in df.columns]
+    return df[keep].dropna(subset=["Close"])
+
+
+@router.get("/history")
+async def get_history(
+    symbol:   str = Query(..., min_length=1, max_length=20),
+    period:   str = Query("2y"),
+    interval: str = Query("1d"),
+) -> dict[str, Any]:
+    symbol   = symbol.strip().upper()
+    period   = period.strip().lower()
+    interval = interval.strip().lower()
+
+    if period not in VALID_COMBINATIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid period '{period}'. Must be one of: {sorted(VALID_COMBINATIONS)}",
+        )
+    expected = VALID_COMBINATIONS[period]
+    if interval != expected:
+        raise HTTPException(
+            status_code=400,
+            detail=f"For period='{period}', interval must be '{expected}' (got '{interval}').",
+        )
+
+    is_intraday = interval in INTRADAY_INTERVALS
+    ttl         = INTRADAY_TTL if is_intraday else DAILY_TTL
+    cache_key   = f"history:{symbol}:{period}:{interval}"
+
+    cached = await cache_get(cache_key)
+    if cached is not None:
+        logger.info(f"[HISTORY] Cache HIT — {symbol} {period}/{interval}")
+        return cached
+
+    logger.info(f"[HISTORY] Cache MISS — fetching {symbol} {period}/{interval}")
+    try:
+        df = await asyncio.wait_for(
+            asyncio.to_thread(_fetch_df, symbol, period, interval),
+            timeout=25,
+        )
+    except asyncio.TimeoutError:
+        raise HTTPException(status_code=504, detail="History fetch timed out.")
+    except Exception as exc:
+        logger.error(f"[HISTORY] unexpected error for {symbol}: {exc}")
+        raise HTTPException(status_code=502, detail="Failed to fetch historical data.")
+
+    if df.empty:
+        raise HTTPException(status_code=404, detail=f"No data for symbol '{symbol}'.")
+
+    closes  = [float(v) for v in df["Close"].tolist()]
+    highs   = [float(v) for v in df["High"].tolist()]   if "High"   in df.columns else list(closes)
+    lows    = [float(v) for v in df["Low"].tolist()]    if "Low"    in df.columns else list(closes)
+    opens   = [float(v) for v in df["Open"].tolist()]   if "Open"   in df.columns else list(closes)
+    volumes = [int(v)   for v in df["Volume"].tolist()] if "Volume" in df.columns else [0] * len(closes)
+
+    bb       = calculate_bollinger_bands(closes)
+    macd_d   = calculate_macd(closes)
+    rsi_s    = calculate_rsi_series(closes)
+    sma20_s  = calculate_sma_series(closes, 20)
+
+    vwap_s: list = []
+    if period in INTRADAY_PERIODS:
+        vwap_s = _compute_vwap(df)
+
+    # Date strings — intraday uses Eastern, daily stays UTC date
+    if is_intraday:
+        fmt = "%m/%d %H:%M" if period == "5d" else "%H:%M"
+        try:
+            eastern = df.index.tz_convert("America/New_York")
+            dates = [ts.strftime(fmt) for ts in eastern]
+        except Exception:
+            dates = [ts.strftime(fmt) for ts in df.index]
+    else:
+        dates = [ts.strftime("%Y-%m-%d") for ts in df.index]
+
+    history_bars: list[dict] = []
+    for i, date in enumerate(dates):
+        bar: dict[str, Any] = {
+            "date":        date,
+            "price":       round(closes[i], 4),
+            "open":        round(opens[i],  4),
+            "high":        round(highs[i],  4),
+            "low":         round(lows[i],   4),
+            "volume":      volumes[i],
+            "bb_upper":    bb["upper"][i],
+            "bb_middle":   bb["middle"][i],
+            "bb_lower":    bb["lower"][i],
+            "macd":        macd_d["macd"][i],
+            "macd_signal": macd_d["signal"][i],
+            "macd_hist":   macd_d["hist"][i],
+            "rsi":         rsi_s[i],
+        }
+        if vwap_s:
+            bar["vwap"] = vwap_s[i]
+        history_bars.append(bar)
+
+    log_returns = [
+        float(np.log(closes[i] / closes[i - 1]))
+        for i in range(1, len(closes))
+        if closes[i - 1] > 0 and closes[i] > 0
+    ]
+    ppy     = PERIODS_PER_YEAR.get(interval, 252)
+    ann_vol = float(np.std(log_returns) * np.sqrt(ppy) * 100) if len(log_returns) > 1 else 0.0
+    first   = closes[0]  if closes else 0.0
+    last    = closes[-1] if closes else 0.0
+    sma20_last = next((v for v in reversed(sma20_s) if v is not None), None)
+
+    stats: dict[str, Any] = {
+        "change_pct":  round((last - first) / first * 100, 4) if first > 0 else 0.0,
+        "period_high": round(max(highs), 4),
+        "period_low":  round(min(lows),  4),
+        "sma20":       round(sma20_last, 4) if sma20_last is not None else None,
+        "ann_vol":     round(ann_vol, 2),
+    }
+
+    payload: dict[str, Any] = {
+        "symbol":     symbol,
+        "period":     period,
+        "interval":   interval,
+        "history":    history_bars,
+        "rsi_series": rsi_s,
+        "stats":      stats,
+    }
+
+    await cache_set(cache_key, payload, ttl_seconds=ttl)
+    logger.info(f"[HISTORY] ✓ {symbol} {period}/{interval} — {len(history_bars)} bars, cached {ttl}s")
+    return payload

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -1225,6 +1225,9 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
                     v["note"] = f"[Cached] {v.get('note', '')}"
                 jury = stale_jury
                 logger.info(f"[STEP-5] Using stale jury for {symbol} — Groq quota likely exhausted")
+            # Cache fallback/stale result for 5 min to prevent re-hammering Groq on every request
+            await cache_set(jury_cache_key, jury, ttl_seconds=300)
+            logger.info(f"[STEP-5] Jury failure cached for {symbol} (5 min — quota likely exhausted)")
     logger.info(
         f"[STEP-5] ✓ AI layer complete — "
         f"note={len(note)} chars | jury={len(jury)} verdicts"

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -1183,7 +1183,9 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
     _jury_fp = hashlib.md5(
         f"{rsi:.1f}|{forecast['high']:.2f}|{forecast['low']:.2f}|{closes[-1]:.2f}|{sentiment.get('label', '')}".encode()
     ).hexdigest()[:12]
-    jury_cache_key = f"jury:{symbol.upper()}:{_jury_fp}"
+    jury_cache_key       = f"jury:{symbol.upper()}:{_jury_fp}"
+    jury_stale_cache_key = f"jury_stale:{symbol.upper()}"   # symbol-level, 8h TTL
+
     cached_jury = await cache_get(jury_cache_key)
     if cached_jury is not None:
         logger.info(f"[STEP-5] Jury cache HIT for {symbol} — skipping Groq jury calls")
@@ -1204,8 +1206,25 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
                 stocktwits=stocktwits_data,
             ),
         )
-        if jury:
-            await cache_set(jury_cache_key, jury, ttl_seconds=1200)  # 20 min
+
+        all_fallback = jury and all(
+            v.get("note") in ("Analysis unavailable.", "Rate limit reached — daily Groq quota exhausted.")
+            for v in jury
+        )
+
+        if jury and not all_fallback:
+            # Successful jury — warm both hot cache (2h) and stale fallback (8h)
+            await cache_set(jury_cache_key,       jury, ttl_seconds=7200)   # 2h hot
+            await cache_set(jury_stale_cache_key, jury, ttl_seconds=28800)  # 8h stale
+            logger.info(f"[STEP-5] Jury cached for {symbol} (hot=2h, stale=8h)")
+        elif all_fallback:
+            # All analysts hit rate-limit / error — check for a recent stale verdict
+            stale_jury = await cache_get(jury_stale_cache_key)
+            if stale_jury:
+                for v in stale_jury:
+                    v["note"] = f"[Cached] {v.get('note', '')}"
+                jury = stale_jury
+                logger.info(f"[STEP-5] Using stale jury for {symbol} — Groq quota likely exhausted")
     logger.info(
         f"[STEP-5] ✓ AI layer complete — "
         f"note={len(note)} chars | jury={len(jury)} verdicts"

--- a/frontend/app/api/history/route.ts
+++ b/frontend/app/api/history/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const symbol   = searchParams.get('symbol')   || '';
+  const period   = searchParams.get('period')   || '2y';
+  const interval = searchParams.get('interval') || '1d';
+
+  if (!symbol) {
+    return NextResponse.json({ error: 'symbol is required' }, { status: 400 });
+  }
+
+  try {
+    const url = `${BACKEND_URL}/history?symbol=${encodeURIComponent(symbol)}&period=${encodeURIComponent(period)}&interval=${encodeURIComponent(interval)}`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(30_000) });
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (err: unknown) {
+    console.error('[history] proxy error:', err);
+    return NextResponse.json({ error: 'Failed to fetch history' }, { status: 502 });
+  }
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -317,6 +317,7 @@ export default function QuantumDashboard() {
                   {/* Price chart card */}
                   <PriceChartCard
                     prediction={prediction}
+                    symbol={prediction.symbol}
                     indicators={indicators}
                     setIndicators={setIndicators}
                     chartMode={chartMode}

--- a/frontend/components/PriceChartCard.tsx
+++ b/frontend/components/PriceChartCard.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import React, { useState, useMemo, useRef, useEffect } from 'react';
+import React, { useState, useMemo, useRef, useEffect, useCallback } from 'react';
+import axios from 'axios';
 import {
-  Box, Card, CardContent, Chip, Collapse, Stack, Typography,
+  Box, Card, CardContent, Chip, Collapse, CircularProgress, Stack, Typography,
   ToggleButton, ToggleButtonGroup, Button,
 } from '@mui/material';
 import { Info, ChevronDown, ChevronUp } from 'lucide-react';
@@ -13,14 +14,26 @@ import {
 } from 'recharts';
 import dynamic from 'next/dynamic';
 import VolumeProfile from './VolumeProfile';
-import type { PredictionData, IndicatorKey, ChartEntry, ChartStats, IndicatorSignals } from '../types';
+import type { PredictionData, IndicatorKey, ChartEntry, ChartStats, IndicatorSignals, IntervalHistoryData } from '../types';
 
 const AdvancedChart = dynamic(() => import('./AdvancedChart'), { ssr: false });
+
+// UI label → { period, interval } for the /history endpoint
+const INTERVAL_MAP: Record<string, { period: string; interval: string }> = {
+  '1d': { period: '1d',  interval: '5m'  },
+  '5d': { period: '5d',  interval: '15m' },
+  '1m': { period: '1mo', interval: '1h'  },
+  '3m': { period: '3mo', interval: '1d'  },
+  '6m': { period: '6mo', interval: '1d'  },
+  '1y': { period: '1y',  interval: '1d'  },
+  '2y': { period: '2y',  interval: '1d'  },
+} as const;
 
 const CHART_HEIGHT = 380;
 
 interface Props {
   prediction:      PredictionData;
+  symbol:          string;
   indicators:      IndicatorKey[];
   setIndicators:   (v: IndicatorKey[]) => void;
   chartMode:       'line' | 'candle';
@@ -35,13 +48,75 @@ interface Props {
 }
 
 export default function PriceChartCard({
-  prediction, indicators, setIndicators,
+  prediction, symbol, indicators, setIndicators,
   chartMode, setChartMode, chartEngine, setChartEngine,
   isDark, primaryColor, trendColor, chartStats, indicatorSignals,
 }: Props) {
-  const [legendOpen, setLegendOpen] = useState(false);
+  const [legendOpen,       setLegendOpen]       = useState(false);
+  const [selectedInterval, setSelectedInterval] = useState<string>('2y');
+  const [intervalData,     setIntervalData]     = useState<IntervalHistoryData | null>(null);
+  const [historyLoading,   setHistoryLoading]   = useState(false);
+  // Track the last symbol we rendered for — reset interval when it changes
+  const [lastSymbol, setLastSymbol] = useState(prediction.symbol);
+  if (lastSymbol !== prediction.symbol) {
+    setLastSymbol(prediction.symbol);
+    setSelectedInterval('2y');
+    setIntervalData(null);
+  }
   const chartBoxRef = useRef<HTMLDivElement>(null);
   const [clipBox, setClipBox] = useState<{ l: number; t: number; w: number; h: number } | null>(null);
+
+  const fetchIntervalHistory = useCallback((iv: string) => {
+    if (iv === '2y') {
+      setIntervalData(null);
+      return;
+    }
+    const { period, interval } = INTERVAL_MAP[iv];
+    setHistoryLoading(true);
+    axios
+      .get(`/api/history?symbol=${encodeURIComponent(symbol)}&period=${encodeURIComponent(period)}&interval=${encodeURIComponent(interval)}`)
+      .then(r => setIntervalData(r.data))
+      .catch(() => setIntervalData(null))
+      .finally(() => setHistoryLoading(false));
+  }, [symbol]);
+
+  const handleIntervalChange = useCallback((iv: string) => {
+    setSelectedInterval(iv);
+    fetchIntervalHistory(iv);
+  }, [fetchIntervalHistory]);
+
+  // Active history — interval fetch takes precedence over prediction.history
+  const activeHistory = useMemo(() => {
+    if (intervalData && selectedInterval !== '2y') return intervalData.history;
+    return prediction.history;
+  }, [intervalData, selectedInterval, prediction.history]);
+
+  // Stats for the active interval
+  const activeStats = useMemo(() => {
+    if (intervalData && selectedInterval !== '2y') {
+      const s = intervalData.stats;
+      const isUp  = s.change_pct >= 0;
+      return {
+        changePct:   s.change_pct,
+        isUp,
+        high:        s.period_high,
+        low:         s.period_low,
+        sma20:       s.sma20,
+        annVol:      s.ann_vol,
+        color:       isUp ? (isDark ? '#00ffa3' : '#16a34a') : (isDark ? '#ff0055' : '#dc2626'),
+      };
+    }
+    if (!chartStats) return null;
+    return {
+      changePct: chartStats.changePct,
+      isUp:      chartStats.isUp,
+      high:      chartStats.high,
+      low:       chartStats.low,
+      sma20:     prediction.modelStats?.sma_20   ?? null,
+      annVol:    prediction.modelStats?.ann_volatility_pct ?? null,
+      color:     chartStats.color,
+    };
+  }, [intervalData, selectedInterval, chartStats, prediction.modelStats, isDark]);
 
   useEffect(() => {
     if (chartMode !== 'candle') return;
@@ -63,7 +138,7 @@ export default function PriceChartCard({
   }, [chartMode, prediction, chartEngine]);
 
   const chartData = useMemo(() => {
-    const hist = prediction.history.map(h => {
+    const hist = activeHistory.map(h => {
       const bbU = h.bb_upper ?? undefined;
       const bbL = h.bb_lower ?? undefined;
       return {
@@ -77,27 +152,32 @@ export default function PriceChartCard({
         sma200:    h.sma200 ?? undefined,
         ema20:     h.ema20  ?? undefined,
         ema50:     h.ema50  ?? undefined,
+        vwap:      (h as any).vwap ?? undefined,
         predicted: undefined as number | undefined,
         foreHigh:  undefined as number | undefined,
         foreLow:   undefined as number | undefined,
         fore_band: undefined as number | undefined,
       };
     });
-    const fore = (prediction.forecastDays || []).map(f => ({
-      date:      f.date,
-      price:     undefined as number | undefined,
-      bb_upper:  undefined, bb_middle: undefined, bb_lower: undefined, bb_band: undefined,
-      sma50:     undefined, sma200:    undefined, ema20: undefined, ema50: undefined,
-      predicted: f.predicted,
-      foreHigh:  f.high,
-      foreLow:   f.low,
-      fore_band: f.high != null && f.low != null ? f.high - f.low : undefined,
-    }));
+    // Forecast days only shown on 2Y (they come from prediction, not interval fetch)
+    const fore = selectedInterval === '2y'
+      ? (prediction.forecastDays || []).map(f => ({
+          date:      f.date,
+          price:     undefined as number | undefined,
+          bb_upper:  undefined, bb_middle: undefined, bb_lower: undefined, bb_band: undefined,
+          sma50:     undefined, sma200:    undefined, ema20: undefined, ema50: undefined,
+          vwap:      undefined,
+          predicted: f.predicted,
+          foreHigh:  f.high,
+          foreLow:   f.low,
+          fore_band: f.high != null && f.low != null ? f.high - f.low : undefined,
+        }))
+      : [];
     return [...hist, ...fore];
-  }, [prediction]);
+  }, [activeHistory, prediction.forecastDays, selectedInterval]);
 
   const candleChartData = useMemo(() => {
-    const hist = prediction.history.map(h => {
+    const hist = activeHistory.map(h => {
       const bbU = h.bb_upper ?? undefined;
       const bbL = h.bb_lower ?? undefined;
       return {
@@ -114,47 +194,57 @@ export default function PriceChartCard({
         sma200:    h.sma200 ?? undefined,
         ema20:     h.ema20  ?? undefined,
         ema50:     h.ema50  ?? undefined,
+        vwap:      (h as any).vwap ?? undefined,
         predicted: undefined as number | undefined,
         foreHigh:  undefined as number | undefined,
         foreLow:   undefined as number | undefined,
         fore_band: undefined as number | undefined,
       };
     });
-    const fore = (prediction.forecastDays || []).map(f => ({
-      date: f.date, open: undefined as number | undefined,
-      high: undefined as number | undefined, low: undefined as number | undefined,
-      close: undefined as number | undefined,
-      bb_upper: undefined, bb_middle: undefined, bb_lower: undefined, bb_band: undefined,
-      sma50: undefined, sma200: undefined, ema20: undefined, ema50: undefined,
-      predicted: f.predicted, foreHigh: f.high, foreLow: f.low,
-      fore_band: f.high != null && f.low != null ? f.high - f.low : undefined,
-    }));
+    const fore = selectedInterval === '2y'
+      ? (prediction.forecastDays || []).map(f => ({
+          date: f.date, open: undefined as number | undefined,
+          high: undefined as number | undefined, low: undefined as number | undefined,
+          close: undefined as number | undefined,
+          bb_upper: undefined, bb_middle: undefined, bb_lower: undefined, bb_band: undefined,
+          sma50: undefined, sma200: undefined, ema20: undefined, ema50: undefined,
+          vwap: undefined,
+          predicted: f.predicted, foreHigh: f.high, foreLow: f.low,
+          fore_band: f.high != null && f.low != null ? f.high - f.low : undefined,
+        }))
+      : [];
     return [...hist, ...fore];
-  }, [prediction]);
+  }, [activeHistory, prediction.forecastDays, selectedInterval]);
 
   const macdData = useMemo(() =>
-    prediction.history.map(h => ({
+    activeHistory.map(h => ({
       date:   h.date,
       macd:   h.macd        ?? null,
       signal: h.macd_signal ?? null,
       hist:   h.macd_hist   ?? null,
     }))
-  , [prediction]);
+  , [activeHistory]);
 
   const rsiData = useMemo(() => {
+    if (intervalData && selectedInterval !== '2y') {
+      return activeHistory.map((h, i) => ({
+        date: h.date,
+        rsi:  intervalData.rsi_series[i] ?? (h as any).rsi ?? null,
+      }));
+    }
     const rsiSeries = prediction.indicators?.rsi_series ?? [];
-    return prediction.history.map((h, i) => ({
+    return activeHistory.map((h, i) => ({
       date: h.date,
       rsi:  rsiSeries[i] ?? null,
     }));
-  }, [prediction]);
+  }, [activeHistory, intervalData, selectedInterval, prediction.indicators]);
 
   const volumeData = useMemo(() =>
-    prediction.history.map(h => ({
+    activeHistory.map(h => ({
       date:   h.date,
       volume: h.volume ?? 0,
     }))
-  , [prediction]);
+  , [activeHistory]);
 
   const chartDomain = useMemo((): [number, number] | ['auto', 'auto'] => {
     const data = chartMode === 'line' ? chartData : candleChartData;
@@ -178,7 +268,7 @@ export default function PriceChartCard({
 
   // Detect notable trading days: large price moves (>1.5σ) or volume spikes (>2× median)
   const eventMarkers = useMemo(() => {
-    const hist = prediction.history;
+    const hist = activeHistory;
     if (hist.length < 10) return [];
 
     const returns = hist.slice(1).map((h, i) => (h.price - hist[i].price) / hist[i].price);
@@ -214,13 +304,14 @@ export default function PriceChartCard({
       if (kept.length >= 5) break;
     }
     return kept;
-  }, [prediction.history]);
+  }, [activeHistory]);
 
   const SERIES_LABEL_MAP: Record<string, string> = {
     price: 'Close', close: 'Close (OHLC)', predicted: 'Forecast',
     foreHigh: 'Fore. High', foreLow: 'Fore. Low',
     bb_upper: 'BB Upper', bb_middle: 'BB Mid', bb_lower: 'BB Lower',
     sma50: 'SMA 50', sma200: 'SMA 200', ema20: 'EMA 20', ema50: 'EMA 50',
+    vwap: 'VWAP',
   };
 
   const toggleSx = {
@@ -262,14 +353,18 @@ export default function PriceChartCard({
         </Box>
 
         {/* Stats bar */}
-        {chartStats && (
+        {activeStats && (
           <Stack direction="row" spacing={3} sx={{ mb: 2, flexWrap: 'wrap', gap: 1 }}>
             {[
-              { label: 'CHANGE',      val: `${chartStats.isUp ? '+' : ''}${chartStats.change.toFixed(2)} (${chartStats.isUp ? '+' : ''}${chartStats.changePct.toFixed(2)}%)`, col: trendColor },
-              { label: 'PERIOD HIGH', val: `$${chartStats.high.toFixed(2)}`, col: isDark ? '#00ffa3' : '#16a34a' },
-              { label: 'PERIOD LOW',  val: `$${chartStats.low.toFixed(2)}`,  col: isDark ? '#ff0055' : '#dc2626' },
-              { label: 'SMA 20',      val: `$${prediction.modelStats?.sma_20 ?? '—'}`, col: '#f59e0b' },
-              { label: 'ANN. VOL',    val: `${prediction.modelStats?.ann_volatility_pct ?? '—'}%`, col: 'text.secondary' },
+              {
+                label: 'CHANGE',
+                val: `${activeStats.isUp ? '+' : ''}${activeStats.changePct.toFixed(2)}%`,
+                col: activeStats.color,
+              },
+              { label: 'PERIOD HIGH', val: `$${activeStats.high.toFixed(2)}`, col: isDark ? '#00ffa3' : '#16a34a' },
+              { label: 'PERIOD LOW',  val: `$${activeStats.low.toFixed(2)}`,  col: isDark ? '#ff0055' : '#dc2626' },
+              { label: 'SMA 20',      val: activeStats.sma20 != null ? `$${Number(activeStats.sma20).toFixed(2)}` : '—', col: '#f59e0b' },
+              { label: 'ANN. VOL',    val: activeStats.annVol != null ? `${Number(activeStats.annVol).toFixed(2)}%` : '—', col: 'text.secondary' },
             ].map(s => (
               <Box key={s.label}>
                 <Typography variant="caption" sx={{ opacity: 0.4, display: 'block', letterSpacing: 1 }}>{s.label}</Typography>
@@ -278,6 +373,21 @@ export default function PriceChartCard({
             ))}
           </Stack>
         )}
+
+        {/* Time interval selector */}
+        <ToggleButtonGroup
+          exclusive
+          value={selectedInterval}
+          onChange={(_e, val) => val && handleIntervalChange(val)}
+          size="small"
+          sx={{ mb: 2, ...toggleSx }}
+        >
+          {(['1d', '5d', '1m', '3m', '6m', '1y', '2y'] as const).map(iv => (
+            <ToggleButton key={iv} value={iv}>
+              {iv.toUpperCase()}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
 
         {/* Indicator toggles */}
         <ToggleButtonGroup
@@ -397,8 +507,8 @@ export default function PriceChartCard({
 
         {chartEngine === 'pro' ? (
           <AdvancedChart
-            history={prediction.history}
-            forecast={prediction.forecastDays}
+            history={activeHistory}
+            forecast={selectedInterval === '2y' ? prediction.forecastDays : []}
             rsiSeries={prediction.indicators?.rsi_series ?? []}
             indicators={indicators}
             mode={chartMode}
@@ -410,7 +520,17 @@ export default function PriceChartCard({
           />
         ) : (<>
           {/* Main price + overlay chart */}
-          <Box sx={{ display: 'flex', gap: 1, minWidth: 0 }}>
+          <Box sx={{ display: 'flex', gap: 1, minWidth: 0, position: 'relative' }}>
+            {historyLoading && (
+              <Box sx={{
+                position: 'absolute', inset: 0, zIndex: 10, borderRadius: 2,
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                background: isDark ? 'rgba(13,21,32,0.75)' : 'rgba(255,255,255,0.75)',
+                backdropFilter: 'blur(4px)',
+              }}>
+                <CircularProgress size={36} sx={{ color: primaryColor }} />
+              </Box>
+            )}
             <Box ref={chartBoxRef} sx={{ height: 380, position: 'relative', flex: 1, minWidth: 0 }}>
               <ResponsiveContainer width="100%" height="100%">
                 <ComposedChart data={(chartMode === 'line' ? chartData : candleChartData) as ChartEntry[]} margin={{ top: 5, right: 10, bottom: 5, left: 10 }}>
@@ -450,9 +570,9 @@ export default function PriceChartCard({
                     formatter={(value) => SERIES_LABEL_MAP[value] ?? value}
                   />
 
-                  {Number.isFinite(prediction.modelStats?.sma_20) && (
-                    <ReferenceLine y={prediction.modelStats.sma_20} stroke="#f59e0b" strokeDasharray="4 4" strokeOpacity={0.5}
-                      label={{ value: `SMA20 $${prediction.modelStats.sma_20}`, fill: '#f59e0b', fontSize: 9, position: 'insideTopRight' }}
+                  {activeStats?.sma20 != null && Number.isFinite(activeStats.sma20) && (
+                    <ReferenceLine y={activeStats.sma20} stroke="#f59e0b" strokeDasharray="4 4" strokeOpacity={0.5}
+                      label={{ value: `SMA20 $${Number(activeStats.sma20).toFixed(2)}`, fill: '#f59e0b', fontSize: 9, position: 'insideTopRight' }}
                     />
                   )}
 
@@ -538,6 +658,11 @@ export default function PriceChartCard({
                     <Line type="monotone" dataKey="ema50" stroke="#f43f5e" strokeWidth={1.5} strokeDasharray="4 2" dot={false} connectNulls isAnimationActive={false} />
                   </>}
 
+                  {/* VWAP — only present for intraday intervals */}
+                  {(selectedInterval === '1d' || selectedInterval === '5d') && intervalData && (
+                    <Line type="monotone" dataKey="vwap" stroke="#facc15" strokeWidth={1.5} strokeDasharray="6 2" dot={false} connectNulls isAnimationActive={false} />
+                  )}
+
                   {chartMode === 'line' && (
                     <Area type="monotone" dataKey="price" stroke={trendColor} strokeWidth={2.5} fill="url(#histGrad)" dot={false} connectNulls={false} activeDot={{ r: 4, strokeWidth: 0 }} isAnimationActive={false} />
                   )}
@@ -584,7 +709,7 @@ export default function PriceChartCard({
                 );
               })()}
             </Box>
-            <VolumeProfile history={prediction.history.map(h => ({ price: h.price, high: h.high, low: h.low, volume: h.volume }))} isDark={isDark} height={380} />
+            <VolumeProfile history={activeHistory.map(h => ({ price: h.price, high: h.high, low: h.low, volume: h.volume }))} isDark={isDark} height={380} />
           </Box>
 
           {/* MACD sub-chart */}

--- a/frontend/components/PriceChartCard.tsx
+++ b/frontend/components/PriceChartCard.tsx
@@ -361,8 +361,8 @@ export default function PriceChartCard({
                 val: `${activeStats.isUp ? '+' : ''}${activeStats.changePct.toFixed(2)}%`,
                 col: activeStats.color,
               },
-              { label: 'PERIOD HIGH', val: `$${activeStats.high.toFixed(2)}`, col: isDark ? '#00ffa3' : '#16a34a' },
-              { label: 'PERIOD LOW',  val: `$${activeStats.low.toFixed(2)}`,  col: isDark ? '#ff0055' : '#dc2626' },
+              { label: 'PERIOD HIGH', val: activeStats.high != null && activeStats.high > 0 ? `$${Number(activeStats.high).toFixed(2)}` : '—', col: isDark ? '#00ffa3' : '#16a34a' },
+              { label: 'PERIOD LOW',  val: activeStats.low  != null && activeStats.low  > 0 ? `$${Number(activeStats.low).toFixed(2)}`  : '—', col: isDark ? '#ff0055' : '#dc2626' },
               { label: 'SMA 20',      val: activeStats.sma20 != null ? `$${Number(activeStats.sma20).toFixed(2)}` : '—', col: '#f59e0b' },
               { label: 'ANN. VOL',    val: activeStats.annVol != null ? `${Number(activeStats.annVol).toFixed(2)}%` : '—', col: 'text.secondary' },
             ].map(s => (
@@ -505,10 +505,12 @@ export default function PriceChartCard({
           </Collapse>
         </Box>
 
-        {chartEngine === 'pro' ? (
+        {/* AdvancedChart (PRO) only works for 2Y — its buildTimestamps parses MM/DD strings
+            which is the format prediction.history uses. Interval bars use different formats. */}
+        {chartEngine === 'pro' && selectedInterval === '2y' ? (
           <AdvancedChart
             history={activeHistory}
-            forecast={selectedInterval === '2y' ? prediction.forecastDays : []}
+            forecast={prediction.forecastDays}
             rsiSeries={prediction.indicators?.rsi_series ?? []}
             indicators={indicators}
             mode={chartMode}

--- a/frontend/components/PriceChartCard.tsx
+++ b/frontend/components/PriceChartCard.tsx
@@ -658,8 +658,8 @@ export default function PriceChartCard({
                     <Line type="monotone" dataKey="ema50" stroke="#f43f5e" strokeWidth={1.5} strokeDasharray="4 2" dot={false} connectNulls isAnimationActive={false} />
                   </>}
 
-                  {/* VWAP — only present for intraday intervals */}
-                  {(selectedInterval === '1d' || selectedInterval === '5d') && intervalData && (
+                  {/* VWAP — present for all intraday intervals (1d/5d/1m) */}
+                  {(selectedInterval === '1d' || selectedInterval === '5d' || selectedInterval === '1m') && intervalData && (
                     <Line type="monotone" dataKey="vwap" stroke="#facc15" strokeWidth={1.5} strokeDasharray="6 2" dot={false} connectNulls isAnimationActive={false} />
                   )}
 

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -189,7 +189,7 @@ export interface IntervalHistoryData {
   period:     string;
   interval:   string;
   history:    HistoryPoint[];
-  rsi_series: number[];
+  rsi_series: Array<number | null>;
   stats:      IntervalStats;
 }
 

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -30,6 +30,8 @@ export interface HistoryPoint {
   macd?:        number | null;
   macd_signal?: number | null;
   macd_hist?:   number | null;
+  rsi?:         number | null;
+  vwap?:        number | null;
 }
 
 export interface AnalystJuror {
@@ -172,6 +174,23 @@ export interface OptionsChainResult {
   current_price: number;
   calls:         OptionContract[];
   puts:          OptionContract[];
+}
+
+export interface IntervalStats {
+  change_pct:  number;
+  period_high: number;
+  period_low:  number;
+  sma20:       number | null;
+  ann_vol:     number;
+}
+
+export interface IntervalHistoryData {
+  symbol:     string;
+  period:     string;
+  interval:   string;
+  history:    HistoryPoint[];
+  rsi_series: number[];
+  stats:      IntervalStats;
 }
 
 export interface DCFScenario {


### PR DESCRIPTION
## Summary
Adds a new `/history` endpoint to the backend that fetches OHLCV data at configurable timeframes (1d/5d/1mo/3mo/6mo/1y/2y with matching intervals), computes technical indicators (BB, MACD, RSI, SMA20, VWAP), and caches results. Frontend now includes an interval selector on the price chart that dynamically fetches and displays historical data for the selected period, with stats and indicators updating accordingly.

## Key Changes

**Backend (`backend/routers/history.py`)**
- New `/history` endpoint with strict period↔interval validation (e.g., `1d` requires `5m`, `1mo` requires `1h`)
- Async yfinance wrapper using `asyncio.to_thread()` with 25s timeout
- Technical indicator computation: Bollinger Bands, MACD, RSI, SMA20
- Per-bar VWAP calculation that resets at calendar-day boundaries (for intraday periods only)
- Annualized volatility from log returns with period-specific scaling factors
- Redis caching: 5min TTL for intraday, 15min for daily
- Comprehensive error handling with specific HTTP status codes (400 for invalid params, 404 for no data, 504 for timeout)

**Frontend (`frontend/components/PriceChartCard.tsx`)**
- New `INTERVAL_MAP` constant mapping UI labels (1d, 5d, 1m, etc.) to backend period/interval pairs
- Interval selector toggle button group (7 options: 1d–2y)
- Dynamic data fetching via `/api/history` proxy with loading state overlay
- `activeHistory` and `activeStats` computed from interval fetch (takes precedence over prediction.history)
- Stats display updates to show period-specific high/low/change/SMA20/annualized volatility
- Forecast bars only shown on 2y interval (hidden for other timeframes)
- VWAP line rendered only for intraday intervals (1d, 5d)
- RSI series sourced from interval fetch when available, falls back to prediction indicators

**Frontend API Proxy (`frontend/app/api/history/route.ts`)**
- New Next.js route handler that proxies requests to backend `/history` endpoint
- 30s fetch timeout with proper error handling

**Type Definitions (`frontend/types/index.ts`)**
- Added `rsi` and `vwap` optional fields to `HistoryPoint`
- New `IntervalStats` interface (change_pct, period_high, period_low, sma20, ann_vol)
- New `IntervalHistoryData` interface for interval fetch responses

**Backend Integration (`backend/main.py`)**
- Imported and registered `history` router

## Notable Implementation Details

- **Validation**: Period/interval combinations are strictly enforced server-side; invalid combos return 400 with helpful message
- **Timezone handling**: All data normalized to UTC; intraday dates formatted in Eastern time for readability
- **Graceful degradation**: Missing OHLC columns fall back to Close price; missing Volume defaults to 0
- **Cache efficiency**: Separate TTLs for intraday (5min, more volatile) vs daily (15min)
- **Chart state management**: Symbol changes reset interval to 2y and clear cached interval data
- **Indicator continuity**: RSI series from interval fetch used when available; prediction indicators used as fallback for 2y view

https://claude.ai/code/session_01CvphbRXnwMveGYm2Wrv3mx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Market history API and client-side proxy for fetching interval history.
  * Interval selector (1d, 5d, 1m, 3m, 6m, 1y, 2y) with interval-driven charting.
  * Price chart accepts symbol prop; shows VWAP (intraday), Bollinger, MACD, RSI, SMA, and volume/profile per interval.
  * Improved stats panel (sma20, change%, period high/low, annualized volatility).

* **Bug Fixes / UX**
  * Loading overlay during interval fetches; clearer proxy error responses.
  * Jury messages may surface cached notes (prefixed) and now indicate rate-limit fallbacks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WeekendDevelopment/FiForesight/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->