### PR TITLE
Add walk-forward backtester for the ensemble forecast

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -10,7 +10,7 @@ from fastapi.responses import JSONResponse
 
 from config import Config, SanitizeHttpxFilter
 from redis_cache import init_redis, close_redis
-from routers import predict, simulation, trade, market, history
+from routers import predict, simulation, trade, market, history, backtest
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -46,6 +46,7 @@ app.include_router(simulation.router)
 app.include_router(trade.router)
 app.include_router(market.router)
 app.include_router(history.router)
+app.include_router(backtest.router)
 
 
 if __name__ == "__main__":

--- a/backend/routers/backtest.py
+++ b/backend/routers/backtest.py
@@ -124,10 +124,15 @@ def _run_backtest(symbol: str, closes: List[float], dates: List[str]) -> Optiona
         ens_dirs.append(1 if ens_dir == actual_dir else 0)
 
         # Equity curve: take the position implied by the ensemble's day-5 call
-        # (long if it predicts up, short if down) and book the realized 5-day
-        # return. One trade per window, compounded additively.
-        position = 1 if ens_dir >= 0 else -1
-        window_return_pct = position * (actual[-1] - train_last) / train_last * 100.0
+        # (long if it predicts up, short if down). A flat prediction is treated
+        # as a no-trade rather than defaulting long, so an undecided model
+        # doesn't introduce a systematic long bias. One trade per window,
+        # compounded additively.
+        if ens_dir == 0:
+            window_return_pct = 0.0
+        else:
+            position = 1 if ens_dir > 0 else -1
+            window_return_pct = position * (actual[-1] - train_last) / train_last * 100.0
         cumulative_return_pct += window_return_pct
         equity_curve.append({
             "date": pred_date,
@@ -179,7 +184,14 @@ async def backtest(symbol: str) -> dict:
         return cached
 
     logger.info("[BACKTEST] cache MISS for %s — fetching 2y history", sym)
-    df = await asyncio.to_thread(yf_svc.fetch_history, sym, "2y")
+    try:
+        df = await asyncio.wait_for(
+            asyncio.to_thread(yf_svc.fetch_history, sym, "2y"),
+            timeout=12.0,
+        )
+    except asyncio.TimeoutError:
+        logger.warning("[BACKTEST] yfinance fetch timed out for %s", sym)
+        raise HTTPException(status_code=504, detail=f"Data fetch for {sym} timed out.")
     if df is None or df.empty:
         raise HTTPException(status_code=404, detail=f"No data found for {sym}.")
 

--- a/backend/routers/backtest.py
+++ b/backend/routers/backtest.py
@@ -1,0 +1,230 @@
+# backend/routers/backtest.py
+"""
+Walk-forward backtester for the ensemble forecast.
+
+Rolling-window out-of-sample validation: train each model (Prophet, SARIMAX,
+RandomForest) on a 252-day window, forecast the next 5 trading days, step
+forward 21 days, and compare predictions against the realized closes.
+
+Expensive (~30 train/predict cycles fitting 3 models each) so the result is
+cached in Redis for 24h and the heavy compute runs in a worker thread under a
+120s wall-clock budget.
+"""
+import asyncio
+import logging
+import math
+import re
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+from fastapi import APIRouter, HTTPException
+
+from models import (
+    MODELS_AVAILABLE,
+    _prophet_forecast,
+    _sarima_forecast,
+    _rf_forecast,
+)
+from services import DataCleaner
+from dependencies import yf_svc
+from redis_cache import cache_get, cache_set
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+# Walk-forward parameters
+TRAIN_WINDOW = 252   # ~1 trading year of history per fit
+HORIZON      = 5     # forecast the next 5 trading days
+STEP         = 21    # roll forward ~1 trading month between windows
+
+CACHE_TTL_SECONDS = 86_400   # 24h — backtest is stable intraday & costly
+COMPUTE_TIMEOUT   = 120.0    # wall-clock budget for the worker thread
+
+_SYMBOL_RE = re.compile(r"[A-Za-z0-9.\-:]{1,15}")
+
+
+def _sign(x: float) -> int:
+    """Direction of a move: +1 up, -1 down, 0 flat."""
+    return (x > 0) - (x < 0)
+
+
+def _agg(errors: List[float], dirs: List[int]) -> Dict[str, Optional[float]]:
+    """Aggregate per-window errors + directional hits into MAE + accuracy."""
+    mae = round(sum(errors) / len(errors), 4) if errors else None
+    acc = round(sum(dirs) / len(dirs), 4) if dirs else None
+    return {"mae": mae, "directional_accuracy": acc}
+
+
+def _run_backtest(symbol: str, closes: List[float], dates: List[str]) -> Optional[dict]:
+    """
+    Synchronous walk-forward loop — runs in a worker thread.
+
+    For each rolling window, each model is re-fit on the train slice (closes
+    only) and its 5-day mean path is scored against the realized closes:
+      • MAE        — mean |predicted_close − actual_close| across all horizons
+      • Direction  — did the day-5 prediction get the up/down move right?
+
+    The ensemble path is the simple mean of the available model paths; its
+    day-5 direction drives a long/short equity curve (one trade per window).
+    Returns None when there is not enough history for a single window.
+    """
+    n = len(closes)
+    if n < TRAIN_WINDOW + HORIZON:
+        return None
+
+    model_errors: Dict[str, List[float]] = {"prophet": [], "sarimax": [], "random_forest": []}
+    model_dirs:   Dict[str, List[int]]   = {"prophet": [], "sarimax": [], "random_forest": []}
+    ens_errors:   List[float] = []
+    ens_dirs:     List[int]   = []
+
+    equity_curve: List[dict] = []
+    cumulative_return_pct = 0.0
+    windows_tested = 0
+
+    fitters = {
+        "prophet":       lambda tr: _prophet_forecast(tr, HORIZON),
+        "sarimax":       lambda tr: _sarima_forecast(tr, HORIZON),
+        "random_forest": lambda tr: _rf_forecast(tr, HORIZON),
+    }
+
+    start = 0
+    while start + TRAIN_WINDOW + HORIZON <= n:
+        train  = closes[start: start + TRAIN_WINDOW]
+        actual = closes[start + TRAIN_WINDOW: start + TRAIN_WINDOW + HORIZON]
+        train_last = train[-1]
+        actual_dir = _sign(actual[-1] - train_last)
+        pred_date  = dates[start + TRAIN_WINDOW - 1]
+
+        window_model_paths: List[List[float]] = []
+        for name, fit in fitters.items():
+            try:
+                result = fit(train)                       # shape (HORIZON, 3)
+                pred_path = [float(result[i][0]) for i in range(HORIZON)]
+            except Exception as exc:
+                logger.warning(
+                    "[BACKTEST] %s fit failed for %s window @%s: %s",
+                    name, symbol, pred_date, exc,
+                )
+                continue
+            model_errors[name].extend(abs(p - a) for p, a in zip(pred_path, actual))
+            model_dirs[name].append(1 if _sign(pred_path[-1] - train_last) == actual_dir else 0)
+            window_model_paths.append(pred_path)
+
+        if not window_model_paths:
+            start += STEP
+            continue
+
+        # Ensemble = simple mean of the model paths that succeeded this window.
+        ens_path = [
+            sum(p[i] for p in window_model_paths) / len(window_model_paths)
+            for i in range(HORIZON)
+        ]
+        ens_errors.extend(abs(p - a) for p, a in zip(ens_path, actual))
+        ens_dir = _sign(ens_path[-1] - train_last)
+        ens_dirs.append(1 if ens_dir == actual_dir else 0)
+
+        # Equity curve: take the position implied by the ensemble's day-5 call
+        # (long if it predicts up, short if down) and book the realized 5-day
+        # return. One trade per window, compounded additively.
+        position = 1 if ens_dir >= 0 else -1
+        window_return_pct = position * (actual[-1] - train_last) / train_last * 100.0
+        cumulative_return_pct += window_return_pct
+        equity_curve.append({
+            "date": pred_date,
+            "cumulative_return_pct": round(cumulative_return_pct, 2),
+        })
+
+        windows_tested += 1
+        start += STEP
+
+    if windows_tested == 0:
+        return None
+
+    return {
+        "symbol":         symbol,
+        "windows_tested": windows_tested,
+        "ensemble":       _agg(ens_errors, ens_dirs),
+        "models": {
+            "prophet":       _agg(model_errors["prophet"],       model_dirs["prophet"]),
+            "sarimax":       _agg(model_errors["sarimax"],       model_dirs["sarimax"]),
+            "random_forest": _agg(model_errors["random_forest"], model_dirs["random_forest"]),
+        },
+        "equity_curve": equity_curve,
+        "computed_at":  datetime.now(timezone.utc).isoformat(),
+    }
+
+
+@router.get("/backtest/{symbol}")
+async def backtest(symbol: str) -> dict:
+    """
+    Walk-forward validation of the ensemble forecast over ~2y of daily history.
+
+    Cached in Redis for 24h. The compute runs in a worker thread under a 120s
+    budget since it fits Prophet + SARIMAX + RF once per rolling window.
+    """
+    sym = (symbol or "").strip().upper()
+    if not sym or not _SYMBOL_RE.fullmatch(sym):
+        raise HTTPException(status_code=400, detail="Invalid symbol.")
+
+    if not MODELS_AVAILABLE:
+        raise HTTPException(
+            status_code=503,
+            detail="Forecasting models unavailable — backtest cannot run.",
+        )
+
+    cache_key = f"backtest:{sym}"
+    cached = await cache_get(cache_key)
+    if cached:
+        logger.info("[BACKTEST] cache HIT for %s", sym)
+        return cached
+
+    logger.info("[BACKTEST] cache MISS for %s — fetching 2y history", sym)
+    df = await asyncio.to_thread(yf_svc.fetch_history, sym, "2y")
+    if df is None or df.empty:
+        raise HTTPException(status_code=404, detail=f"No data found for {sym}.")
+
+    try:
+        df = DataCleaner.clean(df)
+    except Exception as exc:
+        logger.warning("[BACKTEST] DataCleaner.clean failed for %s: %s — using raw df", sym, exc)
+
+    hist = DataCleaner.to_history_list(df)
+    hist.sort(key=lambda x: x["_time"])
+    # Keep only finite, positive closes — a stray NaN/inf would silently poison
+    # the Prophet/SARIMAX paths and surface as null MAE in the response.
+    closes: List[float] = []
+    dates:  List[str]   = []
+    for p in hist:
+        c = float(p["close"])
+        if math.isfinite(c) and c > 0:
+            closes.append(c)
+            dates.append(str(p["_time"])[:10])
+
+    if len(closes) < TRAIN_WINDOW + HORIZON:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Insufficient history for {sym} — need ≥ {TRAIN_WINDOW + HORIZON} "
+                f"trading days, have {len(closes)}."
+            ),
+        )
+
+    try:
+        result = await asyncio.wait_for(
+            asyncio.to_thread(_run_backtest, sym, closes, dates),
+            timeout=COMPUTE_TIMEOUT,
+        )
+    except asyncio.TimeoutError:
+        logger.error("[BACKTEST] %s timed out after %ss", sym, COMPUTE_TIMEOUT)
+        raise HTTPException(status_code=504, detail="Backtest timed out — please try again.")
+
+    if result is None:
+        raise HTTPException(status_code=422, detail=f"Not enough data to backtest {sym}.")
+
+    logger.info(
+        "[BACKTEST] ✓ %s — %d windows | ensemble MAE=%s dir_acc=%s",
+        sym, result["windows_tested"],
+        result["ensemble"]["mae"], result["ensemble"]["directional_accuracy"],
+    )
+    await cache_set(cache_key, result, ttl_seconds=CACHE_TTL_SECONDS)
+    return result

--- a/frontend/app/api/backtest/[symbol]/route.ts
+++ b/frontend/app/api/backtest/[symbol]/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import axios from 'axios';
+
+const BACKEND = process.env.BACKEND_URL ?? 'http://localhost:8000';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ symbol: string }> },
+) {
+  const { symbol } = await params;
+  try {
+    // Backtest fits 3 models per rolling window (~30s); allow more than the
+    // backend's 120s budget so the proxy doesn't time out first.
+    const { data } = await axios.get(`${BACKEND}/backtest/${symbol}`, { timeout: 125000 });
+    return NextResponse.json(data);
+  } catch (err: unknown) {
+    const resp = (err as { response?: { status?: number; data?: { detail?: string } } })?.response;
+    const status = resp?.status ?? 500;
+    const detail = resp?.data?.detail ?? 'Backtest fetch failed';
+    return NextResponse.json({ error: detail }, { status });
+  }
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -17,6 +17,7 @@ import { useWatchlist } from '../hooks/useWatchlist';
 import { useAuth } from '../contexts/AuthContext';
 import AuthModal from '../components/AuthModal';
 import ModelWeightBar   from '../components/ModelWeightBar';
+import BacktestPanel    from '../components/BacktestPanel';
 import TrendingSparklines from '../components/TrendingSparklines';
 import MonteCarloFanChart from '../components/MonteCarloFanChart';
 import MonteCarloProbabilitySurface from '../components/MonteCarloProbabilitySurface';
@@ -344,6 +345,9 @@ export default function QuantumDashboard() {
                   {prediction.modelWeights && (
                     <ModelWeightBar weights={prediction.modelWeights} isDark={isDark} />
                   )}
+
+                  {/* ── Walk-forward backtest (on-demand) ────────────── */}
+                  <BacktestPanel symbol={prediction.symbol} isDark={isDark} primaryColor={primaryColor} />
 
                   {/* ── Analyst Jury ──────────────────────────────────── */}
                   {prediction.juryAnalysts && prediction.juryAnalysts.length > 0 && (

--- a/frontend/components/BacktestPanel.tsx
+++ b/frontend/components/BacktestPanel.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import { useState } from 'react';
+import axios from 'axios';
+import {
+  Box, Button, Paper, Stack, Typography, CircularProgress,
+  Table, TableBody, TableCell, TableHead, TableRow, Tooltip as MuiTooltip,
+} from '@mui/material';
+import {
+  LineChart, Line, XAxis, YAxis, CartesianGrid, ResponsiveContainer,
+  ReferenceLine, Tooltip,
+} from 'recharts';
+import { Activity } from 'lucide-react';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface ModelScore {
+  mae: number | null;
+  directional_accuracy: number | null;
+}
+
+interface EquityPoint {
+  date: string;
+  cumulative_return_pct: number;
+}
+
+interface BacktestResult {
+  symbol: string;
+  windows_tested: number;
+  ensemble: ModelScore;
+  models: {
+    prophet: ModelScore;
+    sarimax: ModelScore;
+    random_forest: ModelScore;
+  };
+  equity_curve: EquityPoint[];
+  computed_at: string;
+}
+
+interface Props {
+  symbol: string;
+  isDark: boolean;
+  primaryColor: string;
+}
+
+const MODEL_ROWS: Array<{ key: keyof BacktestResult['models']; label: string; color: string }> = [
+  { key: 'prophet',       label: 'Prophet',       color: '#f97316' },
+  { key: 'sarimax',       label: 'SARIMAX',       color: '#60a5fa' },
+  { key: 'random_forest', label: 'Random Forest', color: '#34d399' },
+];
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const fmtMae = (v: number | null) => (v == null ? '—' : `$${v.toFixed(2)}`);
+const fmtAcc = (v: number | null) => (v == null ? '—' : `${(v * 100).toFixed(0)}%`);
+
+// ── Component ──────────────────────────────────────────────────────────────────
+
+export default function BacktestPanel({ symbol, isDark, primaryColor }: Props) {
+  const [result, setResult] = useState<BacktestResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const textColor = isDark ? 'rgba(220,220,220,0.55)' : 'rgba(20,30,50,0.55)';
+  const gridColor = isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)';
+
+  const runBacktest = async () => {
+    if (!symbol || loading) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const { data } = await axios.get<BacktestResult>(`/api/backtest/${symbol}`, { timeout: 130000 });
+      setResult(data);
+    } catch (err: unknown) {
+      const resp = (err as { response?: { data?: { error?: string } } })?.response;
+      setError(resp?.data?.error ?? 'Backtest failed — please try again.');
+      setResult(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!symbol) return null;
+
+  const lastReturn = result?.equity_curve.at(-1)?.cumulative_return_pct ?? 0;
+
+  return (
+    <Box sx={{ width: '100%' }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0.75 }}>
+        <Typography sx={{ fontSize: 10, fontWeight: 800, letterSpacing: 1.2, color: textColor, textTransform: 'uppercase' }}>
+          Walk-Forward Backtest
+        </Typography>
+        {result && (
+          <Typography sx={{ fontSize: 10, color: textColor }}>
+            {result.windows_tested} windows · 252d train / 5d horizon
+          </Typography>
+        )}
+      </Box>
+
+      {!result && (
+        <MuiTooltip
+          title="Re-fits Prophet, SARIMAX & Random Forest across ~2 years of rolling windows to measure out-of-sample accuracy. Takes ~30s."
+          arrow
+        >
+          <span>
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={runBacktest}
+              disabled={loading}
+              startIcon={loading ? <CircularProgress size={14} /> : <Activity size={14} />}
+              sx={{
+                fontSize: 11, py: 0.4, px: 1.5, textTransform: 'none',
+                borderColor: `${primaryColor}55`, color: primaryColor,
+                '&:hover': { borderColor: primaryColor, background: `${primaryColor}11` },
+              }}
+            >
+              {loading ? 'Running backtest (~30s)…' : 'Run Backtest'}
+            </Button>
+          </span>
+        </MuiTooltip>
+      )}
+
+      {error && (
+        <Typography sx={{ fontSize: 11, color: '#ff6b6b', mt: 1 }}>{error}</Typography>
+      )}
+
+      {result && (
+        <Paper
+          sx={{
+            p: 1.5, mt: 0.5, borderRadius: 2,
+            border: `1px solid ${primaryColor}22`,
+            background: isDark ? 'rgba(255,255,255,0.02)' : 'rgba(0,0,0,0.01)',
+          }}
+        >
+          {/* Per-model accuracy table */}
+          <Table size="small" sx={{ '& td, & th': { borderColor: gridColor, py: 0.5, px: 1 } }}>
+            <TableHead>
+              <TableRow>
+                <TableCell sx={{ fontSize: 10, fontWeight: 700, color: textColor }}>Model</TableCell>
+                <MuiTooltip title="Mean absolute error of the predicted close vs. realized close, averaged over every forecast day." arrow>
+                  <TableCell align="right" sx={{ fontSize: 10, fontWeight: 700, color: textColor, cursor: 'help' }}>MAE</TableCell>
+                </MuiTooltip>
+                <MuiTooltip title="How often the model called the 5-day direction (up/down) correctly." arrow>
+                  <TableCell align="right" sx={{ fontSize: 10, fontWeight: 700, color: textColor, cursor: 'help' }}>Dir. Acc.</TableCell>
+                </MuiTooltip>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {MODEL_ROWS.map(({ key, label, color }) => {
+                const m = result.models[key];
+                return (
+                  <TableRow key={key}>
+                    <TableCell sx={{ fontSize: 12 }}>
+                      <Box component="span" sx={{ display: 'inline-block', width: 8, height: 8, borderRadius: '50%', bgcolor: color, mr: 0.75 }} />
+                      {label}
+                    </TableCell>
+                    <TableCell align="right" sx={{ fontSize: 12, fontVariantNumeric: 'tabular-nums' }}>{fmtMae(m.mae)}</TableCell>
+                    <TableCell align="right" sx={{ fontSize: 12, fontVariantNumeric: 'tabular-nums' }}>{fmtAcc(m.directional_accuracy)}</TableCell>
+                  </TableRow>
+                );
+              })}
+              {/* Ensemble row — emphasized */}
+              <TableRow>
+                <TableCell sx={{ fontSize: 12, fontWeight: 800, color: primaryColor }}>Ensemble</TableCell>
+                <TableCell align="right" sx={{ fontSize: 12, fontWeight: 800, color: primaryColor, fontVariantNumeric: 'tabular-nums' }}>{fmtMae(result.ensemble.mae)}</TableCell>
+                <TableCell align="right" sx={{ fontSize: 12, fontWeight: 800, color: primaryColor, fontVariantNumeric: 'tabular-nums' }}>{fmtAcc(result.ensemble.directional_accuracy)}</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+
+          {/* Equity curve */}
+          <Box sx={{ mt: 1.5 }}>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', mb: 0.5 }}>
+              <Typography sx={{ fontSize: 10, fontWeight: 700, color: textColor, textTransform: 'uppercase', letterSpacing: 0.8 }}>
+                Strategy Equity Curve
+              </Typography>
+              <Typography sx={{ fontSize: 11, fontWeight: 800, color: lastReturn >= 0 ? '#16a34a' : '#dc2626' }}>
+                {lastReturn >= 0 ? '+' : ''}{lastReturn.toFixed(2)}%
+              </Typography>
+            </Box>
+            <ResponsiveContainer width="100%" height={180}>
+              <LineChart data={result.equity_curve} margin={{ top: 6, right: 12, bottom: 4, left: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke={gridColor} />
+                <XAxis dataKey="date" tick={{ fontSize: 9, fill: '#64748b' }} minTickGap={28} />
+                <YAxis
+                  tick={{ fontSize: 9, fill: '#64748b' }}
+                  tickFormatter={(v) => `${v}%`}
+                  width={42}
+                />
+                <Tooltip
+                  formatter={(v: number) => [`${v.toFixed(2)}%`, 'Cumulative']}
+                  contentStyle={{
+                    background: isDark ? '#0d1117' : '#fff',
+                    border: `1px solid ${primaryColor}33`,
+                    borderRadius: 8, fontSize: 12,
+                  }}
+                />
+                <ReferenceLine y={0} stroke="#64748b" strokeDasharray="4 3" />
+                <Line
+                  type="monotone"
+                  dataKey="cumulative_return_pct"
+                  stroke={primaryColor}
+                  strokeWidth={2}
+                  dot={false}
+                  isAnimationActive={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+            <Typography sx={{ fontSize: 9, opacity: 0.45, mt: 0.5 }}>
+              Long/short the ensemble&apos;s 5-day call, one trade per window. Cumulative realized return — not financial advice.
+            </Typography>
+          </Box>
+        </Paper>
+      )}
+    </Box>
+  );
+}

--- a/frontend/components/BacktestPanel.tsx
+++ b/frontend/components/BacktestPanel.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import axios from 'axios';
 import {
-  Box, Button, Paper, Stack, Typography, CircularProgress,
+  Box, Button, Paper, Typography, CircularProgress,
   Table, TableBody, TableCell, TableHead, TableRow, Tooltip as MuiTooltip,
 } from '@mui/material';
 import {
@@ -60,6 +60,13 @@ export default function BacktestPanel({ symbol, isDark, primaryColor }: Props) {
   const [result, setResult] = useState<BacktestResult | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Clear any prior ticker's backtest when the symbol changes so a stale result
+  // isn't shown for the newly-selected ticker until the user reruns.
+  useEffect(() => {
+    setResult(null);
+    setError(null);
+  }, [symbol]);
 
   const textColor = isDark ? 'rgba(220,220,220,0.55)' : 'rgba(20,30,50,0.55)';
   const gridColor = isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)';


### PR DESCRIPTION
## What

New **Walk-Forward Backtester** (Feature 4) — out-of-sample validation of the ensemble forecast.

### Backend
- New `GET /backtest/{symbol}` in `backend/routers/backtest.py`:
  - Fetches 2Y daily OHLCV (yfinance, same `DataCleaner` path as `/predict`).
  - Rolling windows: **252-day train → 5-day forecast → step 21 days**. Each window re-fits Prophet, SARIMAX, and RandomForest and scores predicted closes vs. realized.
  - Returns per-model and ensemble **MAE** + **directional accuracy**, plus an **equity curve** (long/short the ensemble's day-5 call, one trade per window, cumulative realized %).
  - Cached in Redis **24h**; compute runs in `asyncio.to_thread` under `asyncio.wait_for(timeout=120)`.
  - Validates symbol (400), 503 if models unavailable, 404/422 on missing/insufficient data, 504 on timeout.
- Registered the router in `backend/main.py`.

### Frontend
- `frontend/components/BacktestPanel.tsx` — on-demand "Run Backtest" button (tooltip warns ~30s), per-model accuracy table with emphasized ensemble row, and a Recharts equity-curve `LineChart`.
- `frontend/app/api/backtest/[symbol]/route.ts` — Next.js proxy (125s timeout to outlast the backend budget).
- Wired into `frontend/app/page.tsx` directly below `ModelWeightBar`.

## Why
Gives users a quantitative, out-of-sample read on how the forecast models have actually performed, rather than only the live forward forecast.

## Reviewer notes
- Closes are filtered to finite/positive values before the loop so a stray NaN can't silently poison the Prophet/SARIMAX paths (surfaces as null MAE otherwise). Per-window model-fit failures are logged and skipped, never fatal.
- Ensemble path is the simple mean of the models that fit successfully in each window (no RL weights in the backtest — kept deliberately simple/defensible).
- All free-tier / self-hosted (yfinance + Redis), consistent with project constraints.

## Verification
- `ruff` clean; module imports in the project venv.
- Full HTTP route exercised via FastAPI `TestClient` against the **real model stack** (stubbed tz-aware data): `200` with correct response shape, all 3 models + ensemble producing real MAE/directional accuracy, populated equity curve, 13 windows from 520 trading days, `400` on invalid symbol.
- Frontend `tsc --noEmit` and `eslint` clean.
- Not yet run live in-browser (needs both servers + a `/predict` to render the panel + ~30s live yfinance compute).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added walk-forward backtest capability enabling users to test trading strategies on historical data with configurable parameters
  * Displays individual model performance (Prophet, SARIMAX, Random Forest) and an ensemble model accuracy comparison
  * Includes equity curve visualization to track backtest performance over time
  * Results are cached for 24 hours for faster repeated access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->