### PR TITLE
fix(jury): swap Quant lens to gpt-oss-20b + harden verdict parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ AI-driven quantitative financial forecasting SaaS. Ticker lookup → ensemble ML
 | ML/Forecasting | Prophet, SARIMAX (statsmodels), RandomForestRegressor (scikit-learn) |
 | Market Data | yfinance, SerpAPI (news/trending) |
 | Sentiment | VADER (vaderSentiment) — headline scoring, compound score + label |
-| AI / LLM Jury | Groq API — Llama 4 Scout, Llama 3.3 70B, Qwen3 32B (3-analyst jury via LangGraph) |
+| AI / LLM Jury | Groq API — Llama 4 Scout, Llama 3.3 70B, GPT-OSS 20B (3-analyst jury via LangGraph) |
 | Time-Series DB | InfluxDB |
 | Auth | Supabase (email/password, free tier) |
 | Observability | New Relic APM (backend + frontend) |
@@ -141,7 +141,7 @@ User enters ticker
       → SerpAPI: news headlines + trending symbols
       → VADER SentimentService: compound [-1,1] + label (Bullish/Bearish/Neutral)
       → LangGraph StateGraph parallel fan-out (Groq):
-          Llama 4 Scout (Macro & Risk) · Llama 3.3 70B (Growth) · Qwen3 32B (Quant)
+          Llama 4 Scout (Macro & Risk) · Llama 3.3 70B (Growth) · GPT-OSS 20B (Quant)
           Each isolated — failures degrade to Hold/25, not 500
       → Response: history, fundamentals, indicators, forecasts, jury verdicts, news, sentiment, monte carlo
 

--- a/backend/jury_graph.py
+++ b/backend/jury_graph.py
@@ -9,7 +9,7 @@ Replaces the bare asyncio.gather() approach with a proper StateGraph so that:
   - `.stream()` drop-in replaces `.invoke()` for future SSE support
 
 Graph shape (parallel fan-out):
-  START → [llama4scout | llama70b | qwen3] → END
+  START → [llama4scout | llama70b | gptoss] → END
 All three analyst nodes fire concurrently via LangGraph's parallel fan-out.
 """
 

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -212,9 +212,9 @@ async def _run_analyst_jury(
 ) -> List[dict]:
     """
     Run all 3 analyst personas concurrently via AnalystJuryService.
-      - KIMI-K2    → Groq moonshotai/kimi-k2-instruct  (macro & risk lens, Moonshot AI)
-      - LLAMA-70B  → Groq llama-3.3-70b-versatile    (growth lens, Meta)
-      - QWEN3-32B  → Groq qwen/qwen3-32b             (quant lens, Alibaba)
+      - LLAMA-4-SCOUT → Groq meta-llama/llama-4-scout-17b-16e-instruct (macro & risk lens, Meta)
+      - LLAMA-70B     → Groq llama-3.3-70b-versatile  (growth lens, Meta)
+      - GPT-OSS-20B   → Groq openai/gpt-oss-20b        (quant lens, OpenAI)
 
     All provider routing and response parsing are handled inside
     AnalystJuryService — no per-provider branching needed here.

--- a/backend/services.py
+++ b/backend/services.py
@@ -1483,7 +1483,7 @@ class SentimentService:
 #
 #   LLAMA-4-SCOUT → Groq meta-llama/llama-4-scout-17b-16e-instruct (free tier) — Macro & Risk lens
 #   LLAMA-70B → Groq llama-3.3-70b-versatile    (14,400 RPD free) — Growth lens
-#   QWEN3-32B → Groq qwen/qwen3-32b             (free tier)       — Quant lens
+#   GPT-OSS-20B → Groq openai/gpt-oss-20b       (free tier)       — Quant lens
 #
 #   _ai_note uses Groq llama-3.3-70b independently (header note, not jury)
 # ---------------------------------------------------------------------------
@@ -1533,16 +1533,16 @@ ANALYST_PERSONAS = [
         ),
     },
     {
-        "id":          "QWEN3-32B",
-        "avatar":      "QW",
+        "id":          "GPT-OSS-20B",
+        "avatar":      "GO",
         "title":       "Quant Lens",
-        "model_label": "Groq · Qwen3 32B",
+        "model_label": "Groq · GPT-OSS 20B",
         "provider":    "groq",
-        "api_model":   "qwen/qwen3-32b",
+        "api_model":   "openai/gpt-oss-20b",
         "max_tokens":  2048,
         "color":       "#10b981",
         "system": (
-            "You are QWEN3-32B, a quantitative signal analyst running on Alibaba Qwen3 32B. "
+            "You are GPT-OSS-20B, a quantitative signal analyst running on OpenAI GPT-OSS 20B. "
             "You operate purely on technical indicators and statistical signals — no macro bias, no news sentiment. "
             "Analyse the provided OHLCV data and indicator outputs. "
             "Interpret RSI regime, MACD histogram crossover state, Bollinger Band width and price position, "
@@ -1837,7 +1837,7 @@ class AnalystJuryService:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _parse_analyst_response(raw: str, persona_id: str = "?") -> dict:
+    def _parse_analyst_response(raw: str, persona_id: str = "?", model: str = "?") -> dict:
         import json
 
         logger.debug(
@@ -1910,10 +1910,25 @@ class AnalystJuryService:
             )
 
         # ── Last resort: regex field extraction from plain text ───────────────
+        # Both JSON paths failed → the model emitted malformed/structurally-broken
+        # output. Track it (keyed by model) so a chronically-misbehaving model is
+        # visible in New Relic, then salvage a clean note without leaking JSON
+        # punctuation (e.g. stray "}}" from an unbalanced object) into the UI.
         logger.warning(
             f"[JURY/{persona_id}] ⚠ Parse path: LAST-RESORT (regex plain-text extraction) — "
-            f"both JSON parse paths failed"
+            f"both JSON parse paths failed (model={model}, raw_chars={len(raw)}, "
+            f"had_think_block={'<think>' in raw})"
         )
+        try:
+            newrelic.agent.record_custom_event("JuryMalformedOutput", {
+                "persona_id":      persona_id,
+                "model":           model,
+                "raw_chars":       len(raw),
+                "had_think_block": "<think>" in raw,
+            })
+        except Exception:  # observability must never break parsing
+            pass
+
         rating = "Hold"
         for candidate in [
             "Strong Buy", "Strong Sell",
@@ -1927,7 +1942,18 @@ class AnalystJuryService:
 
         conf_match = re.search(r"(\d{1,3})\s*%", cleaned)
         confidence = int(conf_match.group(1)) if conf_match else 60
-        note       = re.sub(r"\{.*?\}", "", cleaned, flags=re.DOTALL).strip()[:420]
+
+        # Salvage the note: first try to lift the "note" field out of the broken
+        # JSON; otherwise drop the JSON-ish span (greedy) and scrub any remaining
+        # brace/bracket/quote so fragments like "}}" can never reach the user.
+        note_match = re.search(r'"note"\s*:\s*"([^"]{1,420})"', cleaned, flags=re.DOTALL)
+        if note_match:
+            note = note_match.group(1).strip()
+        else:
+            note = re.sub(r"\{.*\}", " ", cleaned, flags=re.DOTALL)   # greedy: whole JSON blob
+            note = re.sub(r"[{}\[\]\"]", " ", note)                   # any stray JSON punctuation
+            note = re.sub(r"\s{2,}", " ", note).strip()
+        note = note[:420] or "Quantitative analysis unavailable this run."
 
         result = {
             "rating":     rating,
@@ -2012,7 +2038,7 @@ class AnalystJuryService:
             model_used = "error"
             tools_used = []
 
-        parsed = self._parse_analyst_response(raw, persona_id=persona["id"])
+        parsed = self._parse_analyst_response(raw, persona_id=persona["id"], model=model_used)
 
         verdict = {
             "id":          persona["id"],

--- a/backend/tests/test_jury_parsing.py
+++ b/backend/tests/test_jury_parsing.py
@@ -1,0 +1,59 @@
+"""
+Tests for AnalystJuryService._parse_analyst_response — the structured-verdict
+parser. No network: the parser is a pure staticmethod over the raw model string.
+
+Focus: malformed model output (e.g. GPT-OSS / reasoning models emitting an
+unbalanced object) must never leak JSON punctuation like "}}" into the
+user-facing note.
+"""
+from backend.services import AnalystJuryService
+
+parse = AnalystJuryService._parse_analyst_response
+
+
+def test_parses_clean_json() -> None:
+    raw = '{"rating": "Buy", "note": "Momentum is strong.", "confidence": 72}'
+    out = parse(raw, persona_id="GPT-OSS-20B", model="openai/gpt-oss-20b")
+    assert out["rating"] == "Buy"
+    assert out["note"] == "Momentum is strong."
+    assert out["confidence"] == 72
+
+
+def test_trailing_double_brace_does_not_leak() -> None:
+    """An unbalanced trailing '}}' must not appear in the salvaged note."""
+    # Unbalanced/garbled tail forces the last-resort path.
+    raw = 'Accumulate. {"rating": "Accumulate", "note": "RSI 45, MACD turning up.", "confidence": 63}}'
+    out = parse(raw, persona_id="GPT-OSS-20B", model="openai/gpt-oss-20b")
+    assert "}" not in out["note"] and "{" not in out["note"]
+    assert "}}" not in out["note"]
+
+
+def test_last_resort_salvages_note_field() -> None:
+    """When JSON is broken but a note field is present, it should be lifted out."""
+    raw = '{"rating": "Hold" "note": "Choppy, no edge here.", "confidence": 50'  # missing comma + unterminated
+    out = parse(raw, persona_id="GPT-OSS-20B", model="openai/gpt-oss-20b")
+    assert "Choppy, no edge here." in out["note"]
+    assert "{" not in out["note"] and "}" not in out["note"]
+
+
+def test_plain_text_no_brace_leak() -> None:
+    raw = "Strong Buy — breakout confirmed on volume. Confidence 80%."
+    out = parse(raw, persona_id="GPT-OSS-20B", model="openai/gpt-oss-20b")
+    assert out["rating"] == "Strong Buy"
+    assert out["confidence"] == 80
+    assert "{" not in out["note"] and "}" not in out["note"]
+
+
+def test_think_block_stripped() -> None:
+    raw = '<think>let me reason about this...</think>{"rating": "Sell", "note": "Breaking support.", "confidence": 40}'
+    out = parse(raw, persona_id="GPT-OSS-20B", model="openai/gpt-oss-20b")
+    assert out["rating"] == "Sell"
+    assert "<think>" not in out["note"]
+
+
+def test_note_never_empty() -> None:
+    """Even with unusable content, the note is a non-empty fallback string."""
+    raw = "{}{}{}"
+    out = parse(raw, persona_id="GPT-OSS-20B", model="openai/gpt-oss-20b")
+    assert isinstance(out["note"], str) and out["note"].strip()
+    assert "{" not in out["note"] and "}" not in out["note"]


### PR DESCRIPTION
## Summary
Addresses feedback that the Quant juror (Qwen3-32B) intermittently emitted malformed output whose JSON fragments — e.g. a trailing `}}` — leaked into the analyst note shown on the ticker result.

### Changes
- **Model swap** — the Quant lens moves from `qwen/qwen3-32b` → `openai/gpt-oss-20b` (confirmed available on the Groq tier). Strong structured-JSON adherence and no `<think>` emission. Persona `id`/`avatar`/`model_label`/`system` updated accordingly. (Frontend renders jurors dynamically, so no UI code references the old id.)
- **Parsing hardening** — `_parse_analyst_response`'s last-resort path previously used a non-greedy `re.sub(r"\{.*?\}", …)` that left trailing braces in the note. It now (a) salvages the `note` field out of broken JSON when present, else (b) drops the JSON span greedily and strips every `{`/`}`/`[`/`]`/`"`, guaranteeing no JSON punctuation reaches the UI. The note is never empty.
- **Tracking** — when both JSON parse paths fail, we emit a New Relic `JuryMalformedOutput` custom event keyed by `model` + `persona_id`, so a chronically-misbehaving model is observable. The parser now takes the model for attribution.
- **Docs/comments** — refreshed the jury roster in `CLAUDE.md`, `predict.py`, and `jury_graph.py` (also fixed a stale `KIMI-K2` reference → Llama 4 Scout).

### Testing
- New `backend/tests/test_jury_parsing.py` — 6 cases covering clean JSON, trailing-`}}`, salvage-from-broken-JSON, plain text, `<think>` stripping, and the never-empty guarantee. **No brace can leak.**
- `pytest backend/tests/` — **60 passed** (excludes the known py3.14 `test_new_services` artifact); `ruff` clean.
- **Verified live** against the running backend: gpt-oss-20b returns a clean, detailed quant verdict (`model=openai/gpt-oss-20b`, real RSI/MACD/Bollinger/SMA analysis, no brace leak). Note: gpt-oss-20b has a tighter free-tier rate limit than the Llama models — a burst can 429 it, in which case the existing per-node isolation degrades just that juror to Hold/25 (never a 500). The new tracking will show if that's frequent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)