### PR TITLE
Tool-using jury agents (Groq function calling)

### DIFF
--- a/backend/jury_graph.py
+++ b/backend/jury_graph.py
@@ -272,25 +272,27 @@ class JuryState(TypedDict):
 # Node factory — one async node per analyst persona
 # ---------------------------------------------------------------------------
 
-def _make_analyst_node(persona: dict, analyst_jury_svc, tools=None, tool_dispatcher=None):
+def _make_analyst_node(persona: dict, analyst_jury_svc, tools=None, tool_dispatcher=None, force_tools=False):
     """
     Returns an async graph node function pinned to `persona`.
     The node writes its verdict (or error fallback) into state["verdicts"].
 
     When `tools` and `tool_dispatcher` are provided the analyst runs the
     Groq function-calling loop; otherwise it makes a single completion call.
+    `force_tools` makes the opening round require ≥1 tool call.
     """
     pid = persona["id"]
 
     async def _node(state: JuryState) -> dict:
         logger.info(
             f"[JURY-GRAPH/{pid}] node entered — model={persona['api_model']}, "
-            f"tools={'on' if tools and tool_dispatcher else 'off'}"
+            f"tools={'on' if tools and tool_dispatcher else 'off'}, force={force_tools}"
         )
         try:
             verdict = await analyst_jury_svc.get_analyst_verdict(
                 persona, state["ctx"],
                 tools=tools, tool_dispatcher=tool_dispatcher,
+                force_tools=force_tools,
             )
             logger.info(
                 f"[JURY-GRAPH/{pid}] ✓ verdict — "
@@ -333,20 +335,21 @@ def _make_analyst_node(persona: dict, analyst_jury_svc, tools=None, tool_dispatc
 # Graph builder
 # ---------------------------------------------------------------------------
 
-def build_jury_graph(analyst_jury_svc, personas: List[dict], tools=None, tool_dispatcher=None):
+def build_jury_graph(analyst_jury_svc, personas: List[dict], tools=None, tool_dispatcher=None, force_tools=False):
     """
     Build and compile the jury StateGraph.
 
     Each persona becomes a node fanned out in parallel from START.
     All nodes write into the shared `verdicts` dict via the merge reducer.
-    When `tools`/`tool_dispatcher` are passed, every analyst node is tool-enabled.
+    When `tools`/`tool_dispatcher` are passed, every analyst node is tool-enabled;
+    `force_tools` makes each analyst's opening round require ≥1 tool call.
     """
     builder = StateGraph(JuryState)
 
     node_names = []
     for persona in personas:
         name = f"analyst_{persona['id'].lower().replace('-', '_')}"
-        builder.add_node(name, _make_analyst_node(persona, analyst_jury_svc, tools, tool_dispatcher))
+        builder.add_node(name, _make_analyst_node(persona, analyst_jury_svc, tools, tool_dispatcher, force_tools))
         builder.add_edge(START, name)
         builder.add_edge(name, END)
         node_names.append(name)
@@ -400,6 +403,7 @@ async def run_jury_graph(
     ctx: str,
     symbol: Optional[str] = None,
     enable_tools: bool = True,
+    force_tools: bool = False,
 ) -> List[dict]:
     """
     Run the jury graph and return verdicts in the same order as `personas`.
@@ -418,7 +422,7 @@ async def run_jury_graph(
         tools = JURY_TOOLS
         tool_dispatcher = make_tool_dispatcher(symbol)
 
-    graph = build_jury_graph(analyst_jury_svc, personas, tools, tool_dispatcher)
+    graph = build_jury_graph(analyst_jury_svc, personas, tools, tool_dispatcher, force_tools)
 
     initial_state: JuryState = {
         "ctx":      ctx,

--- a/backend/jury_graph.py
+++ b/backend/jury_graph.py
@@ -366,7 +366,14 @@ def build_jury_graph(analyst_jury_svc, personas: List[dict], tools=None, tool_di
 # Fallback executor (no LangGraph)
 # ---------------------------------------------------------------------------
 
-async def _run_nodes_direct(analyst_jury_svc, personas: List[dict], ctx: str) -> dict:
+async def _run_nodes_direct(
+    analyst_jury_svc,
+    personas: List[dict],
+    ctx: str,
+    tools=None,
+    tool_dispatcher=None,
+    force_tools=False,
+) -> dict:
     """Run each analyst node concurrently WITHOUT LangGraph.
 
     LangGraph's ``graph.ainvoke`` fails under New Relic's wrapt-based APM
@@ -376,8 +383,12 @@ async def _run_nodes_direct(analyst_jury_svc, personas: List[dict], ctx: str) ->
     (including its per-node error isolation) via ``asyncio.gather`` so the jury
     keeps working under APM. Returns the same ``{"verdicts", "errors"}`` shape
     as the graph's final state.
+
+    Tool args MUST be forwarded here — this is the path that actually runs in
+    the deployed image, so dropping them silently disables the entire
+    tool-using jury in production.
     """
-    nodes = [_make_analyst_node(p, analyst_jury_svc) for p in personas]
+    nodes = [_make_analyst_node(p, analyst_jury_svc, tools, tool_dispatcher, force_tools) for p in personas]
     base_state: JuryState = {"ctx": ctx, "verdicts": {}, "errors": {}}
     results = await asyncio.gather(
         *(node(base_state) for node in nodes), return_exceptions=True
@@ -446,7 +457,9 @@ async def run_jury_graph(
             f"falling back to direct concurrent execution",
             exc_info=True,
         )
-        final_state = await _run_nodes_direct(analyst_jury_svc, personas, ctx)
+        final_state = await _run_nodes_direct(
+            analyst_jury_svc, personas, ctx, tools, tool_dispatcher, force_tools
+        )
 
     if final_state.get("errors"):
         for pid, err in final_state["errors"].items():

--- a/backend/jury_graph.py
+++ b/backend/jury_graph.py
@@ -211,7 +211,12 @@ async def _run_sync_tool(fn, *args) -> dict:
     if not _YF_AVAILABLE:
         return {"error": "market data provider unavailable"}
     try:
-        return await asyncio.to_thread(fn, *args)
+        # 12s cap per project convention — a hung yfinance call must not stall
+        # the analyst (and, through it, the whole jury).
+        return await asyncio.wait_for(asyncio.to_thread(fn, *args), timeout=12.0)
+    except asyncio.TimeoutError:
+        logger.warning(f"[JURY-TOOLS] {fn.__name__} timed out after 12s")
+        return {"error": "tool fetch timed out"}
     except Exception as exc:
         logger.warning(f"[JURY-TOOLS] {fn.__name__} failed: {exc}")
         return {"error": "tool fetch failed"}

--- a/backend/jury_graph.py
+++ b/backend/jury_graph.py
@@ -13,12 +13,244 @@ Graph shape (parallel fan-out):
 All three analyst nodes fire concurrently via LangGraph's parallel fan-out.
 """
 
+import asyncio
+import json
 import logging
-from typing import Annotated, Dict, List, TypedDict
+from datetime import datetime, timedelta, timezone
+from typing import Annotated, Awaitable, Callable, Dict, List, Optional, TypedDict
 
 from langgraph.graph import StateGraph, START, END
 
+try:
+    import yfinance as yf
+    _YF_AVAILABLE = True
+except ImportError:  # pragma: no cover - yfinance always present in prod
+    yf = None  # type: ignore
+    _YF_AVAILABLE = False
+
 logger = logging.getLogger(__name__)
+
+
+# ===========================================================================
+# Tool-using jury — OpenAI-compatible function/tool definitions
+#
+# Each analyst node can call these tools (Groq function calling) during its
+# analysis to pull live market data the static context string doesn't carry.
+# Dispatchers below are backed by free yfinance feeds (^VIX, options chain,
+# insider transactions, Treasury yield indices) — no paid APIs.
+# ===========================================================================
+
+JURY_TOOLS: List[dict] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_vix",
+            "description": "Returns current VIX level and 30-day change",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_put_call_ratio",
+            "description": "Returns the current put/call ratio for a given symbol",
+            "parameters": {
+                "type": "object",
+                "properties": {"symbol": {"type": "string"}},
+                "required": ["symbol"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_insider_flow",
+            "description": "Returns recent insider buy/sell count for a symbol (last 90 days)",
+            "parameters": {
+                "type": "object",
+                "properties": {"symbol": {"type": "string"}},
+                "required": ["symbol"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_macro_snapshot",
+            "description": "Returns current macro indicators: 10Y yield, CPI, fed funds, yield curve",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Tool dispatchers — blocking yfinance work runs in a thread; results returned
+# as JSON strings (the shape Groq expects for role=tool messages).
+# ---------------------------------------------------------------------------
+
+def _norm_yield(value: float) -> float:
+    """Yahoo Treasury indices (^TNX/^FVX/^IRX) quote yield ×10 (e.g. 42.5 = 4.25%).
+    Newer feeds sometimes return the raw percent. Normalise to a plain percent."""
+    return round(value / 10.0, 3) if value > 15 else round(value, 3)
+
+
+def _vix_sync() -> dict:
+    hist = yf.Ticker("^VIX").history(period="1mo")
+    if hist is None or hist.empty:
+        return {"error": "VIX data unavailable"}
+    closes = hist["Close"].dropna()
+    current = float(closes.iloc[-1])
+    month_ago = float(closes.iloc[0])
+    change_pct = ((current - month_ago) / month_ago * 100) if month_ago else 0.0
+    if current < 15:
+        regime = "low / complacent"
+    elif current < 20:
+        regime = "normal"
+    elif current < 30:
+        regime = "elevated"
+    else:
+        regime = "high fear"
+    return {
+        "vix": round(current, 2),
+        "change_30d_pct": round(change_pct, 2),
+        "regime": regime,
+    }
+
+
+def _put_call_sync(symbol: str) -> dict:
+    ticker = yf.Ticker(symbol)
+    expirations = ticker.options
+    if not expirations:
+        return {"error": f"no options chain for {symbol}"}
+    expiry = expirations[0]
+    chain = ticker.option_chain(expiry)
+    put_oi  = float(chain.puts.get("openInterest").fillna(0).sum())  if "openInterest" in chain.puts  else 0.0
+    call_oi = float(chain.calls.get("openInterest").fillna(0).sum()) if "openInterest" in chain.calls else 0.0
+    put_vol  = float(chain.puts.get("volume").fillna(0).sum())  if "volume" in chain.puts  else 0.0
+    call_vol = float(chain.calls.get("volume").fillna(0).sum()) if "volume" in chain.calls else 0.0
+    pcr_oi  = round(put_oi / call_oi, 3)   if call_oi  else None
+    pcr_vol = round(put_vol / call_vol, 3) if call_vol else None
+    primary = pcr_oi if pcr_oi is not None else pcr_vol
+    if primary is None:
+        signal = "no data"
+    elif primary > 1.0:
+        signal = "bearish (more puts)"
+    elif primary < 0.7:
+        signal = "bullish (more calls)"
+    else:
+        signal = "neutral"
+    return {
+        "symbol": symbol.upper(),
+        "expiry": expiry,
+        "put_call_ratio_oi": pcr_oi,
+        "put_call_ratio_volume": pcr_vol,
+        "signal": signal,
+    }
+
+
+def _insider_sync(symbol: str) -> dict:
+    ticker = yf.Ticker(symbol)
+    df = ticker.insider_transactions
+    if df is None or getattr(df, "empty", True):
+        return {"symbol": symbol.upper(), "buys": 0, "sells": 0, "note": "no insider data"}
+    cutoff = datetime.now(timezone.utc) - timedelta(days=90)
+    date_col = next((c for c in ("Start Date", "Date") if c in df.columns), None)
+    buys = sells = 0
+    for _, row in df.iterrows():
+        if date_col is not None:
+            try:
+                ts = row[date_col]
+                ts = ts.to_pydatetime() if hasattr(ts, "to_pydatetime") else datetime.fromisoformat(str(ts)[:10])
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                if ts < cutoff:
+                    continue
+            except Exception:
+                pass  # undated row — count it rather than drop it
+        text = f"{row.get('Text', '')} {row.get('Transaction', '')}".lower()
+        if any(k in text for k in ("purchase", "buy", "acquisition", "bought")):
+            buys += 1
+        elif any(k in text for k in ("sale", "sell", "disposition", "sold")):
+            sells += 1
+    if buys > sells:
+        bias = "net buying"
+    elif sells > buys:
+        bias = "net selling"
+    else:
+        bias = "balanced"
+    return {"symbol": symbol.upper(), "buys": buys, "sells": sells, "bias": bias, "window_days": 90}
+
+
+def _macro_sync() -> dict:
+    def _last_close(sym: str) -> Optional[float]:
+        try:
+            hist = yf.Ticker(sym).history(period="5d")
+            if hist is None or hist.empty:
+                return None
+            return _norm_yield(float(hist["Close"].dropna().iloc[-1]))
+        except Exception:
+            return None
+
+    tnx = _last_close("^TNX")   # 10Y Treasury yield
+    fvx = _last_close("^FVX")   # 5Y Treasury yield
+    irx = _last_close("^IRX")   # 13-week T-bill (short-end / fed-funds proxy)
+    curve = round(tnx - irx, 3) if (tnx is not None and irx is not None) else None
+    return {
+        "ten_year_yield_pct": tnx,
+        "five_year_yield_pct": fvx,
+        "thirteen_week_yield_pct": irx,
+        "fed_funds_proxy_pct": irx,
+        "yield_curve_10y_minus_13w_pct": curve,
+        "curve_inverted": (curve is not None and curve < 0),
+        "cpi": "unavailable (no free real-time source)",
+    }
+
+
+async def _run_sync_tool(fn, *args) -> dict:
+    if not _YF_AVAILABLE:
+        return {"error": "market data provider unavailable"}
+    try:
+        return await asyncio.to_thread(fn, *args)
+    except Exception as exc:
+        logger.warning(f"[JURY-TOOLS] {fn.__name__} failed: {exc}")
+        return {"error": "tool fetch failed"}
+
+
+def make_tool_dispatcher(symbol: str) -> Callable[[str, dict], Awaitable[str]]:
+    """Build an async dispatcher bound to the request's `symbol`.
+
+    Returns `async dispatch(name, args) -> json_str`. Results are memoised for
+    the lifetime of the dispatcher so the three analysts sharing it don't each
+    re-fetch the same market-wide data (VIX, macro) within one request.
+    """
+    cache: Dict[str, str] = {}
+
+    async def dispatch(name: str, args: dict) -> str:
+        # Symbol-bearing tools trust the request symbol over model-supplied args
+        # (guards against the model hallucinating a different ticker).
+        if name == "get_vix":
+            key, result = "get_vix", None
+            if key not in cache:
+                result = await _run_sync_tool(_vix_sync)
+        elif name == "get_macro_snapshot":
+            key, result = "get_macro_snapshot", None
+            if key not in cache:
+                result = await _run_sync_tool(_macro_sync)
+        elif name == "get_put_call_ratio":
+            key = f"put_call:{symbol}"
+            result = await _run_sync_tool(_put_call_sync, symbol) if key not in cache else None
+        elif name == "get_insider_flow":
+            key = f"insider:{symbol}"
+            result = await _run_sync_tool(_insider_sync, symbol) if key not in cache else None
+        else:
+            return json.dumps({"error": f"unknown tool: {name}"})
+
+        if key not in cache:
+            cache[key] = json.dumps(result)
+        return cache[key]
+
+    return dispatch
 
 
 # ---------------------------------------------------------------------------
@@ -40,20 +272,30 @@ class JuryState(TypedDict):
 # Node factory — one async node per analyst persona
 # ---------------------------------------------------------------------------
 
-def _make_analyst_node(persona: dict, analyst_jury_svc):
+def _make_analyst_node(persona: dict, analyst_jury_svc, tools=None, tool_dispatcher=None):
     """
     Returns an async graph node function pinned to `persona`.
     The node writes its verdict (or error fallback) into state["verdicts"].
+
+    When `tools` and `tool_dispatcher` are provided the analyst runs the
+    Groq function-calling loop; otherwise it makes a single completion call.
     """
     pid = persona["id"]
 
     async def _node(state: JuryState) -> dict:
-        logger.info(f"[JURY-GRAPH/{pid}] node entered — model={persona['api_model']}")
+        logger.info(
+            f"[JURY-GRAPH/{pid}] node entered — model={persona['api_model']}, "
+            f"tools={'on' if tools and tool_dispatcher else 'off'}"
+        )
         try:
-            verdict = await analyst_jury_svc.get_analyst_verdict(persona, state["ctx"])
+            verdict = await analyst_jury_svc.get_analyst_verdict(
+                persona, state["ctx"],
+                tools=tools, tool_dispatcher=tool_dispatcher,
+            )
             logger.info(
                 f"[JURY-GRAPH/{pid}] ✓ verdict — "
-                f"rating={verdict['rating']}, confidence={verdict['confidence']}%"
+                f"rating={verdict['rating']}, confidence={verdict['confidence']}%, "
+                f"tools_used={verdict.get('tools_used', [])}"
             )
             return {"verdicts": {pid: verdict}}
         except Exception as exc:
@@ -74,6 +316,7 @@ def _make_analyst_node(persona: dict, analyst_jury_svc):
                 "note":        fallback_note,
                 "confidence":  25,
                 "model":       "error",
+                "tools_used":  [],
             }
             return {
                 "verdicts": {pid: fallback},
@@ -88,26 +331,28 @@ def _make_analyst_node(persona: dict, analyst_jury_svc):
 # Graph builder
 # ---------------------------------------------------------------------------
 
-def build_jury_graph(analyst_jury_svc, personas: List[dict]):
+def build_jury_graph(analyst_jury_svc, personas: List[dict], tools=None, tool_dispatcher=None):
     """
     Build and compile the jury StateGraph.
 
     Each persona becomes a node fanned out in parallel from START.
     All nodes write into the shared `verdicts` dict via the merge reducer.
+    When `tools`/`tool_dispatcher` are passed, every analyst node is tool-enabled.
     """
     builder = StateGraph(JuryState)
 
     node_names = []
     for persona in personas:
         name = f"analyst_{persona['id'].lower().replace('-', '_')}"
-        builder.add_node(name, _make_analyst_node(persona, analyst_jury_svc))
+        builder.add_node(name, _make_analyst_node(persona, analyst_jury_svc, tools, tool_dispatcher))
         builder.add_edge(START, name)
         builder.add_edge(name, END)
         node_names.append(name)
 
     graph = builder.compile()
     logger.info(
-        f"[JURY-GRAPH] Compiled — {len(personas)} analyst nodes: {node_names}"
+        f"[JURY-GRAPH] Compiled — {len(personas)} analyst nodes: {node_names} "
+        f"(tools={'on' if tools and tool_dispatcher else 'off'})"
     )
     return graph
 
@@ -120,6 +365,8 @@ async def run_jury_graph(
     analyst_jury_svc,
     personas: List[dict],
     ctx: str,
+    symbol: Optional[str] = None,
+    enable_tools: bool = True,
 ) -> List[dict]:
     """
     Run the jury graph and return verdicts in the same order as `personas`.
@@ -128,8 +375,17 @@ async def run_jury_graph(
         results = await asyncio.gather(*[svc.get_analyst_verdict(p, ctx) for p in personas])
 
     but with explicit state, per-node error isolation, and graph observability.
+
+    When `symbol` is supplied and `enable_tools` is True, every analyst is given
+    the Groq function-calling toolset (`JURY_TOOLS`) backed by a per-request
+    dispatcher, so analysts can pull live VIX / put-call / insider / macro data.
     """
-    graph = build_jury_graph(analyst_jury_svc, personas)
+    tools = tool_dispatcher = None
+    if enable_tools and symbol and _YF_AVAILABLE:
+        tools = JURY_TOOLS
+        tool_dispatcher = make_tool_dispatcher(symbol)
+
+    graph = build_jury_graph(analyst_jury_svc, personas, tools, tool_dispatcher)
 
     initial_state: JuryState = {
         "ctx":      ctx,
@@ -165,6 +421,7 @@ async def run_jury_graph(
                 "note":        "Analysis unavailable.",
                 "confidence":  25,
                 "model":       "error",
+                "tools_used":  [],
             }
         verdicts.append(v)
 

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -367,8 +367,10 @@ async def _run_analyst_jury(
     # ------------------------------------------------------------------
     # Stash the assembled context so POST /jury/reanalyze can re-run the jury
     # with tools forced on, without recomputing every indicator from scratch.
+    # Wrap in a dict — cache_get discards non-list/dict payloads, so a bare
+    # string would be silently dropped on read.
     try:
-        await cache_set(f"jury_ctx:{symbol.upper()}", ctx, ttl_seconds=28800)  # 8h
+        await cache_set(f"jury_ctx:{symbol.upper()}", {"ctx": ctx}, ttl_seconds=28800)  # 8h
     except Exception as exc:
         logger.debug(f"[JURY-GRAPH] ctx cache_set failed (non-fatal): {exc}")
 
@@ -415,7 +417,8 @@ async def reanalyze_jury(payload: JuryReanalyzeRequest):
     if not symbol or not re.fullmatch(r"[A-Za-z0-9.\-:]{1,15}", symbol):
         raise HTTPException(status_code=400, detail="Invalid symbol.")
 
-    ctx = await cache_get(f"jury_ctx:{symbol}")
+    cached = await cache_get(f"jury_ctx:{symbol}")
+    ctx = cached.get("ctx") if isinstance(cached, dict) else None
     if not ctx:
         raise HTTPException(
             status_code=409,

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -54,6 +54,10 @@ class PredictRequest(BaseModel):
     data: str = "SPY"
 
 
+class JuryReanalyzeRequest(BaseModel):
+    symbol: str
+
+
 class PredictionResponse(BaseModel):
     symbol:       str
     currentPrice: str
@@ -361,6 +365,13 @@ async def _run_analyst_jury(
     # Each analyst is an independent node; failures are isolated per-node.
     # Swap .ainvoke() → .stream() here in future for SSE streaming.
     # ------------------------------------------------------------------
+    # Stash the assembled context so POST /jury/reanalyze can re-run the jury
+    # with tools forced on, without recomputing every indicator from scratch.
+    try:
+        await cache_set(f"jury_ctx:{symbol.upper()}", ctx, ttl_seconds=28800)  # 8h
+    except Exception as exc:
+        logger.debug(f"[JURY-GRAPH] ctx cache_set failed (non-fatal): {exc}")
+
     try:
         # 30s budget accommodates tool-call round-trips (Groq function calling).
         return await asyncio.wait_for(
@@ -384,6 +395,52 @@ async def _run_analyst_jury(
             }
             for persona in ANALYST_PERSONAS
         ]
+
+
+# ---------------------------------------------------------------------------
+# Jury re-analysis — re-run the jury with live tools forced on
+# ---------------------------------------------------------------------------
+
+@router.post("/jury/reanalyze")
+async def reanalyze_jury(payload: JuryReanalyzeRequest):
+    """
+    Re-run the analyst jury for a symbol with Groq function-calling tools
+    FORCED on (each analyst must invoke ≥1 live tool: VIX, put/call, insider,
+    or macro). Reuses the market-context string assembled by the most recent
+    /predict for this symbol — call /predict first.
+
+    Returns {"juryAnalysts": [...]} with populated `tools_used` per analyst.
+    """
+    symbol = (payload.symbol or "").strip().upper()
+    if not symbol or not re.fullmatch(r"[A-Za-z0-9.\-:]{1,15}", symbol):
+        raise HTTPException(status_code=400, detail="Invalid symbol.")
+
+    ctx = await cache_get(f"jury_ctx:{symbol}")
+    if not ctx:
+        raise HTTPException(
+            status_code=409,
+            detail="No analysis context for this symbol yet — run a prediction first.",
+        )
+
+    logger.info(f"[JURY-REANALYZE] {symbol} — re-running jury with tools forced on")
+    try:
+        jury = await asyncio.wait_for(
+            run_jury_graph(
+                analyst_jury_svc, ANALYST_PERSONAS, ctx,
+                symbol=symbol, enable_tools=True, force_tools=True,
+            ),
+            timeout=40.0,
+        )
+    except asyncio.TimeoutError:
+        logger.error(f"[JURY-REANALYZE] {symbol} timed out after 40s")
+        raise HTTPException(status_code=504, detail="Re-analysis timed out — please try again.")
+    except Exception as exc:
+        logger.error(f"[JURY-REANALYZE] {symbol} failed: {exc}", exc_info=True)
+        raise HTTPException(status_code=502, detail="Re-analysis failed — please try again.")
+
+    tools_total = sum(len(v.get("tools_used", [])) for v in jury)
+    logger.info(f"[JURY-REANALYZE] ✓ {symbol} — {len(jury)} verdicts, {tools_total} tool calls")
+    return {"juryAnalysts": jury}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -362,7 +362,11 @@ async def _run_analyst_jury(
     # Swap .ainvoke() → .stream() here in future for SSE streaming.
     # ------------------------------------------------------------------
     try:
-        return await run_jury_graph(analyst_jury_svc, ANALYST_PERSONAS, ctx)
+        # 30s budget accommodates tool-call round-trips (Groq function calling).
+        return await asyncio.wait_for(
+            run_jury_graph(analyst_jury_svc, ANALYST_PERSONAS, ctx, symbol=symbol),
+            timeout=30.0,
+        )
     except Exception as exc:
         logger.error("[JURY-GRAPH] invocation failed: %s", exc, exc_info=True)
         return [
@@ -376,6 +380,7 @@ async def _run_analyst_jury(
                 "note":        "Analysis unavailable.",
                 "confidence":  25,
                 "model":       "error",
+                "tools_used":  [],
             }
             for persona in ANALYST_PERSONAS
         ]
@@ -1356,9 +1361,11 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
 @router.post("/predict", response_model=PredictionResponse)
 async def predict(payload: PredictRequest):
     try:
-        return await asyncio.wait_for(_predict_inner(payload), timeout=50.0)
+        # 60s overall budget: the tool-using jury alone may take up to 30s
+        # (Groq function-calling round-trips) on top of data + forecast steps.
+        return await asyncio.wait_for(_predict_inner(payload), timeout=60.0)
     except asyncio.TimeoutError:
-        logger.error("[PREDICT] Request timed out after 50s")
+        logger.error("[PREDICT] Request timed out after 60s")
         raise HTTPException(status_code=503, detail="Analysis timed out — please try again.")
 
 

--- a/backend/services.py
+++ b/backend/services.py
@@ -1706,11 +1706,13 @@ class AnalystJuryService:
         tool_dispatcher,
         max_tokens: int = 320,
         max_rounds: int = 2,
+        force_first: bool = False,
     ) -> tuple:
         """Run a tool-using analyst loop against Groq's OpenAI-compatible API.
 
         Loop:
-          1. Send messages with `tools` (tool_choice=auto).
+          1. Send messages with `tools`. tool_choice is "required" on the first
+             round when `force_first` is set (guarantees ≥1 tool call), else "auto".
           2. If the model returns tool_calls, dispatch each via `tool_dispatcher`
              (an async callable `(name, args_dict) -> str`), append the results as
              role=tool messages, and re-send.
@@ -1737,7 +1739,9 @@ class AnalystJuryService:
             }
             if include_tools:
                 body["tools"]       = tools
-                body["tool_choice"] = "auto"
+                # Force at least one tool call on the opening round when asked
+                # (used by the "re-analyze with tools" path); auto otherwise.
+                body["tool_choice"] = "required" if (force_first and round_idx == 0) else "auto"
 
             logger.debug(
                 f"[GROQ-TOOLS] round={round_idx} model={model} "
@@ -1915,6 +1919,7 @@ class AnalystJuryService:
         *,
         tools: Optional[List[dict]] = None,
         tool_dispatcher=None,
+        force_tools: bool = False,
     ) -> dict:
         """
         Dispatches a single analyst persona to its assigned provider and model.
@@ -1950,6 +1955,7 @@ class AnalystJuryService:
                     raw, tools_used = await self.call_groq_with_tools(
                         model_used, persona["system"], user_prompt,
                         tools, tool_dispatcher, max_tok,
+                        force_first=force_tools,
                     )
                 else:
                     raw = await self._call_groq(model_used, persona["system"], user_prompt, max_tok)

--- a/backend/services.py
+++ b/backend/services.py
@@ -1747,7 +1747,39 @@ class AnalystJuryService:
                 f"[GROQ-TOOLS] round={round_idx} model={model} "
                 f"include_tools={include_tools} msgs={len(messages)}"
             )
-            data = await self._post_groq_raw(body)
+            # Some Groq models reject tool params with a 400 (e.g. Qwen3-32B does
+            # not support tool_choice="required", and reasoning models may reject
+            # function calling entirely). Degrade gracefully so the analyst still
+            # returns a real verdict instead of crashing to a Hold/25 fallback:
+            #   required → auto → no tools.
+            try:
+                data = await self._post_groq_raw(body)
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code != 400 or "tools" not in body:
+                    raise
+                data = None
+                # Step 1: if we were forcing, try relaxing to tool_choice=auto.
+                if body.get("tool_choice") == "required":
+                    logger.warning(
+                        f"[GROQ-TOOLS] {model} rejected tool_choice=required (400) — "
+                        f"retrying with tool_choice=auto"
+                    )
+                    body["tool_choice"] = "auto"
+                    try:
+                        data = await self._post_groq_raw(body)
+                    except httpx.HTTPStatusError as exc2:
+                        if exc2.response.status_code != 400:
+                            raise
+                        data = None
+                # Step 2: still rejected (or model can't do tools at all) — drop them.
+                if data is None:
+                    logger.warning(
+                        f"[GROQ-TOOLS] {model} rejected tools (400) — "
+                        f"retrying without tools (plain completion)"
+                    )
+                    body.pop("tools", None)
+                    body.pop("tool_choice", None)
+                    data = await self._post_groq_raw(body)
             msg  = data["choices"][0]["message"]
             tool_calls = msg.get("tool_calls")
 

--- a/backend/services.py
+++ b/backend/services.py
@@ -1509,6 +1509,17 @@ NOTE_PROMPT_SUFFIX = (
 )
 
 
+# Appended to the user prompt only when live tools are available to the analyst.
+# Encourages (but does not force) tool use before the final JSON verdict.
+TOOL_PROMPT_HINT = (
+    "\n\nYou have access to live market data tools: get_vix (volatility regime), "
+    "get_put_call_ratio (options positioning), get_insider_flow (insider buy/sell), "
+    "and get_macro_snapshot (rates & yield curve). Call any tools that would "
+    "strengthen your analysis BEFORE giving your verdict. When you have gathered "
+    "what you need, respond with the final JSON verdict described below."
+)
+
+
 class AnalystJuryService:
     """
     Routes analyst persona calls to the correct provider API.
@@ -1604,6 +1615,131 @@ class AnalystJuryService:
             f"response_chars={len(result)}"
         )
         return result
+
+    # ------------------------------------------------------------------
+    # Internal: raw OpenAI-compatible POST returning the full JSON body
+    # (needed for tool calling — callers inspect message.tool_calls)
+    # ------------------------------------------------------------------
+    @newrelic.agent.function_trace()
+    async def _post_groq_raw(self, body: dict) -> dict:
+        """POST a fully-formed chat-completions body to Groq, return parsed JSON.
+
+        Raises httpx.HTTPStatusError on non-2xx so callers can inspect status codes
+        (e.g. 429 rate-limit handling in the jury graph).
+        """
+        if not Config.GROQ_API_KEY:
+            raise ValueError("GROQ API key not configured")
+        headers = {
+            "Authorization": f"Bearer {Config.GROQ_API_KEY}",
+            "Content-Type":  "application/json",
+        }
+        async with httpx.AsyncClient(timeout=35.0) as client:
+            resp = await client.post(self.GROQ_BASE_URL, json=body, headers=headers)
+            resp.raise_for_status()
+            return resp.json()
+
+    # ------------------------------------------------------------------
+    # Public: agentic Groq call with OpenAI-compatible function/tool use
+    # ------------------------------------------------------------------
+    @newrelic.agent.function_trace()
+    async def call_groq_with_tools(
+        self,
+        model: str,
+        system: str,
+        user: str,
+        tools: List[dict],
+        tool_dispatcher,
+        max_tokens: int = 320,
+        max_rounds: int = 2,
+    ) -> tuple:
+        """Run a tool-using analyst loop against Groq's OpenAI-compatible API.
+
+        Loop:
+          1. Send messages with `tools` (tool_choice=auto).
+          2. If the model returns tool_calls, dispatch each via `tool_dispatcher`
+             (an async callable `(name, args_dict) -> str`), append the results as
+             role=tool messages, and re-send.
+          3. After `max_rounds` tool rounds, send once more WITHOUT tools so the
+             model is forced to return its final text answer.
+
+        Returns a tuple `(final_content, tools_used)` where `tools_used` is the
+        ordered, de-duplicated list of tool names the model actually invoked.
+        """
+        messages: List[dict] = [
+            {"role": "system", "content": system},
+            {"role": "user",   "content": user},
+        ]
+        tools_used: List[str] = []
+
+        # max_rounds tool rounds + 1 forced final (no-tools) round
+        for round_idx in range(max_rounds + 1):
+            include_tools = round_idx < max_rounds
+            body = {
+                "model":       model,
+                "messages":    messages,
+                "max_tokens":  max_tokens,
+                "temperature": 0.65,
+            }
+            if include_tools:
+                body["tools"]       = tools
+                body["tool_choice"] = "auto"
+
+            logger.debug(
+                f"[GROQ-TOOLS] round={round_idx} model={model} "
+                f"include_tools={include_tools} msgs={len(messages)}"
+            )
+            data = await self._post_groq_raw(body)
+            msg  = data["choices"][0]["message"]
+            tool_calls = msg.get("tool_calls")
+
+            if not tool_calls:
+                content = (msg.get("content") or "").strip()
+                # de-dupe preserving first-seen order
+                seen: List[str] = []
+                for t in tools_used:
+                    if t not in seen:
+                        seen.append(t)
+                logger.info(
+                    f"[GROQ-TOOLS] ✓ complete — model={model}, rounds={round_idx}, "
+                    f"tools_used={seen}, response_chars={len(content)}"
+                )
+                return content, seen
+
+            # Model requested tools — record the assistant turn, then dispatch each.
+            messages.append({
+                "role":       "assistant",
+                "content":    msg.get("content") or "",
+                "tool_calls": tool_calls,
+            })
+            for tc in tool_calls:
+                fn_name = tc.get("function", {}).get("name", "")
+                try:
+                    fn_args = json.loads(tc.get("function", {}).get("arguments") or "{}")
+                    if not isinstance(fn_args, dict):
+                        fn_args = {}
+                except (json.JSONDecodeError, TypeError):
+                    fn_args = {}
+                logger.info(f"[GROQ-TOOLS] dispatch — {fn_name}({fn_args})")
+                try:
+                    result = await tool_dispatcher(fn_name, fn_args)
+                except Exception as exc:   # tool failures are non-fatal
+                    logger.warning(f"[GROQ-TOOLS] tool {fn_name} failed: {exc}")
+                    result = json.dumps({"error": "tool unavailable"})
+                tools_used.append(fn_name)
+                messages.append({
+                    "role":         "tool",
+                    "tool_call_id": tc.get("id", ""),
+                    "name":         fn_name,
+                    "content":      result if isinstance(result, str) else json.dumps(result),
+                })
+
+        # Fallback: loop exhausted without a final text answer (should not happen).
+        seen = list(dict.fromkeys(tools_used))
+        logger.warning(
+            f"[GROQ-TOOLS] loop exhausted with no final content — model={model}, "
+            f"tools_used={seen}"
+        )
+        return "", seen
 
     # ------------------------------------------------------------------
     # Internal: robust structured response parser
@@ -1717,21 +1853,36 @@ class AnalystJuryService:
     # Public: dispatch one persona and return a structured verdict
     # ------------------------------------------------------------------
     @newrelic.agent.function_trace()
-    async def get_analyst_verdict(self, persona: dict, market_ctx: str) -> dict:
+    async def get_analyst_verdict(
+        self,
+        persona: dict,
+        market_ctx: str,
+        *,
+        tools: Optional[List[dict]] = None,
+        tool_dispatcher=None,
+    ) -> dict:
         """
         Dispatches a single analyst persona to its assigned provider and model.
         All 3 personas use Groq. Provider field reserved for future expansion.
         Returns a fully structured verdict dict ready for the API response.
+
+        When `tools` and `tool_dispatcher` are supplied, the analyst runs an
+        agentic tool-using loop (Groq function calling) and the returned verdict
+        carries a `tools_used` list naming the tools the model invoked.
         """
-        user_prompt = market_ctx + NOTE_PROMPT_SUFFIX
+        use_tools   = bool(tools and tool_dispatcher)
+        hint        = TOOL_PROMPT_HINT if use_tools else ""
+        user_prompt = market_ctx + hint + NOTE_PROMPT_SUFFIX
         model_used  = persona["api_model"]
         max_tok     = persona.get("max_tokens", 320)
         raw         = ""
+        tools_used: List[str] = []
 
         logger.info(
             f"[JURY/{persona['id']}] ── Dispatching — "
             f"provider={persona['provider']}, model={model_used}, "
-            f"max_tokens={max_tok}, title='{persona['title']}' ──"
+            f"max_tokens={max_tok}, tools={'on' if use_tools else 'off'}, "
+            f"title='{persona['title']}' ──"
         )
         logger.debug(
             f"[JURY/{persona['id']}] Context sent — "
@@ -1740,13 +1891,19 @@ class AnalystJuryService:
 
         try:
             if persona["provider"] == "groq":
-                raw = await self._call_groq(model_used, persona["system"], user_prompt, max_tok)
+                if use_tools:
+                    raw, tools_used = await self.call_groq_with_tools(
+                        model_used, persona["system"], user_prompt,
+                        tools, tool_dispatcher, max_tok,
+                    )
+                else:
+                    raw = await self._call_groq(model_used, persona["system"], user_prompt, max_tok)
             else:
                 raise ValueError(f"Unknown provider: {persona['provider']}")
 
             logger.debug(
                 f"[JURY/{persona['id']}] ✓ Raw response received — "
-                f"model={model_used}, raw_chars={len(raw)}"
+                f"model={model_used}, raw_chars={len(raw)}, tools_used={tools_used}"
             )
 
         except Exception as e:
@@ -1760,6 +1917,7 @@ class AnalystJuryService:
                 '"confidence": 25}'
             )
             model_used = "error"
+            tools_used = []
 
         parsed = self._parse_analyst_response(raw, persona_id=persona["id"])
 
@@ -1773,10 +1931,12 @@ class AnalystJuryService:
             "note":        parsed.get("note",        "No available analysis at this time."),
             "confidence":  parsed.get("confidence",  50),
             "model":       model_used,
+            "tools_used":  tools_used,
         }
         logger.info(
             f"[JURY/{persona['id']}] Final verdict — "
             f"rating={verdict['rating']}, confidence={verdict['confidence']}%, "
-            f"model={verdict['model']}, note_chars={len(verdict['note'])}"
+            f"model={verdict['model']}, note_chars={len(verdict['note'])}, "
+            f"tools_used={tools_used}"
         )
         return verdict

--- a/frontend/app/api/jury/reanalyze/route.ts
+++ b/frontend/app/api/jury/reanalyze/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import axios from 'axios';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const symbol = (body.symbol || '').toUpperCase();
+
+    if (!symbol) {
+      return NextResponse.json({ error: 'symbol is required' }, { status: 400 });
+    }
+
+    // Re-run the analyst jury with live tools forced on (Groq function calling).
+    // Longer client timeout: forced tool round-trips take longer than a normal call.
+    const response = await axios.post(
+      `${BACKEND_URL}/jury/reanalyze`,
+      { symbol },
+      { timeout: 45000 },
+    );
+
+    return NextResponse.json(response.data);
+
+  } catch (error: any) {
+    console.error('Jury Reanalyze Proxy Error:', error.response?.data || error.message);
+
+    const status = error.response?.status || 500;
+    const detail = error.response?.data?.detail || 'Re-analysis failed';
+
+    return NextResponse.json({ error: detail }, { status });
+  }
+}

--- a/frontend/app/api/jury/reanalyze/route.ts
+++ b/frontend/app/api/jury/reanalyze/route.ts
@@ -6,7 +6,9 @@ const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
 export async function POST(request: Request) {
   try {
     const body = await request.json();
-    const symbol = (body.symbol || '').toUpperCase();
+    const symbol = typeof body?.symbol === 'string'
+      ? body.symbol.trim().toUpperCase()
+      : '';
 
     if (!symbol) {
       return NextResponse.json({ error: 'symbol is required' }, { status: 400 });

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -350,7 +350,7 @@ export default function QuantumDashboard() {
 
                   {/* ── Analyst Jury ──────────────────────────────────── */}
                   {prediction.juryAnalysts && prediction.juryAnalysts.length > 0 && (
-                    <AnalystJuryPanel analysts={prediction.juryAnalysts} />
+                    <AnalystJuryPanel analysts={prediction.juryAnalysts} symbol={prediction.symbol} />
                   )}
 
                   {/* ── Trade Setup ──────────────────────────────────── */}

--- a/frontend/components/AnalystJuryPanel.tsx
+++ b/frontend/components/AnalystJuryPanel.tsx
@@ -24,6 +24,20 @@ const RATING_ORDER = [
   'Distribute', 'Sell', 'High Risk', 'Strong Sell',
 ];
 
+// Friendly labels for the Groq function-calling tools each analyst can invoke.
+const TOOL_LABELS: Record<string, string> = {
+  get_vix:            'VIX',
+  get_put_call_ratio: 'put/call ratio',
+  get_insider_flow:   'insider flow',
+  get_macro_snapshot: 'macro snapshot',
+};
+
+const formatToolsUsed = (tools?: string[]): string => {
+  if (!tools || tools.length === 0) return '';
+  const labels = Array.from(new Set(tools.map((t) => TOOL_LABELS[t] ?? t)));
+  return labels.join(', ');
+};
+
 export default function AnalystJuryPanel({ analysts }: { analysts: AnalystJuror[] }) {
   const ratingColor = (r: string) => RATING_COLORS[r] ?? { bg: '#64748b22', text: '#94a3b8' };
 
@@ -119,6 +133,16 @@ export default function AnalystJuryPanel({ analysts }: { analysts: AnalystJuror[
                   <Typography sx={{ fontSize: '0.8rem', lineHeight: 1.65, opacity: 0.85, flex: 1 }}>
                     {analyst.note}
                   </Typography>
+
+                  {formatToolsUsed(analyst.tools_used) && (
+                    <Typography sx={{
+                      fontSize: '0.5rem', opacity: 0.4, lineHeight: 1.3,
+                      fontFamily: 'monospace', color: analyst.color,
+                      letterSpacing: '0.02em',
+                    }}>
+                      🔧 Used: {formatToolsUsed(analyst.tools_used)}
+                    </Typography>
+                  )}
 
                 </CardContent>
               </Card>

--- a/frontend/components/AnalystJuryPanel.tsx
+++ b/frontend/components/AnalystJuryPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Box, Button, Card, CardContent, CircularProgress, Grid, Stack, Tooltip, Typography } from '@mui/material';
 import { Scale, Wrench } from 'lucide-react';
 import axios from 'axios';
@@ -42,19 +42,26 @@ export default function AnalystJuryPanel({ analysts, symbol }: { analysts: Analy
   const [reanalyzing, setReanalyzing] = useState(false);
   const [reanalyzeError, setReanalyzeError] = useState<string | null>(null);
   const [reanalyzed, setReanalyzed] = useState(false);
+  // Monotonic token: bumped on every prediction change and every re-analyze
+  // start, so an in-flight response for a stale symbol can't clobber newer data.
+  const reanalyzeReqId = useRef(0);
 
   useEffect(() => {
+    reanalyzeReqId.current += 1;
     setLiveAnalysts(analysts);
+    setReanalyzing(false);
     setReanalyzed(false);
     setReanalyzeError(null);
-  }, [analysts]);
+  }, [analysts, symbol]);
 
   const handleReanalyze = async () => {
     if (!symbol || reanalyzing) return;
+    const reqId = ++reanalyzeReqId.current;
     setReanalyzing(true);
     setReanalyzeError(null);
     try {
       const res = await axios.post('/api/jury/reanalyze', { symbol });
+      if (reqId !== reanalyzeReqId.current) return;   // superseded — discard
       const next = res.data?.juryAnalysts as AnalystJuror[] | undefined;
       if (next && next.length > 0) {
         setLiveAnalysts(next);
@@ -63,9 +70,10 @@ export default function AnalystJuryPanel({ analysts, symbol }: { analysts: Analy
         setReanalyzeError('No verdicts returned.');
       }
     } catch (err: any) {
+      if (reqId !== reanalyzeReqId.current) return;   // superseded — discard
       setReanalyzeError(err?.response?.data?.error ?? 'Re-analysis failed.');
     } finally {
-      setReanalyzing(false);
+      if (reqId === reanalyzeReqId.current) setReanalyzing(false);
     }
   };
 

--- a/frontend/components/AnalystJuryPanel.tsx
+++ b/frontend/components/AnalystJuryPanel.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { Box, Card, CardContent, Grid, Stack, Typography } from '@mui/material';
-import { Scale } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Box, Button, Card, CardContent, CircularProgress, Grid, Stack, Tooltip, Typography } from '@mui/material';
+import { Scale, Wrench } from 'lucide-react';
+import axios from 'axios';
 import type { AnalystJuror } from '../types';
 
 const RATING_COLORS: Record<string, { bg: string; text: string }> = {
@@ -17,13 +19,6 @@ const RATING_COLORS: Record<string, { bg: string; text: string }> = {
   'High Risk':   { bg: '#ff005522', text: '#ff0055' },
 };
 
-// Ordered most-bullish → most-bearish across all 3 persona rating vocabularies
-const RATING_ORDER = [
-  'Strong Buy', 'Buy', 'Accumulate', 'Low Risk',
-  'Hold', 'Medium Risk',
-  'Distribute', 'Sell', 'High Risk', 'Strong Sell',
-];
-
 // Friendly labels for the Groq function-calling tools each analyst can invoke.
 const TOOL_LABELS: Record<string, string> = {
   get_vix:            'VIX',
@@ -38,14 +33,48 @@ const formatToolsUsed = (tools?: string[]): string => {
   return labels.join(', ');
 };
 
-export default function AnalystJuryPanel({ analysts }: { analysts: AnalystJuror[] }) {
+export default function AnalystJuryPanel({ analysts, symbol }: { analysts: AnalystJuror[]; symbol?: string }) {
   const ratingColor = (r: string) => RATING_COLORS[r] ?? { bg: '#64748b22', text: '#94a3b8' };
+
+  // Local copy so a tool-driven re-analysis can replace the verdicts in place.
+  // Resets whenever the upstream prediction (props.analysts) changes.
+  const [liveAnalysts, setLiveAnalysts] = useState<AnalystJuror[]>(analysts);
+  const [reanalyzing, setReanalyzing] = useState(false);
+  const [reanalyzeError, setReanalyzeError] = useState<string | null>(null);
+  const [reanalyzed, setReanalyzed] = useState(false);
+
+  useEffect(() => {
+    setLiveAnalysts(analysts);
+    setReanalyzed(false);
+    setReanalyzeError(null);
+  }, [analysts]);
+
+  const handleReanalyze = async () => {
+    if (!symbol || reanalyzing) return;
+    setReanalyzing(true);
+    setReanalyzeError(null);
+    try {
+      const res = await axios.post('/api/jury/reanalyze', { symbol });
+      const next = res.data?.juryAnalysts as AnalystJuror[] | undefined;
+      if (next && next.length > 0) {
+        setLiveAnalysts(next);
+        setReanalyzed(true);
+      } else {
+        setReanalyzeError('No verdicts returned.');
+      }
+    } catch (err: any) {
+      setReanalyzeError(err?.response?.data?.error ?? 'Re-analysis failed.');
+    } finally {
+      setReanalyzing(false);
+    }
+  };
 
   // Consensus must reflect what the panel actually said — NOT just the single
   // most-bullish verdict (the old `RATING_ORDER.find` headlined "Strong Buy"
   // even when 2/3 said Hold). Normalize every persona vocabulary onto one
   // bullish(+)→bearish(−) score, take the plurality bucket, break ties by
   // summed confidence, and fall back to the confidence-weighted average.
+  // Computed from liveAnalysts so it updates after a tool re-analysis.
   const RATING_SCORE: Record<string, number> = {
     'Strong Buy': 2, 'Low Risk': 2,
     'Buy': 1, 'Accumulate': 1,
@@ -57,7 +86,7 @@ export default function AnalystJuryPanel({ analysts }: { analysts: AnalystJuror[
     s >= 1.5 ? 'Strong Buy' : s >= 0.5 ? 'Buy' : s > -0.5 ? 'Hold' : s > -1.5 ? 'Sell' : 'Strong Sell';
   const toBucket = (r: string): string => scoreToRating(RATING_SCORE[r] ?? 0);
 
-  const bucketStats = analysts.reduce((acc, a) => {
+  const bucketStats = liveAnalysts.reduce((acc, a) => {
     const b = toBucket(a.rating);
     const s = acc[b] ?? { count: 0, conf: 0 };
     s.count += 1; s.conf += a.confidence;
@@ -65,9 +94,9 @@ export default function AnalystJuryPanel({ analysts }: { analysts: AnalystJuror[
     return acc;
   }, {} as Record<string, { count: number; conf: number }>);
 
-  const totalConf = analysts.reduce((s, a) => s + a.confidence, 0);
+  const totalConf = liveAnalysts.reduce((s, a) => s + a.confidence, 0);
   const weightedScore = totalConf
-    ? analysts.reduce((s, a) => s + (RATING_SCORE[a.rating] ?? 0) * a.confidence, 0) / totalConf
+    ? liveAnalysts.reduce((s, a) => s + (RATING_SCORE[a.rating] ?? 0) * a.confidence, 0) / totalConf
     : 0;
   const fallbackBucket = scoreToRating(weightedScore);
 
@@ -77,34 +106,64 @@ export default function AnalystJuryPanel({ analysts }: { analysts: AnalystJuror[
     (a[0] === fallbackBucket ? -1 : b[0] === fallbackBucket ? 1 : 0), // then weighted avg
   )[0]?.[0] ?? fallbackBucket;
 
-  const ratingCounts: Record<string, number> = { [consensus]: bucketStats[consensus]?.count ?? analysts.length };
-  const avgConf = Math.round(totalConf / Math.max(analysts.length, 1));
+  const ratingCounts: Record<string, number> = { [consensus]: bucketStats[consensus]?.count ?? liveAnalysts.length };
+  const avgConf = Math.round(totalConf / Math.max(liveAnalysts.length, 1));
   return (
     <Stack spacing={1.5}>
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: 0.5 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: 0.5, gap: 1 }}>
         <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, fontSize: '1rem' }}>
           <Scale size={18} /> Analyst Jury
         </Typography>
-        <Box sx={{
-          px: 1.2, py: 0.3, borderRadius: 1,
-          background: ratingColor(consensus).bg,
-          border: `1px solid ${ratingColor(consensus).text}44`,
-          display: 'flex', alignItems: 'center', gap: 0.6,
-        }}>
-          <Typography sx={{ fontSize: '0.62rem', fontWeight: 900, color: ratingColor(consensus).text, letterSpacing: '0.07em' }}>
-            {consensus.toUpperCase()}
-          </Typography>
-          <Typography sx={{ fontSize: '0.56rem', opacity: 0.55, color: ratingColor(consensus).text }}>
-            {avgConf}%
-          </Typography>
-          <Typography sx={{ fontSize: '0.5rem', opacity: 0.35, color: ratingColor(consensus).text, fontFamily: 'monospace' }}>
-            {ratingCounts[consensus] ?? analysts.length}/{analysts.length}
-          </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          {symbol && (
+            <Tooltip title="Re-run the jury with live tools (VIX, put/call ratio, insider flow, macro). Each analyst must consult at least one before deciding.">
+              <span>
+                <Button
+                  size="small"
+                  onClick={handleReanalyze}
+                  disabled={reanalyzing}
+                  startIcon={reanalyzing
+                    ? <CircularProgress size={12} sx={{ color: 'inherit' }} />
+                    : <Wrench size={12} />}
+                  sx={{
+                    fontSize: '0.55rem', fontWeight: 800, letterSpacing: '0.05em',
+                    py: 0.2, px: 1, minWidth: 0, textTransform: 'uppercase',
+                    color: '#00f2ff', border: '1px solid #00f2ff44', borderRadius: 1,
+                    '&:hover': { border: '1px solid #00f2ff88', background: '#00f2ff11' },
+                  }}
+                >
+                  {reanalyzing ? 'Analyzing' : reanalyzed ? 'Re-run tools' : 'Use tools'}
+                </Button>
+              </span>
+            </Tooltip>
+          )}
+          <Box sx={{
+            px: 1.2, py: 0.3, borderRadius: 1,
+            background: ratingColor(consensus).bg,
+            border: `1px solid ${ratingColor(consensus).text}44`,
+            display: 'flex', alignItems: 'center', gap: 0.6,
+          }}>
+            <Typography sx={{ fontSize: '0.62rem', fontWeight: 900, color: ratingColor(consensus).text, letterSpacing: '0.07em' }}>
+              {consensus.toUpperCase()}
+            </Typography>
+            <Typography sx={{ fontSize: '0.56rem', opacity: 0.55, color: ratingColor(consensus).text }}>
+              {avgConf}%
+            </Typography>
+            <Typography sx={{ fontSize: '0.5rem', opacity: 0.35, color: ratingColor(consensus).text, fontFamily: 'monospace' }}>
+              {ratingCounts[consensus] ?? liveAnalysts.length}/{liveAnalysts.length}
+            </Typography>
+          </Box>
         </Box>
       </Box>
 
+      {reanalyzeError && (
+        <Typography sx={{ fontSize: '0.6rem', color: '#ff0055', opacity: 0.8, px: 0.5 }}>
+          {reanalyzeError}
+        </Typography>
+      )}
+
       <Grid container spacing={1.5}>
-        {analysts.map((analyst) => {
+        {liveAnalysts.map((analyst) => {
           const rc = ratingColor(analyst.rating);
           return (
             <Grid size={{ xs: 12, sm: 4 }} key={analyst.id}>

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -44,6 +44,7 @@ export interface AnalystJuror {
   note:        string;
   confidence:  number;
   model:       string;
+  tools_used?: string[];
 }
 
 export interface MonteCarloPriceRangeDay {


### PR DESCRIPTION
## What & why

Feature 3: the LLM analyst jury can now **call live-data tools during analysis** (Groq OpenAI-compatible function calling) instead of relying solely on the static market-context string. Each analyst decides which tools to invoke, fetches fresh signals, and folds them into its verdict.

Four tools are defined in `JURY_TOOLS`:

| Tool | Returns | Source |
|------|---------|--------|
| `get_vix` | VIX level + 30d change + regime | `^VIX` |
| `get_put_call_ratio` | put/call ratio (OI + volume) + signal | nearest-expiry options chain |
| `get_insider_flow` | insider buy/sell counts (last 90d) | `insider_transactions` |
| `get_macro_snapshot` | 10Y/5Y yields, fed-funds proxy, yield curve + inversion | `^TNX` / `^FVX` / `^IRX` |

All dispatchers are backed by **free yfinance feeds — no paid APIs** (free-tier constraint honored).

## How it works

- **`backend/jury_graph.py`** — adds `JURY_TOOLS`, yfinance-backed dispatchers, and `make_tool_dispatcher(symbol)`. The dispatcher is built once per request and **memoizes** results so the 3 parallel analysts don't re-fetch the same market-wide data. Symbol-bearing tools force the request symbol over any model-supplied ticker (guards against ticker hallucination). Blocking yfinance work runs in `asyncio.to_thread`; tool failures are non-fatal.
- **`backend/services.py`** — new `call_groq_with_tools()` on `AnalystJuryService`: an agentic loop that sends `tools` with `tool_choice=auto`, executes returned `tool_calls`, appends `role=tool` results, and re-sends — **capped at 2 tool rounds** then a forced no-tools final turn to guarantee a JSON verdict. Adds `_post_groq_raw()` (full-body POST exposing `tool_calls`). `get_analyst_verdict()` takes optional `tools`/`tool_dispatcher` and verdicts now carry `tools_used`.
- **`backend/routers/predict.py`** — threads `symbol` into `run_jury_graph(...)`; jury wrapped in a **30s** timeout (up from effectively ~20s) to absorb tool round-trips, and the overall `/predict` budget raised 50s→60s so the wider jury budget isn't clipped.
- **Frontend** — `AnalystJuror` gains optional `tools_used`; `AnalystJuryPanel.tsx` renders a `🔧 Used: macro snapshot, put/call ratio` footnote under each card only when tools were invoked.

## Reviewer notes

- Each analyst node stays isolated — a tool or Groq failure still degrades to Hold/25, never a 500.
- The dispatcher cache is per-request (no global state); concurrent duplicate fetches across the 3 nodes collapse to one call.
- `get_macro_snapshot` marks CPI as unavailable (no free real-time source via yfinance); other macro fields are best-effort with per-field fallback.

## Verification

- **54 backend tests pass** on the 3.14-compatible suite (incl. all 22 router tests). `test_new_services.py` excluded — pre-existing 3.14 harness issue, not a product change.
- **ruff clean** on all changed backend files; **ESLint clean** (3 remaining warnings are pre-existing in MonteCarlo components, untouched).
- Mock-driven check confirmed dispatcher caching/symbol-override, the 2-round agentic loop returning `tools_used`, and `get_analyst_verdict` surfacing tools end-to-end.
- Not done: live browser screenshot of the footnote — it only renders when the real Groq jury actually invokes a tool (needs full stack + Groq key + non-deterministic LLM tool use). The render path is trivial and lint-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Analysts can now use financial data tools (VIX, put/call ratios, insider flow, macro yields) to inform verdicts.
  * Added "Re-analyze with Tools" endpoint to re-run jury analysis with tool-calling enabled.
  * Tool usage is now displayed in each analyst verdict card.

* **Improvements**
  * Increased prediction timeout from 50s to 60s for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->