### PR TITLE
Chart: zoom/pan on all time ranges; remove classic view

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -807,6 +807,7 @@ def run_ensemble_forecast(
             predicted = round(last_price * (1 + (vol * 0.3 * (1 if i % 2 == 0 else -0.5))), 2)
             days.append({
                 "date":           dt.strftime("%m/%d"),
+                "time":           int(dt.timestamp()),
                 "predicted":      predicted,
                 "high":           round(predicted * (1 + vol), 2),
                 "low":            round(predicted * (1 - vol), 2),
@@ -891,6 +892,7 @@ def run_ensemble_forecast(
             dt = datetime.now(timezone.utc) + timedelta(days=i)
             days.append({
                 "date":           dt.strftime("%m/%d"),
+                "time":           int(dt.timestamp()),
                 "predicted":      round(last_price * (1 + vol * 0.1 * i * 0.3), 2),
                 "high":           round(last_price * (1 + vol * i * 0.4), 2),
                 "low":            round(last_price * (1 - vol * i * 0.4), 2),
@@ -1009,6 +1011,7 @@ def run_ensemble_forecast(
         dt = datetime.now(timezone.utc) + timedelta(days=i + 1)
         days.append({
             "date":           dt.strftime("%m/%d"),
+            "time":           int(dt.timestamp()),
             "predicted":      round(predicted, 2),
             "high":           day_high,
             "low":            day_low,

--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -215,10 +215,16 @@ async def get_history(
     else:
         dates = [ts.strftime("%Y-%m-%d") for ts in df.index]
 
+    # Real UNIX epoch (seconds, UTC) per bar — fed straight to the lightweight-
+    # charts time scale so the zoom chart works on every range (incl. intraday),
+    # without reconstructing a calendar date from the display string.
+    times = [int(ts.timestamp()) for ts in df.index]
+
     history_bars: list[dict] = []
     for i, date in enumerate(dates):
         bar: dict[str, Any] = {
             "date":        date,
+            "time":        times[i],
             "price":       round(closes[i], 4),
             "open":        round(opens[i],  4),
             "high":        round(highs[i],  4),

--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -195,6 +195,14 @@ async def get_history(
     opens   = [float(v) for v in df["Open"].tolist()]   if "Open"   in df.columns else list(closes)
     volumes = [int(v)   for v in df["Volume"].tolist()] if "Volume" in df.columns else [0] * len(closes)
 
+    # InfluxDB stores intraday live-price snapshots (close-only) alongside daily
+    # OHLC bars; those snapshot rows arrive with open/high/low == 0 and would
+    # render as candlesticks spanning from $0. Coalesce any non-positive OHLC to
+    # the close so every bar is a valid candle (a flat doji for snapshot rows).
+    opens = [o if o > 0 else c for o, c in zip(opens, closes)]
+    highs = [h if h > 0 else c for h, c in zip(highs, closes)]
+    lows  = [low if low > 0 else c for low, c in zip(lows, closes)]
+
     bb       = calculate_bollinger_bands(closes)
     macd_d   = calculate_macd(closes)
     rsi_s    = calculate_rsi_series(closes)

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -1306,6 +1306,7 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
     for idx, p in enumerate(historical_prices[slice_start:], start=slice_start):
         history.append({
             "date":        p["_time"].strftime("%m/%d") if hasattr(p["_time"], "strftime") else str(p["_time"])[:10],
+            "time":        int(p["_time"].timestamp()) if hasattr(p["_time"], "timestamp") else None,
             "price":       round(float(p["close"]),                 2),
             "open":        round(float(p.get("open",  p["close"])), 2),
             "high":        round(float(p.get("high",  p["close"])), 2),

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -66,7 +66,6 @@ export default function QuantumDashboard() {
   const [error,            setError]            = useState<string | null>(null);
   const [indicators,       setIndicators]       = useState<IndicatorKey[]>(['bb', 'sma']);
   const [chartMode,        setChartMode]        = useState<'line' | 'candle'>('line');
-  const [chartEngine,      setChartEngine]      = useState<'classic' | 'pro'>('classic');
   const [tradeSetup,       setTradeSetup]       = useState<TradeSetupResponse | null>(null);
   const [tradeSetupLoading, setTradeSetupLoading] = useState(false);
   const [optionsData,      setOptionsData]      = useState<OptionsChainResult | null>(null);
@@ -323,8 +322,6 @@ export default function QuantumDashboard() {
                     setIndicators={setIndicators}
                     chartMode={chartMode}
                     setChartMode={setChartMode}
-                    chartEngine={chartEngine}
-                    setChartEngine={setChartEngine}
                     isDark={isDark}
                     primaryColor={primaryColor}
                     trendColor={trendColor}

--- a/frontend/components/AdvancedChart.tsx
+++ b/frontend/components/AdvancedChart.tsx
@@ -24,6 +24,7 @@ export type IndicatorKey = 'bb' | 'sma' | 'ema' | 'macd' | 'rsi' | 'volume';
 
 export interface AdvHistoryPoint {
   date: string;
+  time?: number;   // UNIX epoch seconds (UTC) — preferred over `date` when present
   price: number;
   open?: number;
   high?: number;
@@ -43,6 +44,7 @@ export interface AdvHistoryPoint {
 
 export interface AdvForecastPoint {
   date: string;
+  time?: number;   // UNIX epoch seconds (UTC)
   predicted: number;
   high: number;
   low: number;
@@ -59,6 +61,7 @@ interface Props {
   trendColor: string;
   support?: number[];
   resistance?: number[];
+  intraday?: boolean;   // show HH:MM on the time axis (1D/5D/1M ranges)
 }
 
 /**
@@ -120,6 +123,7 @@ export default function AdvancedChart({
   trendColor,
   support = [],
   resistance = [],
+  intraday = false,
 }: Props) {
   const priceRef   = useRef<HTMLDivElement>(null);
   const volumeRef  = useRef<HTMLDivElement>(null);
@@ -134,11 +138,25 @@ export default function AdvancedChart({
     let handlers: Array<() => void> = [];
 
     try {
-    const allDates = [
-      ...history.map(h => h.date),
-      ...forecast.map(f => f.date),
-    ];
-    const { histTimes, foreTimes } = buildTimestamps(allDates, history.length);
+    // Prefer real epoch timestamps from the backend (works for every range
+    // incl. intraday). Fall back to MM/DD reconstruction only if any bar is
+    // missing `time` (e.g. a stale cached payload mid-rollout).
+    const haveEpoch =
+      history.every(h => typeof h.time === 'number') &&
+      forecast.every(f => typeof f.time === 'number');
+
+    let histTimes: UTCTimestamp[];
+    let foreTimes: UTCTimestamp[];
+    if (haveEpoch) {
+      histTimes = history.map(h => h.time as UTCTimestamp);
+      foreTimes = forecast.map(f => f.time as UTCTimestamp);
+    } else {
+      const allDates = [
+        ...history.map(h => h.date),
+        ...forecast.map(f => f.date),
+      ];
+      ({ histTimes, foreTimes } = buildTimestamps(allDates, history.length));
+    }
 
     const bg          = isDark ? '#0d1520' : '#ffffff';
     const textColor   = isDark ? 'rgba(220,220,220,0.75)' : 'rgba(20,30,50,0.75)';
@@ -151,7 +169,7 @@ export default function AdvancedChart({
       grid:   { vertLines: { color: gridColor }, horzLines: { color: gridColor } },
       crosshair: { mode: CrosshairMode.Normal },
       rightPriceScale: { borderColor: gridColor },
-      timeScale: { borderColor: gridColor, timeVisible: false, secondsVisible: false },
+      timeScale: { borderColor: gridColor, timeVisible: intraday, secondsVisible: false },
       autoSize: true,
     };
 
@@ -328,7 +346,7 @@ export default function AdvancedChart({
       handlers.forEach(h => h());
       charts.forEach(c => c.remove());
     };
-  }, [history, forecast, rsiSeries, indicators, mode, isDark, primaryColor, trendColor, support, resistance]);
+  }, [history, forecast, rsiSeries, indicators, mode, isDark, primaryColor, trendColor, support, resistance, intraday]);
 
   const paneBorder = isDark ? '1px solid rgba(255,255,255,0.05)' : '1px solid rgba(0,0,0,0.08)';
   const labelStyle: React.CSSProperties = {

--- a/frontend/components/AdvancedChart.tsx
+++ b/frontend/components/AdvancedChart.tsx
@@ -151,11 +151,27 @@ export default function AdvancedChart({
       histTimes = history.map(h => h.time as UTCTimestamp);
       foreTimes = forecast.map(f => f.time as UTCTimestamp);
     } else {
+      // Stale cached payload without epoch `time` (only possible transiently,
+      // within the /history cache TTL right after a deploy). buildTimestamps
+      // understands ONLY MM/DD; ISO (YYYY-MM-DD) or intraday (HH:MM) labels
+      // would reconstruct to NaN and blank the chart. So use buildTimestamps
+      // only for genuine MM/DD data, otherwise synthesize monotonic ascending
+      // timestamps so the chart still renders until the cache refreshes.
       const allDates = [
         ...history.map(h => h.date),
         ...forecast.map(f => f.date),
       ];
-      ({ histTimes, foreTimes } = buildTimestamps(allDates, history.length));
+      const looksMmDd = allDates.every(d => /^\d{1,2}\/\d{1,2}$/.test(d));
+      if (looksMmDd) {
+        ({ histTimes, foreTimes } = buildTimestamps(allDates, history.length));
+      } else {
+        const nowSec = Math.floor(Date.now() / 1000);
+        const synthetic = allDates.map(
+          (_, i) => (nowSec - (allDates.length - 1 - i) * 86_400) as UTCTimestamp,
+        );
+        histTimes = synthetic.slice(0, history.length);
+        foreTimes = synthetic.slice(history.length);
+      }
     }
 
     const bg          = isDark ? '#0d1520' : '#ffffff';

--- a/frontend/components/AdvancedChart.tsx
+++ b/frontend/components/AdvancedChart.tsx
@@ -206,13 +206,18 @@ export default function AdvancedChart({
         upColor, downColor, wickUpColor: upColor, wickDownColor: downColor,
         borderVisible: false,
       });
+      // Some daily bars are close-only snapshots (open/high/low === 0); treat
+      // any non-positive OHLC as the close so they render as a valid doji
+      // instead of a candle spanning from $0.
+      const ohlc = (v: number | null | undefined, close: number) =>
+        typeof v === 'number' && v > 0 ? v : close;
       candles.setData(
         history
           .map((h, i) => ({
             time: histTimes[i],
-            open: (h.open ?? h.price) as number,
-            high: (h.high ?? h.price) as number,
-            low:  (h.low  ?? h.price) as number,
+            open: ohlc(h.open, h.price),
+            high: ohlc(h.high, h.price),
+            low:  ohlc(h.low,  h.price),
             close: h.price,
           }))
           .filter(c => Number.isFinite(c.open) && Number.isFinite(c.close))

--- a/frontend/components/PriceChartCard.tsx
+++ b/frontend/components/PriceChartCard.tsx
@@ -1,20 +1,14 @@
 'use client';
 
-import React, { useState, useMemo, useRef, useEffect, useCallback } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import axios from 'axios';
 import {
   Box, Card, CardContent, Chip, Collapse, CircularProgress, Stack, Typography,
   ToggleButton, ToggleButtonGroup, Button,
 } from '@mui/material';
 import { Info, ChevronDown, ChevronUp } from 'lucide-react';
-import {
-  XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
-  Line, ReferenceLine, ComposedChart, Area, Legend,
-  BarChart, Bar, Cell,
-} from 'recharts';
 import dynamic from 'next/dynamic';
-import VolumeProfile from './VolumeProfile';
-import type { PredictionData, IndicatorKey, ChartEntry, ChartStats, IndicatorSignals, IntervalHistoryData } from '../types';
+import type { PredictionData, IndicatorKey, ChartStats, IndicatorSignals, IntervalHistoryData } from '../types';
 
 const AdvancedChart = dynamic(() => import('./AdvancedChart'), { ssr: false });
 
@@ -29,7 +23,8 @@ const INTERVAL_MAP: Record<string, { period: string; interval: string }> = {
   '2y': { period: '2y',  interval: '1d'  },
 } as const;
 
-const CHART_HEIGHT = 380;
+// Ranges whose bars are intraday (5m/15m/1h) — show HH:MM on the time axis.
+const INTRADAY_RANGES = new Set(['1d', '5d', '1m']);
 
 interface Props {
   prediction:      PredictionData;
@@ -38,8 +33,6 @@ interface Props {
   setIndicators:   (v: IndicatorKey[]) => void;
   chartMode:       'line' | 'candle';
   setChartMode:    (v: 'line' | 'candle') => void;
-  chartEngine:     'classic' | 'pro';
-  setChartEngine:  (v: 'classic' | 'pro') => void;
   isDark:          boolean;
   primaryColor:    string;
   trendColor:      string;
@@ -49,7 +42,7 @@ interface Props {
 
 export default function PriceChartCard({
   prediction, symbol, indicators, setIndicators,
-  chartMode, setChartMode, chartEngine, setChartEngine,
+  chartMode, setChartMode,
   isDark, primaryColor, trendColor, chartStats, indicatorSignals,
 }: Props) {
   const [legendOpen,       setLegendOpen]       = useState(false);
@@ -63,9 +56,6 @@ export default function PriceChartCard({
     setSelectedInterval('2y');
     setIntervalData(null);
   }
-  const chartBoxRef = useRef<HTMLDivElement>(null);
-  const [clipBox, setClipBox] = useState<{ l: number; t: number; w: number; h: number } | null>(null);
-
   const fetchIntervalHistory = useCallback((iv: string) => {
     if (iv === '2y') {
       setIntervalData(null);
@@ -118,201 +108,13 @@ export default function PriceChartCard({
     };
   }, [intervalData, selectedInterval, chartStats, prediction.modelStats, isDark]);
 
-  useEffect(() => {
-    if (chartMode !== 'candle') return;
-    const el = chartBoxRef.current;
-    if (!el) return;
-    const measure = () => {
-      const rect = el.querySelector('clipPath rect');
-      if (!rect) return;
-      setClipBox({
-        l: +rect.getAttribute('x')!,
-        t: +rect.getAttribute('y')!,
-        w: +rect.getAttribute('width')!,
-        h: +rect.getAttribute('height')!,
-      });
-    };
-    measure();
-    const id = setTimeout(measure, 50);
-    return () => clearTimeout(id);
-  }, [chartMode, prediction, chartEngine]);
-
-  const chartData = useMemo(() => {
-    const hist = activeHistory.map(h => {
-      const bbU = h.bb_upper ?? undefined;
-      const bbL = h.bb_lower ?? undefined;
-      return {
-        date:      h.date,
-        price:     h.price,
-        bb_upper:  bbU,
-        bb_middle: h.bb_middle ?? undefined,
-        bb_lower:  bbL,
-        bb_band:   bbU != null && bbL != null ? bbU - bbL : undefined,
-        sma50:     h.sma50  ?? undefined,
-        sma200:    h.sma200 ?? undefined,
-        ema20:     h.ema20  ?? undefined,
-        ema50:     h.ema50  ?? undefined,
-        vwap:      (h as any).vwap ?? undefined,
-        predicted: undefined as number | undefined,
-        foreHigh:  undefined as number | undefined,
-        foreLow:   undefined as number | undefined,
-        fore_band: undefined as number | undefined,
-      };
-    });
-    // Forecast days only shown on 2Y (they come from prediction, not interval fetch)
-    const fore = selectedInterval === '2y'
-      ? (prediction.forecastDays || []).map(f => ({
-          date:      f.date,
-          price:     undefined as number | undefined,
-          bb_upper:  undefined, bb_middle: undefined, bb_lower: undefined, bb_band: undefined,
-          sma50:     undefined, sma200:    undefined, ema20: undefined, ema50: undefined,
-          vwap:      undefined,
-          predicted: f.predicted,
-          foreHigh:  f.high,
-          foreLow:   f.low,
-          fore_band: f.high != null && f.low != null ? f.high - f.low : undefined,
-        }))
-      : [];
-    return [...hist, ...fore];
-  }, [activeHistory, prediction.forecastDays, selectedInterval]);
-
-  const candleChartData = useMemo(() => {
-    const hist = activeHistory.map(h => {
-      const bbU = h.bb_upper ?? undefined;
-      const bbL = h.bb_lower ?? undefined;
-      return {
-        date:      h.date,
-        open:      h.open  ?? h.price,
-        high:      h.high  ?? h.price,
-        low:       h.low   ?? h.price,
-        close:     h.price,
-        bb_upper:  bbU,
-        bb_middle: h.bb_middle ?? undefined,
-        bb_lower:  bbL,
-        bb_band:   bbU != null && bbL != null ? bbU - bbL : undefined,
-        sma50:     h.sma50  ?? undefined,
-        sma200:    h.sma200 ?? undefined,
-        ema20:     h.ema20  ?? undefined,
-        ema50:     h.ema50  ?? undefined,
-        vwap:      (h as any).vwap ?? undefined,
-        predicted: undefined as number | undefined,
-        foreHigh:  undefined as number | undefined,
-        foreLow:   undefined as number | undefined,
-        fore_band: undefined as number | undefined,
-      };
-    });
-    const fore = selectedInterval === '2y'
-      ? (prediction.forecastDays || []).map(f => ({
-          date: f.date, open: undefined as number | undefined,
-          high: undefined as number | undefined, low: undefined as number | undefined,
-          close: undefined as number | undefined,
-          bb_upper: undefined, bb_middle: undefined, bb_lower: undefined, bb_band: undefined,
-          sma50: undefined, sma200: undefined, ema20: undefined, ema50: undefined,
-          vwap: undefined,
-          predicted: f.predicted, foreHigh: f.high, foreLow: f.low,
-          fore_band: f.high != null && f.low != null ? f.high - f.low : undefined,
-        }))
-      : [];
-    return [...hist, ...fore];
-  }, [activeHistory, prediction.forecastDays, selectedInterval]);
-
-  const macdData = useMemo(() =>
-    activeHistory.map(h => ({
-      date:   h.date,
-      macd:   h.macd        ?? null,
-      signal: h.macd_signal ?? null,
-      hist:   h.macd_hist   ?? null,
-    }))
-  , [activeHistory]);
-
-  const rsiData = useMemo(() => {
-    if (intervalData && selectedInterval !== '2y') {
-      return activeHistory.map((h, i) => ({
-        date: h.date,
-        rsi:  intervalData.rsi_series[i] ?? (h as any).rsi ?? null,
-      }));
-    }
-    const rsiSeries = prediction.indicators?.rsi_series ?? [];
-    return activeHistory.map((h, i) => ({
-      date: h.date,
-      rsi:  rsiSeries[i] ?? null,
-    }));
-  }, [activeHistory, intervalData, selectedInterval, prediction.indicators]);
-
-  const volumeData = useMemo(() =>
-    activeHistory.map(h => ({
-      date:   h.date,
-      volume: h.volume ?? 0,
-    }))
-  , [activeHistory]);
-
-  const chartDomain = useMemo((): [number, number] | ['auto', 'auto'] => {
-    const data = chartMode === 'line' ? chartData : candleChartData;
-    if (!data.length) return ['auto', 'auto'];
-    const allVals = data.flatMap(d => [
-      (d as any).price,    (d as any).predicted, (d as any).foreHigh, (d as any).foreLow,
-      (d as any).open,     (d as any).high,       (d as any).low,      (d as any).close,
-      indicators.includes('bb')  ? (d as any).bb_upper  : undefined,
-      indicators.includes('bb')  ? (d as any).bb_lower  : undefined,
-      indicators.includes('sma') ? (d as any).sma50     : undefined,
-      indicators.includes('sma') ? (d as any).sma200    : undefined,
-      indicators.includes('ema') ? (d as any).ema20     : undefined,
-      indicators.includes('ema') ? (d as any).ema50     : undefined,
-    ].filter((v): v is number => v !== undefined && v !== null));
-    if (!allVals.length) return ['auto', 'auto'];
-    const min = Math.min(...allVals);
-    const max = Math.max(...allVals);
-    const pad = (max - min) * 0.12 || max * 0.02;
-    return [min - pad, max + pad];
-  }, [chartData, candleChartData, chartMode, indicators]);
-
-  // Detect notable trading days: large price moves (>1.5σ) or volume spikes (>2× median)
-  const eventMarkers = useMemo(() => {
-    const hist = activeHistory;
-    if (hist.length < 10) return [];
-
-    const returns = hist.slice(1).map((h, i) => (h.price - hist[i].price) / hist[i].price);
-    const mu  = returns.reduce((s, r) => s + r, 0) / returns.length;
-    const sig = Math.sqrt(returns.reduce((s, r) => s + (r - mu) ** 2, 0) / returns.length);
-
-    const vols = hist.map(h => h.volume ?? 0).filter(v => v > 0);
-    const medVol = vols.length ? [...vols].sort((a, b) => a - b)[Math.floor(vols.length / 2)] : 0;
-
-    const events: { date: string; type: 'up' | 'down' | 'volume'; label: string; pct: number; z: number }[] = [];
-    returns.forEach((ret, i) => {
-      const h      = hist[i + 1];
-      const zScore = sig > 0 ? Math.abs(ret - mu) / sig : 0;
-      const volMult = medVol > 0 ? (h.volume ?? 0) / medVol : 0;
-      const volSpike = volMult > 2.2;
-      if (zScore >= 1.5 || volSpike) {
-        const isUp   = ret > 0;
-        const pctVal = ret * 100;
-        // Short label: "▲+7.9%" or "◆vol×3.1" to avoid overflow
-        const label  = zScore >= 1.5
-          ? `${isUp ? '+' : ''}${pctVal.toFixed(1)}%`
-          : `vol×${volMult.toFixed(1)}`;
-        events.push({ date: h.date, type: volSpike && zScore < 1.5 ? 'volume' : isUp ? 'up' : 'down', label, pct: pctVal, z: zScore });
-      }
-    });
-
-    // Sort by significance, deduplicate events closer than 5 trading days, keep top 5
-    const sorted = events.sort((a, b) => Math.abs(b.z) - Math.abs(a.z));
-    const kept: typeof events = [];
-    for (const ev of sorted) {
-      const tooClose = kept.some(k => Math.abs(hist.findIndex(h => h.date === ev.date) - hist.findIndex(h => h.date === k.date)) < 5);
-      if (!tooClose) kept.push(ev);
-      if (kept.length >= 5) break;
-    }
-    return kept;
-  }, [activeHistory]);
-
-  const SERIES_LABEL_MAP: Record<string, string> = {
-    price: 'Close', close: 'Close (OHLC)', predicted: 'Forecast',
-    foreHigh: 'Fore. High', foreLow: 'Fore. Low',
-    bb_upper: 'BB Upper', bb_middle: 'BB Mid', bb_lower: 'BB Lower',
-    sma50: 'SMA 50', sma200: 'SMA 200', ema20: 'EMA 20', ema50: 'EMA 50',
-    vwap: 'VWAP',
-  };
+  // Range-aware data for the always-on AdvancedChart (lightweight-charts).
+  // Forecast / support / resistance only apply to the native 2Y view.
+  const isTwoYear = selectedInterval === '2y';
+  const intraday  = INTRADAY_RANGES.has(selectedInterval);
+  const rsiSeries = isTwoYear
+    ? (prediction.indicators?.rsi_series ?? [])
+    : (intervalData?.rsi_series ?? []);
 
   const toggleSx = {
     '& .MuiToggleButton-root': {
@@ -418,12 +220,6 @@ export default function PriceChartCard({
             <ToggleButton value="line">LINE</ToggleButton>
             <ToggleButton value="candle">CANDLE</ToggleButton>
           </ToggleButtonGroup>
-          <ToggleButtonGroup exclusive aria-label="chart-engine" value={chartEngine}
-            onChange={(_e, val) => val && setChartEngine(val)} size="small" sx={toggleSx}
-          >
-            <ToggleButton value="classic">CLASSIC</ToggleButton>
-            <ToggleButton value="pro">PRO (ZOOM)</ToggleButton>
-          </ToggleButtonGroup>
         </Box>
 
         {/* Indicators Guide (collapsible) */}
@@ -505,282 +301,34 @@ export default function PriceChartCard({
           </Collapse>
         </Box>
 
-        {/* AdvancedChart (PRO) only works for 2Y — its buildTimestamps parses MM/DD strings
-            which is the format prediction.history uses. Interval bars use different formats. */}
-        {chartEngine === 'pro' && selectedInterval === '2y' ? (
+        {/* Unified interactive chart (lightweight-charts) for EVERY range.
+            The backend now supplies a real epoch `time` per bar, so zoom/pan
+            works on intraday and daily ranges alike — no MM/DD reconstruction. */}
+        <Box sx={{ position: 'relative' }}>
+          {historyLoading && (
+            <Box sx={{
+              position: 'absolute', inset: 0, zIndex: 10, borderRadius: 2,
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              background: isDark ? 'rgba(13,21,32,0.75)' : 'rgba(255,255,255,0.75)',
+              backdropFilter: 'blur(4px)',
+            }}>
+              <CircularProgress size={36} sx={{ color: primaryColor }} />
+            </Box>
+          )}
           <AdvancedChart
             history={activeHistory}
-            forecast={prediction.forecastDays}
-            rsiSeries={prediction.indicators?.rsi_series ?? []}
+            forecast={isTwoYear ? prediction.forecastDays : []}
+            rsiSeries={rsiSeries}
             indicators={indicators}
             mode={chartMode}
             isDark={isDark}
             primaryColor={primaryColor}
             trendColor={trendColor}
-            support={prediction.indicators?.support ?? []}
-            resistance={prediction.indicators?.resistance ?? []}
+            support={isTwoYear ? (prediction.indicators?.support ?? []) : []}
+            resistance={isTwoYear ? (prediction.indicators?.resistance ?? []) : []}
+            intraday={intraday}
           />
-        ) : (<>
-          {/* Main price + overlay chart */}
-          <Box sx={{ display: 'flex', gap: 1, minWidth: 0, position: 'relative' }}>
-            {historyLoading && (
-              <Box sx={{
-                position: 'absolute', inset: 0, zIndex: 10, borderRadius: 2,
-                display: 'flex', alignItems: 'center', justifyContent: 'center',
-                background: isDark ? 'rgba(13,21,32,0.75)' : 'rgba(255,255,255,0.75)',
-                backdropFilter: 'blur(4px)',
-              }}>
-                <CircularProgress size={36} sx={{ color: primaryColor }} />
-              </Box>
-            )}
-            <Box ref={chartBoxRef} sx={{ height: 380, position: 'relative', flex: 1, minWidth: 0 }}>
-              <ResponsiveContainer width="100%" height="100%">
-                <ComposedChart data={(chartMode === 'line' ? chartData : candleChartData) as ChartEntry[]} margin={{ top: 5, right: 10, bottom: 5, left: 10 }}>
-                  <defs>
-                    <linearGradient id="histGrad" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="5%"  stopColor={trendColor} stopOpacity={0.35} />
-                      <stop offset="95%" stopColor={trendColor} stopOpacity={0}    />
-                    </linearGradient>
-                    <linearGradient id="foreGrad" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="5%"  stopColor="#bc13fe" stopOpacity={0.25} />
-                      <stop offset="95%" stopColor="#bc13fe" stopOpacity={0}    />
-                    </linearGradient>
-                    <linearGradient id="bbGrad" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="5%"  stopColor={primaryColor} stopOpacity={0.08} />
-                      <stop offset="95%" stopColor={primaryColor} stopOpacity={0.02} />
-                    </linearGradient>
-                  </defs>
-
-                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(128,128,128,0.1)" vertical={false} />
-                  <XAxis dataKey="date" stroke="rgba(128,128,128,0.2)" tick={{ fill: 'rgba(128,128,128,0.5)', fontSize: 10 }} tickLine={false} axisLine={false} />
-                  <YAxis domain={chartDomain} stroke="rgba(128,128,128,0.2)" tick={{ fill: 'rgba(128,128,128,0.5)', fontSize: 10 }} tickLine={false} axisLine={false} width={65}
-                    tickFormatter={(v: number) => v >= 1000 ? `$${(v/1000).toFixed(1)}k` : v >= 1 ? `$${v.toFixed(1)}` : `$${v.toFixed(4)}`}
-                  />
-                  <Tooltip
-                    contentStyle={{ background: isDark ? '#0d1520' : '#fff', border: `1px solid ${primaryColor}4d`, borderRadius: 10, fontSize: 12 }}
-                    formatter={(value: any, name: string) => {
-                      if (name === 'bb_band' || name === 'fore_band') return null;
-                      const v = Number(value);
-                      const fmt = v >= 1000 ? `$${(v / 1000).toFixed(1)}k`
-                                : v >= 1    ? `$${v.toFixed(2)}`
-                                :             `$${v.toFixed(4)}`;
-                      return [fmt, SERIES_LABEL_MAP[name] ?? name];
-                    }}
-                    labelStyle={{ opacity: 0.5, fontSize: 11 }}
-                  />
-                  <Legend wrapperStyle={{ fontSize: '0.65rem', opacity: 0.6, paddingTop: 8 }}
-                    formatter={(value) => SERIES_LABEL_MAP[value] ?? value}
-                  />
-
-                  {activeStats?.sma20 != null && Number.isFinite(activeStats.sma20) && (
-                    <ReferenceLine y={activeStats.sma20} stroke="#f59e0b" strokeDasharray="4 4" strokeOpacity={0.5}
-                      label={{ value: `SMA20 $${Number(activeStats.sma20).toFixed(2)}`, fill: '#f59e0b', fontSize: 9, position: 'insideTopRight' }}
-                    />
-                  )}
-
-                  {(prediction.indicators?.support ?? []).map((lvl, i) => (
-                    <ReferenceLine key={`sup-${i}`} y={lvl} stroke="#00ffa3" strokeDasharray="6 3" strokeOpacity={0.7} strokeWidth={1.2}
-                      label={{ value: `S $${lvl}`, fill: '#00ffa3', fontSize: 9, position: 'insideBottomRight' }}
-                    />
-                  ))}
-
-                  {(prediction.indicators?.resistance ?? []).map((lvl, i) => (
-                    <ReferenceLine key={`res-${i}`} y={lvl} stroke="#ff0055" strokeDasharray="6 3" strokeOpacity={0.7} strokeWidth={1.2}
-                      label={{ value: `R $${lvl}`, fill: '#ff0055', fontSize: 9, position: 'insideTopRight' }}
-                    />
-                  ))}
-
-                  {/* Event markers — large moves / volume spikes */}
-                  {eventMarkers.map((ev, i) => {
-                    const color  = ev.type === 'up' ? '#00ffa3' : ev.type === 'down' ? '#ff0055' : '#f59e0b';
-                    const symbol = ev.type === 'up' ? '▲' : ev.type === 'down' ? '▼' : '◆';
-                    // Stagger label y so clustered markers don't collide
-                    const yOffset = 8 + (i % 3) * 14;
-                    return (
-                      <ReferenceLine
-                        key={`ev-${i}`}
-                        x={ev.date}
-                        stroke={color}
-                        strokeWidth={1}
-                        strokeOpacity={0.4}
-                        strokeDasharray="2 4"
-                        label={({ viewBox }: any) => {
-                          const { x, y } = viewBox;
-                          return (
-                            <text
-                              x={x + 3}
-                              y={(y ?? 0) + yOffset}
-                              fill={color}
-                              fontSize={8}
-                              opacity={0.9}
-                              style={{ pointerEvents: 'none', userSelect: 'none' }}
-                            >
-                              {symbol}{ev.label}
-                            </text>
-                          );
-                        }}
-                      />
-                    );
-                  })}
-
-                  {/* Earnings date markers */}
-                  {(prediction.earningsDates ?? []).map((d, i) => (
-                    <ReferenceLine
-                      key={`earn-${i}`}
-                      x={d}
-                      stroke="#facc15"
-                      strokeWidth={1.5}
-                      strokeDasharray="3 3"
-                      strokeOpacity={0.8}
-                      label={({ viewBox }: any) => {
-                        const { x, y } = viewBox;
-                        return (
-                          <text x={x + 3} y={(y ?? 0) + 10} fill="#facc15" fontSize={8} opacity={0.9}
-                            style={{ pointerEvents: 'none', userSelect: 'none' }}>
-                            📅E
-                          </text>
-                        );
-                      }}
-                    />
-                  ))}
-
-                  {indicators.includes('bb') && <>
-                    <Line  type="monotone" dataKey="bb_lower"  stroke={primaryColor} strokeWidth={1} strokeDasharray="3 2" strokeOpacity={0.5} dot={false} connectNulls isAnimationActive={false} />
-                    <Line  type="monotone" dataKey="bb_upper"  stroke={primaryColor} strokeWidth={1} strokeDasharray="3 2" strokeOpacity={0.5} dot={false} connectNulls isAnimationActive={false} />
-                    <Line  type="monotone" dataKey="bb_middle" stroke={primaryColor} strokeWidth={1} strokeDasharray="5 3" strokeOpacity={0.4} dot={false} connectNulls isAnimationActive={false} />
-                  </>}
-
-                  {indicators.includes('sma') && <>
-                    <Line type="monotone" dataKey="sma50"  stroke="#f97316" strokeWidth={1.5} dot={false} connectNulls isAnimationActive={false} />
-                    <Line type="monotone" dataKey="sma200" stroke="#a855f7" strokeWidth={1.5} dot={false} connectNulls isAnimationActive={false} />
-                  </>}
-
-                  {indicators.includes('ema') && <>
-                    <Line type="monotone" dataKey="ema20" stroke="#06b6d4" strokeWidth={1.5} strokeDasharray="4 2" dot={false} connectNulls isAnimationActive={false} />
-                    <Line type="monotone" dataKey="ema50" stroke="#f43f5e" strokeWidth={1.5} strokeDasharray="4 2" dot={false} connectNulls isAnimationActive={false} />
-                  </>}
-
-                  {/* VWAP — present for all intraday intervals (1d/5d/1m) */}
-                  {(selectedInterval === '1d' || selectedInterval === '5d' || selectedInterval === '1m') && intervalData && (
-                    <Line type="monotone" dataKey="vwap" stroke="#facc15" strokeWidth={1.5} strokeDasharray="6 2" dot={false} connectNulls isAnimationActive={false} />
-                  )}
-
-                  {chartMode === 'line' && (
-                    <Area type="monotone" dataKey="price" stroke={trendColor} strokeWidth={2.5} fill="url(#histGrad)" dot={false} connectNulls={false} activeDot={{ r: 4, strokeWidth: 0 }} isAnimationActive={false} />
-                  )}
-
-                  <Line type="monotone" dataKey="foreLow"  stroke="rgba(188,19,254,0.4)" strokeWidth={1}   strokeDasharray="5 3" dot={false} connectNulls={false} isAnimationActive={false} legendType="none" />
-                  <Line type="monotone" dataKey="foreHigh" stroke="rgba(188,19,254,0.5)" strokeWidth={1.5} strokeDasharray="5 3" dot={false} connectNulls={false} isAnimationActive={false} />
-                  <Line type="monotone" dataKey="predicted" stroke="#bc13fe" strokeWidth={2} strokeDasharray="6 3"
-                    dot={{ r: 4, fill: '#bc13fe', strokeWidth: 0 }} connectNulls={false} isAnimationActive={false} />
-                </ComposedChart>
-              </ResponsiveContainer>
-
-              {/* Candlestick SVG overlay */}
-              {chartMode === 'candle' && chartDomain[0] !== 'auto' && (() => {
-                const plotL = clipBox?.l ?? 0;
-                const plotT = clipBox?.t ?? 0;
-                const plotW = clipBox?.w ?? 0;
-                const plotH = clipBox?.h ?? 0;
-                if (!plotW || !plotH) return null;
-                const [dMin, dMax] = chartDomain as [number, number];
-                const pRange  = dMax - dMin;
-                const total   = candleChartData.length;
-                const slotW   = plotW / total;
-                const toY = (p: number) => plotT + (1 - (p - dMin) / pRange) * plotH;
-                const toX = (i: number) => plotL + (i + 0.5) * slotW;
-                return (
-                  <svg style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: CHART_HEIGHT, pointerEvents: 'none' }}>
-                    {candleChartData.map((d: any, i: number) => {
-                      if (d.close == null || d.open == null) return null;
-                      const isUp  = d.close >= d.open;
-                      const color = isUp ? '#00ffa3' : '#ff0055';
-                      const cx    = toX(i);
-                      const hw    = Math.max(slotW * 0.38, 1);
-                      const yO    = toY(d.open);
-                      const yC    = toY(d.close);
-                      return (
-                        <g key={i}>
-                          <line x1={cx} y1={toY(d.high)} x2={cx} y2={toY(d.low)} stroke={color} strokeWidth={1} opacity={0.75} />
-                          <rect x={cx - hw} y={Math.min(yO, yC)} width={hw * 2} height={Math.max(Math.abs(yC - yO), 1)}
-                            fill={isUp ? 'transparent' : color} stroke={color} strokeWidth={1.2} />
-                        </g>
-                      );
-                    })}
-                  </svg>
-                );
-              })()}
-            </Box>
-            <VolumeProfile history={activeHistory.map(h => ({ price: h.price, high: h.high, low: h.low, volume: h.volume }))} isDark={isDark} height={380} />
-          </Box>
-
-          {/* MACD sub-chart */}
-          {indicators.includes('macd') && macdData.length > 0 && (
-            <Box sx={{ mt: 2 }}>
-              <Typography variant="caption" sx={{ opacity: 0.4, letterSpacing: 2, display: 'block', mb: 1 }}>MACD (12, 26, 9)</Typography>
-              <Box sx={{ height: 120 }}>
-                <ResponsiveContainer width="100%" height="100%">
-                  <ComposedChart data={macdData} margin={{ top: 0, right: 10, bottom: 0, left: 10 }}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="rgba(128,128,128,0.08)" vertical={false} />
-                    <XAxis dataKey="date" hide />
-                    <YAxis width={45} tick={{ fill: 'rgba(128,128,128,0.4)', fontSize: 9 }} tickLine={false} axisLine={false} />
-                    <Tooltip contentStyle={{ background: isDark ? '#0d1520' : '#fff', border: `1px solid ${primaryColor}33`, borderRadius: 8, fontSize: 11 }}
-                      formatter={(v: any, name: string) => [Number(v).toFixed(3), name === 'hist' ? 'Histogram' : name === 'macd' ? 'MACD' : 'Signal']} />
-                    <Bar dataKey="hist" isAnimationActive={false}>
-                      {macdData.map((entry, i) => (
-                        <Cell key={i} fill={(entry.hist ?? 0) >= 0 ? (isDark ? '#00ffa3' : '#16a34a') : (isDark ? '#ff0055' : '#dc2626')} fillOpacity={0.7} />
-                      ))}
-                    </Bar>
-                    <Line type="monotone" dataKey="macd"   stroke={primaryColor} strokeWidth={1.5} dot={false} connectNulls isAnimationActive={false} />
-                    <Line type="monotone" dataKey="signal" stroke="#f59e0b"      strokeWidth={1.5} dot={false} connectNulls isAnimationActive={false} />
-                  </ComposedChart>
-                </ResponsiveContainer>
-              </Box>
-            </Box>
-          )}
-
-          {/* RSI sub-chart */}
-          {indicators.includes('rsi') && rsiData.length > 0 && (
-            <Box sx={{ mt: 2 }}>
-              <Typography variant="caption" sx={{ opacity: 0.4, letterSpacing: 2, display: 'block', mb: 1 }}>RSI (14)</Typography>
-              <Box sx={{ height: 100 }}>
-                <ResponsiveContainer width="100%" height="100%">
-                  <ComposedChart data={rsiData} margin={{ top: 0, right: 10, bottom: 0, left: 10 }}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="rgba(128,128,128,0.08)" vertical={false} />
-                    <XAxis dataKey="date" hide />
-                    <YAxis domain={[0, 100]} width={30} tick={{ fill: 'rgba(128,128,128,0.4)', fontSize: 9 }} tickLine={false} axisLine={false} ticks={[30, 50, 70]} />
-                    <Tooltip contentStyle={{ background: isDark ? '#0d1520' : '#fff', border: `1px solid ${primaryColor}33`, borderRadius: 8, fontSize: 11 }}
-                      formatter={(v: any) => [Number(v).toFixed(1), 'RSI']} />
-                    <ReferenceLine y={70} stroke={isDark ? '#ff0055' : '#dc2626'} strokeDasharray="4 3" strokeOpacity={0.5} />
-                    <ReferenceLine y={30} stroke={isDark ? '#00ffa3' : '#16a34a'} strokeDasharray="4 3" strokeOpacity={0.5} />
-                    <ReferenceLine y={50} stroke="rgba(128,128,128,0.2)" />
-                    <Area type="monotone" dataKey="rsi" stroke="#bc13fe" strokeWidth={2} fill="#bc13fe" fillOpacity={0.1} dot={false} connectNulls isAnimationActive={false} />
-                  </ComposedChart>
-                </ResponsiveContainer>
-              </Box>
-            </Box>
-          )}
-
-          {/* Volume sub-chart */}
-          {indicators.includes('volume') && volumeData.length > 0 && (
-            <Box sx={{ mt: 2 }}>
-              <Typography variant="caption" sx={{ opacity: 0.4, letterSpacing: 2, display: 'block', mb: 1 }}>VOLUME</Typography>
-              <Box sx={{ height: 80 }}>
-                <ResponsiveContainer width="100%" height="100%">
-                  <BarChart data={volumeData} margin={{ top: 0, right: 10, bottom: 0, left: 10 }}>
-                    <XAxis dataKey="date" hide />
-                    <YAxis width={45} tick={{ fill: 'rgba(128,128,128,0.4)', fontSize: 9 }} tickLine={false} axisLine={false}
-                      tickFormatter={(v: number) => v >= 1e9 ? `${(v/1e9).toFixed(1)}B` : v >= 1e6 ? `${(v/1e6).toFixed(0)}M` : `${v}`}
-                    />
-                    <Tooltip contentStyle={{ background: isDark ? '#0d1520' : '#fff', border: `1px solid ${primaryColor}33`, borderRadius: 8, fontSize: 11 }}
-                      formatter={(v: any) => [Number(v).toLocaleString(), 'Volume']} />
-                    <Bar dataKey="volume" fill={primaryColor} fillOpacity={0.4} isAnimationActive={false} />
-                  </BarChart>
-                </ResponsiveContainer>
-              </Box>
-            </Box>
-          )}
-        </>)}
+        </Box>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## What & why

The interactive **PRO (ZOOM)** chart only worked on the **2Y** range — every other range silently fell back to the old Recharts "CLASSIC" chart.

**Root cause:** `AdvancedChart` (lightweight-charts) reconstructed each bar's timestamp from a `MM/DD` string via `buildTimestamps()`. That format only comes from `/predict` (2Y). The `/history` endpoint (all other ranges) emits incompatible date strings the parser couldn't handle:

| Range | Source | `date` format |
|-------|--------|--------------|
| 2Y | `/predict` | `06/04` (MM/DD) |
| 3mo–1y | `/history` | `2026-06-04` (ISO) |
| 5d | `/history` | `06/04 14:30` |
| 1d, 1mo | `/history` | `14:30` (time only) |

So a `selectedInterval === '2y'` gate was the only thing keeping zoom usable.

## Approach

Stop reconstructing dates from display strings — emit a real **UNIX epoch `time`** (seconds, UTC) per bar from both backends and feed it straight to lightweight-charts (which natively accepts `UTCTimestamp`). Then drop the classic path entirely.

- **Backend** (`history.py`, `predict.py`, `models.py`): add `time` to every history bar and forecast day.
- **`AdvancedChart.tsx`**: prefer `time` (falls back to MM/DD reconstruction for stale cached payloads); new `intraday` prop turns on the **HH:MM** time axis for 1D/5D/1M.
- **`PriceChartCard.tsx`**: always render `AdvancedChart` for every range; **remove** the CLASSIC view, the CLASSIC/PRO toggle, and all the Recharts price/MACD/RSI/Volume sub-charts + `VolumeProfile` + their derived `useMemo`s. Forecast / support / resistance pass through only on the native 2Y view.
- **`page.tsx`**: drop the now-unused `chartEngine` state/props.

Net **−427 lines**. Volume stays a time-series strip (bottom pane of the zoom chart), per the agreed design.

## Verification

Confirmed locally end-to-end (uvicorn + Next dev), clicking through ranges:
- **2Y** (MM/DD) — zoom chart renders ✓
- **1D** (intraday 5m) — zoom chart renders with **HH:MM axis** ✓ (previously fell back to classic)
- **3M** (ISO daily) — zoom chart renders ✓
- No CLASSIC/PRO toggle; LINE/CANDLE + indicator toggles + range buttons intact.

`/history` and `/predict` now return a numeric `time` per bar. Backend tests (31) + `ruff` clean; frontend `eslint` clean (only pre-existing MonteCarlo warnings) + `next build` type-check passes.

## Notes

- `VolumeProfile.tsx` is now unused (orphaned) — left in place to keep this PR focused; can be deleted in a follow-up.
- The frontend falls back to the old MM/DD reconstruction if a cached `/history` payload lacks `time`, so there's no hard break during the cache-TTL rollout window.
- Independent of the tool-using-jury PR (#220).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Changes**
  * Removed the "chart engine" toggle from the dashboard.

* **Improvements**
  * History, forecast, and prediction data now include precise epoch timestamps for more consistent chart alignment.
  * Intraday vs. non-intraday ranges are handled automatically; time-axis visibility adapts accordingly.

* **Bug Fixes**
  * Prevented $0-height candlesticks by normalizing non-positive OHLC values to the bar’s close for snapshot bars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->