### PR TITLE
fix: resolve app-tester QA findings (jury consensus, DCF, SerpAPI, StockTwits, orderbook)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,6 +13,9 @@ INFLUXDB_BUCKET=FiForesightBucket
 # --- News / sentiment (optional) ---
 SERP_API_KEY=
 FINNHUB_API_KEY=
+# StockTwits social sentiment. The public API now returns 403 without auth, so
+# this is OFF by default — leave unset unless you wire up an authenticated source.
+STOCKTWITS_ENABLED=false
 
 # --- Order Book / Market Depth ---
 # Crypto pairs (e.g. BTC-USD) return genuine Level-2 depth from Coinbase's

--- a/backend/config.py
+++ b/backend/config.py
@@ -18,6 +18,9 @@ class Config:
     ALPACA_SECRET_KEY = os.getenv("ALPACA_SECRET_KEY", "")
     PORT = int(os.getenv("PORT", 8000))
     SUPABASE_JWT_SECRET = os.getenv("SUPABASE_JWT_SECRET", "")
+    # StockTwits public API now returns 403 without auth — disabled by default so
+    # we don't fire a guaranteed-failing request on every prediction.
+    STOCKTWITS_ENABLED = os.getenv("STOCKTWITS_ENABLED", "false").lower() in ("1", "true", "yes")
 
 class SanitizeHttpxFilter(logging.Filter):
     SENSITIVE_PARAMS = {"api_key", "token", "secret", "password", "key"}

--- a/backend/jury_graph.py
+++ b/backend/jury_graph.py
@@ -51,7 +51,13 @@ def _make_analyst_node(persona: dict, analyst_jury_svc):
     async def _node(state: JuryState) -> dict:
         logger.info(f"[JURY-GRAPH/{pid}] node entered — model={persona['api_model']}")
         try:
-            verdict = await analyst_jury_svc.get_analyst_verdict(persona, state["ctx"])
+            # Hard 12s ceiling on the external LLM fetch so one hung upstream call
+            # can't stall the whole jury (applies to both the graph and the
+            # direct-fallback execution paths).
+            verdict = await asyncio.wait_for(
+                analyst_jury_svc.get_analyst_verdict(persona, state["ctx"]),
+                timeout=12.0,
+            )
             logger.info(
                 f"[JURY-GRAPH/{pid}] ✓ verdict — "
                 f"rating={verdict['rating']}, confidence={verdict['confidence']}%"
@@ -59,9 +65,11 @@ def _make_analyst_node(persona: dict, analyst_jury_svc):
             return {"verdicts": {pid: verdict}}
         except Exception as exc:
             logger.error(f"[JURY-GRAPH/{pid}] ✗ node failed: {exc}", exc_info=True)
-            # Surface a useful message: 429 = daily quota exhausted, else generic
+            # Surface a useful message: timeout, 429 = quota, else generic
             exc_str = str(exc)
-            if "429" in exc_str or "rate_limit" in exc_str.lower() or "rate limit" in exc_str.lower():
+            if isinstance(exc, (asyncio.TimeoutError, TimeoutError)):
+                fallback_note = "Analysis timed out."
+            elif "429" in exc_str or "rate_limit" in exc_str.lower() or "rate limit" in exc_str.lower():
                 fallback_note = "Rate limit reached — daily Groq quota exhausted."
             else:
                 fallback_note = "Analysis unavailable."

--- a/backend/jury_graph.py
+++ b/backend/jury_graph.py
@@ -13,6 +13,7 @@ Graph shape (parallel fan-out):
 All three analyst nodes fire concurrently via LangGraph's parallel fan-out.
 """
 
+import asyncio
 import logging
 from typing import Annotated, Dict, List, TypedDict
 
@@ -113,6 +114,37 @@ def build_jury_graph(analyst_jury_svc, personas: List[dict]):
 
 
 # ---------------------------------------------------------------------------
+# Fallback executor (no LangGraph)
+# ---------------------------------------------------------------------------
+
+async def _run_nodes_direct(analyst_jury_svc, personas: List[dict], ctx: str) -> dict:
+    """Run each analyst node concurrently WITHOUT LangGraph.
+
+    LangGraph's ``graph.ainvoke`` fails under New Relic's wrapt-based APM
+    instrumentation in the deployed image ("FunctionWrapperBase() missing
+    required argument 'wrapper'"), which would otherwise degrade the entire
+    jury to Hold/25. This path reuses the exact same per-analyst node logic
+    (including its per-node error isolation) via ``asyncio.gather`` so the jury
+    keeps working under APM. Returns the same ``{"verdicts", "errors"}`` shape
+    as the graph's final state.
+    """
+    nodes = [_make_analyst_node(p, analyst_jury_svc) for p in personas]
+    base_state: JuryState = {"ctx": ctx, "verdicts": {}, "errors": {}}
+    results = await asyncio.gather(
+        *(node(base_state) for node in nodes), return_exceptions=True
+    )
+    verdicts: Dict[str, dict] = {}
+    errors: Dict[str, str] = {}
+    for persona, res in zip(personas, results):
+        if isinstance(res, BaseException):
+            errors[persona["id"]] = str(res)
+            continue
+        verdicts.update(res.get("verdicts", {}))
+        errors.update(res.get("errors", {}))
+    return {"ctx": ctx, "verdicts": verdicts, "errors": errors}
+
+
+# ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
 
@@ -141,7 +173,19 @@ async def run_jury_graph(
         f"[JURY-GRAPH] Invoking — {len(personas)} analysts, "
         f"ctx_chars={len(ctx)}"
     )
-    final_state = await graph.ainvoke(initial_state)
+    try:
+        final_state = await graph.ainvoke(initial_state)
+    except Exception as exc:
+        # LangGraph's Pregel runner is wrapped by New Relic's APM in the deployed
+        # image and raises "FunctionWrapperBase() missing required argument
+        # 'wrapper'", which would degrade the whole jury to Hold/25. Fall back to
+        # running the same nodes directly so the jury still produces real verdicts.
+        logger.error(
+            f"[JURY-GRAPH] graph.ainvoke failed ({exc}) — "
+            f"falling back to direct concurrent execution",
+            exc_info=True,
+        )
+        final_state = await _run_nodes_direct(analyst_jury_svc, personas, ctx)
 
     if final_state.get("errors"):
         for pid, err in final_state["errors"].items():

--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -52,8 +52,33 @@ def _run_dcf(
 @router.get("/dcf/{symbol}")
 async def dcf_valuation(symbol: str):
     import yfinance as yf
+    from redis_cache import cache_get, cache_set
 
-    info = await asyncio.to_thread(yf_svc.fetch_info, symbol)
+    def _missing(v) -> bool:
+        return v in (None, "N/A", "")
+
+    # Reuse the shared fundamentals cache (populated by /predict, 1h TTL) so the
+    # DCF reads the SAME beta/revenue_growth as the rest of the dashboard. Under
+    # the dashboard's concurrent request burst yfinance sometimes returns partial
+    # `info`; caching plus a single retry when the key growth/risk inputs are
+    # missing stops the intrinsic value from silently flipping to the default
+    # beta=1.0 / growth=5% (which produced wildly different valuations per load).
+    info_cache_key = f"info:{symbol.upper()}"
+    info = await cache_get(info_cache_key)
+    if not info:
+        info = await asyncio.to_thread(yf_svc.fetch_info, symbol)
+        if info:
+            await cache_set(info_cache_key, info, ttl_seconds=3600)
+
+    if _missing(info.get("beta")) or _missing(info.get("revenue_growth")):
+        retry = await asyncio.to_thread(yf_svc.fetch_info, symbol)
+        if retry and not (_missing(retry.get("beta")) and _missing(retry.get("revenue_growth"))):
+            info = retry
+            await cache_set(info_cache_key, info, ttl_seconds=3600)
+
+    fundamentals_complete = not (
+        _missing(info.get("beta")) or _missing(info.get("revenue_growth"))
+    )
 
     # Raw data
     fcf           = info.get("free_cash_flow")
@@ -148,6 +173,9 @@ async def dcf_valuation(symbol: str):
         "wacc_base":          round(wacc_base * 100, 2),
         "growth_rate_base":   round(g * 100, 2),
         "method":             "FCF",
+        # False when yfinance returned partial fundamentals and beta/growth fell
+        # back to defaults — lets the frontend flag a lower-confidence valuation.
+        "fundamentals_complete": fundamentals_complete,
     }
 
 

--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -54,8 +54,20 @@ async def dcf_valuation(symbol: str):
     import yfinance as yf
     from redis_cache import cache_get, cache_set
 
-    def _missing(v) -> bool:
+    def _missing(v: Any) -> bool:
         return v in (None, "N/A", "")
+
+    async def _fetch_info_bounded() -> dict:
+        """fetch_info wrapped in a 12s timeout (matches sibling endpoints) so a
+        hung yfinance call can't stall the /dcf response. Always returns a dict."""
+        try:
+            result = await asyncio.wait_for(
+                asyncio.to_thread(yf_svc.fetch_info, symbol), timeout=12.0
+            )
+            return result or {}
+        except asyncio.TimeoutError:
+            logger.warning("[DCF] fetch_info timed out for %s", symbol)
+            return {}
 
     # Reuse the shared fundamentals cache (populated by /predict, 1h TTL) so the
     # DCF reads the SAME beta/revenue_growth as the rest of the dashboard. Under
@@ -66,13 +78,16 @@ async def dcf_valuation(symbol: str):
     info_cache_key = f"info:{symbol.upper()}"
     info = await cache_get(info_cache_key)
     if not info:
-        info = await asyncio.to_thread(yf_svc.fetch_info, symbol)
+        info = await _fetch_info_bounded()
         if info:
             await cache_set(info_cache_key, info, ttl_seconds=3600)
+    info = info or {}
 
     if _missing(info.get("beta")) or _missing(info.get("revenue_growth")):
-        retry = await asyncio.to_thread(yf_svc.fetch_info, symbol)
-        if retry and not (_missing(retry.get("beta")) and _missing(retry.get("revenue_growth"))):
+        retry = await _fetch_info_bounded()
+        # Accept the retry only when it makes BOTH inputs present (symmetric with
+        # the trigger above) so we never overwrite the cache with still-partial data.
+        if retry and not (_missing(retry.get("beta")) or _missing(retry.get("revenue_growth"))):
             info = retry
             await cache_set(info_cache_key, info, ttl_seconds=3600)
 

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -997,9 +997,11 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
     else:
         logger.info(
             "[STEP-4c] News cache MISS — launching SerpAPI, yfinance news, "
-            "Finnhub, and StockTwits tasks"
+            "Finnhub%s tasks" % (", and StockTwits" if Config.STOCKTWITS_ENABLED else "")
         )
-        serp_task = asyncio.create_task(serp_svc.fetch_data(symbol))
+        serp_task = asyncio.create_task(
+            serp_svc.fetch_data(symbol, exchange=(info.get("exchange") or "NASDAQ"))
+        )
         yf_news_task = asyncio.create_task(
             _safe_fetch(
                 asyncio.to_thread(yf_svc.fetch_news, symbol),
@@ -1012,12 +1014,19 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
         yahoo_rss_task = asyncio.create_task(
             _safe_fetch(yahoo_rss_svc.fetch_news(symbol), empty=[], name="YAHOORSE")
         )
-        stocktwits_task = asyncio.create_task(
-            _safe_fetch(
-                stocktwits_svc.fetch_sentiment(symbol),
-                empty={"bullish": 0, "bearish": 0, "sentiment": 0.0},
-                name="STOCKTWITS",
+        # StockTwits' public stream now returns 403 without auth, so the call is
+        # gated behind STOCKTWITS_ENABLED to avoid a guaranteed-failing request
+        # on every prediction. Enable it only once a working/authed source exists.
+        stocktwits_task = (
+            asyncio.create_task(
+                _safe_fetch(
+                    stocktwits_svc.fetch_sentiment(symbol),
+                    empty={"bullish": 0, "bearish": 0, "sentiment": 0.0},
+                    name="STOCKTWITS",
+                )
             )
+            if Config.STOCKTWITS_ENABLED
+            else None
         )
 
     earnings_task = asyncio.create_task(
@@ -1044,7 +1053,7 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
         stocktwits_data = cached_news_payload.get("stocktwits", {"bullish": 0, "bearish": 0, "sentiment": 0.0})
         logger.info(f"[STEP-4e] Using cached news/sentiment/stocktwits for {symbol}")
     else:
-        logger.info("[STEP-4e] Awaiting SerpAPI, yfinance news, Finnhub, StockTwits ...")
+        logger.info("[STEP-4e] Awaiting news sources (SerpAPI, yfinance, Finnhub, Yahoo RSS) ...")
         serp_data: dict = {"news_results": [], "markets": {}}
         try:
             serp_data = await serp_task
@@ -1073,6 +1082,9 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
                             "change":   str(t.get("price_change_percentage", "0%")),
                             "category": category,
                         })
+            # Primary trending source: google_finance `discover_more` (related/
+            # most-active tickers), parsed in SerpService into a ready list.
+            trending.extend(serp_data.get("trending", [])[:12])
             logger.info(
                 f"[STEP-4e] ✓ SerpAPI — news={len(serp_news)} articles, "
                 f"trending={len(trending)} tickers"
@@ -1085,7 +1097,8 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
         yf_news: List[dict]      = await yf_news_task
         finnhub_news: List[dict] = await finnhub_task
         yahoo_rss: List[dict]    = await yahoo_rss_task
-        stocktwits_data          = await stocktwits_task
+        if stocktwits_task is not None:
+            stocktwits_data = await stocktwits_task
 
         logger.info(
             f"[STEP-4e] Sources — serp={len(serp_news)}, "

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -1083,8 +1083,16 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
                             "category": category,
                         })
             # Primary trending source: google_finance `discover_more` (related/
-            # most-active tickers), parsed in SerpService into a ready list.
-            trending.extend(serp_data.get("trending", [])[:12])
+            # most-active tickers), parsed in SerpService. Dedupe by symbol against
+            # anything already added from the legacy markets block.
+            _seen_syms = {t.get("symbol") for t in trending}
+            for t in serp_data.get("trending", []):
+                sym = t.get("symbol")
+                if sym and sym not in _seen_syms:
+                    trending.append(t)
+                    _seen_syms.add(sym)
+                if len(trending) >= 12:
+                    break
             logger.info(
                 f"[STEP-4e] ✓ SerpAPI — news={len(serp_news)} articles, "
                 f"trending={len(trending)} tickers"

--- a/backend/services.py
+++ b/backend/services.py
@@ -740,6 +740,18 @@ class ForecastStore:
 # YFinance Service  —  free historical OHLCV + fundamentals
 # ---------------------------------------------------------------------------
 
+# Maps yfinance exchange codes → Google-Finance exchange suffixes. SerpAPI's
+# google_finance engine only returns results for the "TICKER:EXCHANGE" format;
+# a bare ticker errors with "hasn't returned any results".
+_GOOGLE_EXCHANGE = {
+    "NMS": "NASDAQ", "NGM": "NASDAQ", "NCM": "NASDAQ", "NAS": "NASDAQ",
+    "NYQ": "NYSE",   "NYS": "NYSE",
+    "PCX": "NYSEARCA",
+    "ASE": "NYSEAMERICAN",
+    "BTS": "BATS",
+}
+
+
 class YFinanceService:
     """
     Wraps yfinance for:
@@ -872,6 +884,10 @@ class YFinanceService:
                 "sector":          info.get("sector",          "N/A"),
                 "industry":        info.get("industry",        "N/A"),
                 "currency":        info.get("currency",        "USD"),
+                # Google-Finance exchange suffix (e.g. NASDAQ/NYSE) derived from
+                # yfinance's exchange code — needed for the SerpAPI google_finance
+                # query, which requires the TICKER:EXCHANGE format. "" when unknown.
+                "exchange":        _GOOGLE_EXCHANGE.get(info.get("exchange") or "", ""),
                 # Extended quant fundamentals
                 "beta":            info.get("beta",                 "N/A"),
                 "forward_pe":      info.get("forwardPE",            "N/A"),
@@ -1170,27 +1186,60 @@ class SerpService:
         except ValueError:
             return 0.0
 
-    async def fetch_data(self, query: str) -> dict:
+    @staticmethod
+    def _parse_trending(data: dict) -> List[dict]:
+        """Build a trending-ticker list from the google_finance `discover_more`
+        block (related/most-active tickers). Each item carries symbol, price and
+        a signed change string the frontend sparklines understand."""
+        trending: List[dict] = []
+        seen: set = set()
+        for block in data.get("discover_more", []) or []:
+            for it in (block.get("items", []) if isinstance(block, dict) else []):
+                stock = str(it.get("stock", ""))          # e.g. "TSLA:NASDAQ"
+                sym = stock.split(":")[0].strip().upper()
+                if not sym or sym in seen:
+                    continue
+                mv = it.get("price_movement", {}) or {}
+                pct = mv.get("percentage")
+                up = str(mv.get("movement", "")).lower() == "up"
+                change = (f"{'+' if up else '-'}{pct}%") if pct is not None else ""
+                trending.append({
+                    "symbol": sym,
+                    "price":  it.get("price", ""),
+                    "change": change,
+                })
+                seen.add(sym)
+        return trending
+
+    async def fetch_data(self, query: str, exchange: str = "NASDAQ") -> dict:
         """
         Query SerpAPI Google Finance for news and trending market data.
         Returns a dict with keys:
           - news_results : list of news articles
-          - markets      : dict of category → list of tickers
+          - markets      : dict of category → list of tickers (legacy)
+          - trending     : list of trending tickers (from `discover_more`)
         Falls back to empty structure if the API key is missing or the call fails.
+
+        The google_finance engine requires a "TICKER:EXCHANGE" query — a bare
+        ticker returns an error — so the exchange suffix is appended when absent.
         """
         if not Config.SERP_API_KEY:
             logger.info(
                 "[SERP] API key not set — news/trending fetch SKIPPED "
                 "(returning empty news_results and markets)"
             )
-            return {"news_results": [], "markets": {}}
+            return {"news_results": [], "markets": {}, "trending": []}
+
+        # google_finance needs TICKER:EXCHANGE. Honor an already-qualified query;
+        # otherwise append the resolved exchange (default NASDAQ).
+        gq = query if ":" in query else f"{query.upper()}:{(exchange or 'NASDAQ').upper()}"
 
         logger.debug(
-            f"[SERP] fetch_data — query='{query}', engine=google_finance, timeout=25s"
+            f"[SERP] fetch_data — query='{gq}', engine=google_finance, timeout=25s"
         )
         params = {
             "engine":  "google_finance",
-            "q":       query,
+            "q":       gq,
             "api_key": Config.SERP_API_KEY,
         }
         try:
@@ -1199,25 +1248,26 @@ class SerpService:
                 resp.raise_for_status()
                 data = resp.json()
 
+            if data.get("error"):
+                logger.warning(f"[SERP] google_finance returned no results for '{gq}': {data['error']}")
+                return {"news_results": [], "markets": {}, "trending": []}
+
+            trending      = self._parse_trending(data)
             news_count    = len(data.get("news_results", []))
-            market_cats   = list(data.get("markets", {}).keys())
-            market_total  = sum(
-                len(v) for v in data.get("markets", {}).values() if isinstance(v, list)
-            )
             logger.info(
-                f"[SERP] ✓ fetch_data — query='{query}' | "
+                f"[SERP] ✓ fetch_data — query='{gq}' | "
                 f"news_articles={news_count} | "
-                f"market_categories={market_cats} | "
-                f"trending_tickers={market_total}"
+                f"trending_tickers={len(trending)}"
             )
             return {
                 "news_results": data.get("news_results", []),
                 "markets":      data.get("markets",      {}),
+                "trending":     trending,
             }
 
         except Exception as e:
-            logger.warning(f"[SERP] fetch_data failed ('{query}'): {e} → fallback: 0 articles, empty markets")
-            return {"news_results": [], "markets": {}}
+            logger.warning(f"[SERP] fetch_data failed ('{gq}'): {e} → fallback: 0 articles, empty trending")
+            return {"news_results": [], "markets": {}, "trending": []}
 
 
 # ---------------------------------------------------------------------------
@@ -1276,9 +1326,14 @@ class FinnhubService:
 
 class StockTwitsService:
     """
-    Fetches the public StockTwits symbol stream (no auth required).
-    Counts Bullish/Bearish tags on the last N messages and returns a
-    ratio in [-1, 1]: +1 = all bullish, -1 = all bearish.
+    Fetches the StockTwits symbol stream, counts Bullish/Bearish tags on the
+    last N messages and returns a ratio in [-1, 1]: +1 = all bullish,
+    -1 = all bearish.
+
+    NOTE: the public `api.stocktwits.com` endpoint now returns 403 Forbidden
+    without authentication, so the caller gates this behind
+    `Config.STOCKTWITS_ENABLED` (off by default). The parsing logic below is
+    kept intact for when an authed/working source is wired up.
     """
     _BASE_URL = "https://api.stocktwits.com/api/2/streams/symbol/{symbol}.json"
 

--- a/backend/tests/test_new_services.py
+++ b/backend/tests/test_new_services.py
@@ -15,7 +15,10 @@ from backend.routers.predict import _dedup_news
 # ---------------------------------------------------------------------------
 
 def run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    # asyncio.run creates and manages a fresh loop per call. The old
+    # get_event_loop().run_until_complete pattern raises "no current event loop"
+    # on Python 3.12+/3.14 when no loop is set on the main thread.
+    return asyncio.run(coro)
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/components/AnalystJuryPanel.tsx
+++ b/frontend/components/AnalystJuryPanel.tsx
@@ -17,22 +17,47 @@ const RATING_COLORS: Record<string, { bg: string; text: string }> = {
   'High Risk':   { bg: '#ff005522', text: '#ff0055' },
 };
 
-// Ordered most-bullish → most-bearish across all 3 persona rating vocabularies
-const RATING_ORDER = [
-  'Strong Buy', 'Buy', 'Accumulate', 'Low Risk',
-  'Hold', 'Medium Risk',
-  'Distribute', 'Sell', 'High Risk', 'Strong Sell',
-];
-
 export default function AnalystJuryPanel({ analysts }: { analysts: AnalystJuror[] }) {
   const ratingColor = (r: string) => RATING_COLORS[r] ?? { bg: '#64748b22', text: '#94a3b8' };
 
-  const ratingCounts = analysts.reduce((acc, a) => {
-    acc[a.rating] = (acc[a.rating] || 0) + 1;
+  // Consensus must reflect what the panel actually said — NOT just the single
+  // most-bullish verdict (the old `RATING_ORDER.find` headlined "Strong Buy"
+  // even when 2/3 said Hold). Normalize every persona vocabulary onto one
+  // bullish(+)→bearish(−) score, take the plurality bucket, break ties by
+  // summed confidence, and fall back to the confidence-weighted average.
+  const RATING_SCORE: Record<string, number> = {
+    'Strong Buy': 2, 'Low Risk': 2,
+    'Buy': 1, 'Accumulate': 1,
+    'Hold': 0, 'Medium Risk': 0,
+    'Distribute': -1, 'Sell': -1, 'High Risk': -1,
+    'Strong Sell': -2,
+  };
+  const scoreToRating = (s: number): string =>
+    s >= 1.5 ? 'Strong Buy' : s >= 0.5 ? 'Buy' : s > -0.5 ? 'Hold' : s > -1.5 ? 'Sell' : 'Strong Sell';
+  const toBucket = (r: string): string => scoreToRating(RATING_SCORE[r] ?? 0);
+
+  const bucketStats = analysts.reduce((acc, a) => {
+    const b = toBucket(a.rating);
+    const s = acc[b] ?? { count: 0, conf: 0 };
+    s.count += 1; s.conf += a.confidence;
+    acc[b] = s;
     return acc;
-  }, {} as Record<string, number>);
-  const consensus = RATING_ORDER.find(r => ratingCounts[r]) ?? analysts[0]?.rating ?? 'Hold';
-  const avgConf   = Math.round(analysts.reduce((s, a) => s + a.confidence, 0) / Math.max(analysts.length, 1));
+  }, {} as Record<string, { count: number; conf: number }>);
+
+  const totalConf = analysts.reduce((s, a) => s + a.confidence, 0);
+  const weightedScore = totalConf
+    ? analysts.reduce((s, a) => s + (RATING_SCORE[a.rating] ?? 0) * a.confidence, 0) / totalConf
+    : 0;
+  const fallbackBucket = scoreToRating(weightedScore);
+
+  const consensus = Object.entries(bucketStats).sort((a, b) =>
+    b[1].count - a[1].count ||                                   // most votes
+    b[1].conf  - a[1].conf  ||                                   // then summed confidence
+    (a[0] === fallbackBucket ? -1 : b[0] === fallbackBucket ? 1 : 0), // then weighted avg
+  )[0]?.[0] ?? fallbackBucket;
+
+  const ratingCounts: Record<string, number> = { [consensus]: bucketStats[consensus]?.count ?? analysts.length };
+  const avgConf = Math.round(totalConf / Math.max(analysts.length, 1));
   return (
     <Stack spacing={1.5}>
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: 0.5 }}>

--- a/frontend/components/DCFCard.tsx
+++ b/frontend/components/DCFCard.tsx
@@ -79,6 +79,11 @@ export default function DCFCard({ dcf, isDark, primaryColor }: Props) {
         <Typography sx={{ fontSize: '0.65rem', opacity: 0.4, lineHeight: 1.5 }}>
           FCF ${dcf.fcf_billions.toFixed(1)}B · Base WACC {dcf.wacc_base.toFixed(1)}% · Growth {dcf.growth_rate_base.toFixed(1)}% · 5yr DCF + Gordon terminal
         </Typography>
+        {dcf.fundamentals_complete === false && (
+          <Typography sx={{ fontSize: '0.6rem', color: '#f59e0b', opacity: 0.8, mt: 0.5 }}>
+            ⚠ Partial fundamentals — beta/growth defaulted; valuation is lower-confidence.
+          </Typography>
+        )}
       </CardContent>
     </Card>
   );

--- a/frontend/components/OrderBookPanel.tsx
+++ b/frontend/components/OrderBookPanel.tsx
@@ -46,11 +46,16 @@ export default function OrderBookPanel({ symbol }: { symbol: string }) {
       setBook(data);
       setError(null);
     } catch (err: unknown) {
-      const msg =
-        (err as { response?: { data?: { error?: string } } })?.response?.data?.error ??
-        'Order book unavailable';
+      const resp = (err as { response?: { status?: number; data?: { error?: string; detail?: string } } })?.response;
+      const msg = resp?.data?.error ?? resp?.data?.detail ?? 'Order book unavailable';
       setError(msg);
       setBook(null);
+      // 503 (no Alpaca key) / 404 / auth errors are permanent for this symbol —
+      // stop polling so we don't hammer a request that will never succeed.
+      if (resp?.status && [400, 401, 403, 404, 503].includes(resp.status) && timer.current) {
+        clearInterval(timer.current);
+        timer.current = null;
+      }
     } finally {
       setLoading(false);
     }

--- a/frontend/lib/supabase.ts
+++ b/frontend/lib/supabase.ts
@@ -1,6 +1,9 @@
 import { createClient } from '@supabase/supabase-js';
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL  ?? 'https://placeholder.supabase.co';
-const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? 'placeholder-anon-key';
+// Use `||` (not `??`) so an empty-string env var also falls back to the
+// placeholder. In CI / fork PRs these vars are set-but-empty, and `createClient('')`
+// throws "supabaseUrl is required" during static prerender of /_not-found.
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co';
+const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder-anon-key';
 
 export const supabase = createClient(url, key);

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -211,4 +211,5 @@ export interface DCFResult {
   wacc_base:          number;
   growth_rate_base:   number;
   method:             string;
+  fundamentals_complete?: boolean;
 }


### PR DESCRIPTION
Resolves the issues found in the local feature-QA sweep. Non-fork replacement for #210 (so CI runs with repo secrets).

## Fixes
- **Jury consensus** (`AnalystJuryPanel`): was headlining the single most-bullish verdict (e.g. "Strong Buy" with 2/3 Hold). Now normalizes all persona vocabularies to one bullish→bearish score and takes the **plurality** bucket (tie-break: summed confidence → confidence-weighted average).
- **DCF non-determinism** (`routers/market.py`): `/dcf` reuses the shared `info:` fundamentals cache (populated by `/predict`) and retries once when beta/revenue_growth come back empty, so intrinsic value no longer flips to default beta=1.0/growth=5% under the dashboard's concurrent yfinance burst. Adds `fundamentals_complete` flag, surfaced in `DCFCard`.
- **SerpAPI 0 news/trending**: `google_finance` requires `TICKER:EXCHANGE` — it was queried with a bare ticker (errored). `fetch_info` maps the yfinance exchange code to a Google suffix; `SerpService` appends it and parses trending from the `discover_more` block. Verified: AMD `0 → 12` news, trending `0 → 4`.
- **StockTwits 403**: public API now blocks unauthenticated access. Gated behind `STOCKTWITS_ENABLED` (off by default) so we no longer fire a guaranteed-failing request on every prediction. Parser + tests kept intact.
- **OrderBookPanel**: stops the 3s poll loop on permanent errors (503 no-key / 404 / auth) instead of hammering a request that can never succeed.
- **test_new_services.py**: helper used `asyncio.get_event_loop()` which raises on Python 3.12+/3.14; switched to `asyncio.run`. Backend tests: **69 passed**.
- **CI hardening** (`lib/supabase.ts`): use `||` not `??` so empty-string Supabase env vars fall back to the placeholder (fixed the `/_not-found` prerender crash on builds without secrets).

## Verification
Local: `ruff` ✓, `pnpm lint` ✓, `pnpm build` ✓ (incl. with empty Supabase env), `pytest` 69/69 ✓. All fixes also confirmed live in the running app (jury badge, trending sparklines, DCF, order-book polling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * StockTwits integration can be toggled via configuration (off by default).
  * DCF valuations now show a confidence flag when key fundamentals are incomplete.
  * Trending tickers extraction expanded for richer results.

* **Bug Fixes**
  * Supabase config fallback fixed to avoid prerender errors.
  * Order book stops polling on permanent fetch errors (400/401/403/404/503).

* **Improvements**
  * Added a reliable fallback execution path for jury analysis.
  * Jury consensus uses normalized scoring across analyst ratings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->