### PR TITLE
feat: VWAP overlay, URL-persistent analysis tab, watchlist quick-launch

### DIFF
--- a/backend/tests/test_history.py
+++ b/backend/tests/test_history.py
@@ -1,0 +1,124 @@
+"""
+/history endpoint tests — dynamic chart intervals.
+
+yfinance, InfluxDB, and the Redis cache are all mocked; no network required.
+"""
+from unittest.mock import patch, AsyncMock, MagicMock
+
+import numpy as np
+import pandas as pd
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Lightweight app with only the history router — avoids the Redis lifespan in
+# main.py while exercising the real validation + metric computation.
+from backend.routers import history
+
+_test_app = FastAPI()
+_test_app.include_router(history.router)
+client = TestClient(_test_app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_ohlcv_df(rows: int, freq: str, start: str = "2026-01-02 09:30") -> pd.DataFrame:
+    """OHLCV frame with a tz-aware UTC DatetimeIndex, shaped like a yfinance
+    download result (single-level columns)."""
+    idx  = pd.date_range(start, periods=rows, freq=freq, tz="UTC")
+    base = np.linspace(100.0, 120.0, rows)
+    return pd.DataFrame(
+        {
+            "Open":   base,
+            "High":   base + 1.0,
+            "Low":    base - 1.0,
+            "Close":  base + 0.5,
+            "Volume": np.full(rows, 1_000_000.0),
+        },
+        index=idx,
+    )
+
+
+def _cache_patches():
+    """Force a cache miss and a no-op cache write."""
+    return (
+        patch("backend.routers.history.cache_get", AsyncMock(return_value=None)),
+        patch("backend.routers.history.cache_set", AsyncMock(return_value=None)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shape + metrics
+# ---------------------------------------------------------------------------
+
+def test_history_intraday_shape_and_metrics() -> None:
+    """1d/5m is intraday: skips InfluxDB, returns VWAP-bearing bars + stats."""
+    df = _make_ohlcv_df(40, "5min")
+    cg, cs = _cache_patches()
+    with cg, cs, patch("yfinance.download", MagicMock(return_value=df)):
+        resp = client.get("/history?symbol=aapl&period=1d&interval=5m")
+
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["symbol"]   == "AAPL"   # uppercased
+    assert d["period"]   == "1d"
+    assert d["interval"] == "5m"
+    assert len(d["history"]) == 40
+
+    bar = d["history"][0]
+    for key in ("date", "time", "price", "open", "high", "low", "volume", "rsi"):
+        assert key in bar, f"missing bar key: {key}"
+    # Intraday bars carry a per-bar VWAP.
+    assert "vwap" in bar
+
+    stats = d["stats"]
+    for key in ("change_pct", "period_high", "period_low", "sma20", "ann_vol"):
+        assert key in stats, f"missing stats key: {key}"
+    assert stats["period_high"] >= stats["period_low"]
+    assert isinstance(d["rsi_series"], list)
+
+
+def test_history_daily_yfinance_fallback() -> None:
+    """3mo/1d is daily: InfluxDB is consulted first; sparse data falls back to
+    yfinance. Daily bars carry no VWAP."""
+    df = _make_ohlcv_df(120, "D", start="2026-01-02")
+    mock_influx = MagicMock()
+    mock_influx.query_history.return_value = []   # below the min-rows threshold
+    cg, cs = _cache_patches()
+    with cg, cs, \
+         patch("backend.routers.history.influx_svc", mock_influx), \
+         patch("yfinance.download", MagicMock(return_value=df)):
+        resp = client.get("/history?symbol=MSFT&period=3mo&interval=1d")
+
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["interval"] == "1d"
+    assert len(d["history"]) == 120
+    assert "vwap" not in d["history"][0]
+    mock_influx.query_history.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def test_history_invalid_interval_for_period_returns_400() -> None:
+    cg, cs = _cache_patches()
+    with cg, cs:
+        resp = client.get("/history?symbol=AAPL&period=1d&interval=1d")
+    assert resp.status_code == 400
+
+
+def test_history_invalid_period_returns_400() -> None:
+    cg, cs = _cache_patches()
+    with cg, cs:
+        resp = client.get("/history?symbol=AAPL&period=10y&interval=1d")
+    assert resp.status_code == 400
+
+
+def test_history_empty_data_returns_404() -> None:
+    cg, cs = _cache_patches()
+    with cg, cs, patch("yfinance.download", MagicMock(return_value=pd.DataFrame())):
+        resp = client.get("/history?symbol=ZZZZ&period=1d&interval=5m")
+    assert resp.status_code == 404

--- a/backend/tests/test_history.py
+++ b/backend/tests/test_history.py
@@ -3,6 +3,8 @@
 
 yfinance, InfluxDB, and the Redis cache are all mocked; no network required.
 """
+from contextlib import AbstractContextManager
+from typing import Any, Tuple
 from unittest.mock import patch, AsyncMock, MagicMock
 
 import numpy as np
@@ -40,7 +42,7 @@ def _make_ohlcv_df(rows: int, freq: str, start: str = "2026-01-02 09:30") -> pd.
     )
 
 
-def _cache_patches():
+def _cache_patches() -> Tuple[AbstractContextManager[Any], AbstractContextManager[Any]]:
     """Force a cache miss and a no-op cache write."""
     return (
         patch("backend.routers.history.cache_get", AsyncMock(return_value=None)),

--- a/frontend/app/(app)/analysis/page.tsx
+++ b/frontend/app/(app)/analysis/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import React, { useState, useMemo, useEffect, Suspense } from 'react';
-import { useSearchParams } from 'next/navigation';
+import React, { useState, useMemo, useEffect, useRef, Suspense } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import axios from 'axios';
 import {
   Box, Container, Typography, TextField, Button, Card, CardContent,
@@ -59,8 +59,12 @@ const POPULAR_TICKERS = [
 
 function AnalysisContent() {
   const { isDark, primaryColor } = useAppShell();
+  const router        = useRouter();
   const searchParams  = useSearchParams();
   const symbolFromUrl = searchParams.get('symbol');
+  // Base ticker (no exchange suffix) most recently fetched — guards the URL-sync
+  // effect below so a programmatic router.replace doesn't re-trigger a fetch.
+  const lastLoadedRef = useRef<string | null>(null);
 
   const [ticker,           setTicker]           = useState('NVDA');
   const [exchange,         setExchange]         = useState('');
@@ -112,6 +116,9 @@ function AnalysisContent() {
       fullSymbol = exchange ? `${ticker}:${exchange}` : ticker;
     }
     const baseSymbol = fullSymbol.split(':')[0];
+    // Record before fetching so the router.replace below (which changes the URL,
+    // and therefore symbolFromUrl) doesn't bounce back into a duplicate fetch.
+    lastLoadedRef.current = baseSymbol;
 
     setLoading(true);
     setError(null);
@@ -122,6 +129,9 @@ function AnalysisContent() {
     try {
       const response = await axios.post('/api/predict', { data: fullSymbol });
       setPrediction(response.data);
+      // Persist the ticker in the URL so the view is shareable, reload-safe, and
+      // back/forward navigable. scroll:false keeps the current scroll position.
+      router.replace(`/analysis?symbol=${encodeURIComponent(baseSymbol)}`, { scroll: false });
       if (user) {
         fetchTradeSetup(response.data);
       } else {
@@ -143,9 +153,11 @@ function AnalysisContent() {
     }
   };
 
-  // Auto-trigger analysis when arriving with a ?symbol= query (e.g. from the landing search).
+  // Auto-trigger analysis when the ?symbol= query changes — on first load (e.g.
+  // from the landing search) and on browser back/forward. Skips the case where
+  // the change came from our own router.replace after a fetch (guarded by ref).
   useEffect(() => {
-    if (symbolFromUrl) {
+    if (symbolFromUrl && symbolFromUrl.toUpperCase() !== lastLoadedRef.current) {
       handlePredict(symbolFromUrl);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -421,7 +433,7 @@ function AnalysisContent() {
                           key={sym}
                           label={sym}
                           size="small"
-                          onClick={() => setTicker(sym)}
+                          onClick={() => handlePredict(sym)}
                           onDelete={() => void toggleWatchlist(sym)}
                           sx={{
                             cursor: 'pointer',

--- a/frontend/components/AdvancedChart.tsx
+++ b/frontend/components/AdvancedChart.tsx
@@ -40,6 +40,7 @@ export interface AdvHistoryPoint {
   macd?: number | null;
   macd_signal?: number | null;
   macd_hist?: number | null;
+  vwap?: number | null;
 }
 
 export interface AdvForecastPoint {
@@ -62,6 +63,7 @@ interface Props {
   support?: number[];
   resistance?: number[];
   intraday?: boolean;   // show HH:MM on the time axis (1D/5D/1M ranges)
+  showVwap?: boolean;   // dashed VWAP overlay (intraday ranges only)
 }
 
 /**
@@ -124,6 +126,7 @@ export default function AdvancedChart({
   support = [],
   resistance = [],
   intraday = false,
+  showVwap = false,
 }: Props) {
   const priceRef   = useRef<HTMLDivElement>(null);
   const volumeRef  = useRef<HTMLDivElement>(null);
@@ -258,6 +261,12 @@ export default function AdvancedChart({
       ema50.setData(histPoints(h => h.ema50));
     }
 
+    // VWAP — dashed orange overlay (intraday ranges only)
+    if (showVwap) {
+      const vwapLine = priceChart.addSeries(LineSeries, { color: '#ff9800', lineWidth: 2, lineStyle: 2 });
+      vwapLine.setData(histPoints(h => h.vwap));
+    }
+
     // Forecast line + band
     if (forecast.length) {
       const foreLine = priceChart.addSeries(LineSeries, { color: '#bc13fe', lineWidth: 2, lineStyle: 2 });
@@ -367,7 +376,7 @@ export default function AdvancedChart({
       handlers.forEach(h => h());
       charts.forEach(c => c.remove());
     };
-  }, [history, forecast, rsiSeries, indicators, mode, isDark, primaryColor, trendColor, support, resistance, intraday]);
+  }, [history, forecast, rsiSeries, indicators, mode, isDark, primaryColor, trendColor, support, resistance, intraday, showVwap]);
 
   const paneBorder = isDark ? '1px solid rgba(255,255,255,0.05)' : '1px solid rgba(0,0,0,0.08)';
   const labelStyle: React.CSSProperties = {

--- a/frontend/components/PriceChartCard.tsx
+++ b/frontend/components/PriceChartCard.tsx
@@ -49,12 +49,14 @@ export default function PriceChartCard({
   const [selectedInterval, setSelectedInterval] = useState<string>('2y');
   const [intervalData,     setIntervalData]     = useState<IntervalHistoryData | null>(null);
   const [historyLoading,   setHistoryLoading]   = useState(false);
+  const [showVwap,         setShowVwap]         = useState(false);
   // Track the last symbol we rendered for — reset interval when it changes
   const [lastSymbol, setLastSymbol] = useState(prediction.symbol);
   if (lastSymbol !== prediction.symbol) {
     setLastSymbol(prediction.symbol);
     setSelectedInterval('2y');
     setIntervalData(null);
+    setShowVwap(false);
   }
   const fetchIntervalHistory = useCallback((iv: string) => {
     if (iv === '2y') {
@@ -72,6 +74,8 @@ export default function PriceChartCard({
 
   const handleIntervalChange = useCallback((iv: string) => {
     setSelectedInterval(iv);
+    // VWAP only applies to intraday ranges (1D/5D/1M) — clear it otherwise.
+    if (!INTRADAY_RANGES.has(iv)) setShowVwap(false);
     fetchIntervalHistory(iv);
   }, [fetchIntervalHistory]);
 
@@ -220,6 +224,19 @@ export default function PriceChartCard({
             <ToggleButton value="line">LINE</ToggleButton>
             <ToggleButton value="candle">CANDLE</ToggleButton>
           </ToggleButtonGroup>
+
+          {/* VWAP overlay — intraday ranges only (5m/15m/1h carry vwap bars) */}
+          {intraday && (
+            <ToggleButtonGroup
+              aria-label="vwap-overlay"
+              value={showVwap ? ['vwap'] : []}
+              onChange={() => setShowVwap(v => !v)}
+              size="small"
+              sx={toggleSx}
+            >
+              <ToggleButton value="vwap">VWAP</ToggleButton>
+            </ToggleButtonGroup>
+          )}
         </Box>
 
         {/* Indicators Guide (collapsible) */}
@@ -327,6 +344,7 @@ export default function PriceChartCard({
             support={isTwoYear ? (prediction.indicators?.support ?? []) : []}
             resistance={isTwoYear ? (prediction.indicators?.resistance ?? []) : []}
             intraday={intraday}
+            showVwap={intraday && showVwap}
           />
         </Box>
       </CardContent>


### PR DESCRIPTION
## Summary

Completes the **Ticker Analysis Tab polish** (Feature 7). The dynamic chart interval selector and the `/history` backend endpoint + proxy already shipped to `main` in earlier work, so this PR adds the three genuinely-remaining pieces plus test coverage.

### Improvement A — VWAP overlay (the missing slice)
The `/history` endpoint already computes a per-bar VWAP for intraday ranges, but it was never rendered.
- `AdvancedChart` gains a `showVwap` prop → dashed **orange** line series from each bar's `vwap`.
- `PriceChartCard` shows a `[VWAP]` toggle **only for intraday ranges** (1D/5D/1M = 5m/15m/1h bars); it resets on symbol change and when switching to a daily range.

### Improvement B — Persistent symbol in URL
- After a successful prediction, `handlePredict` calls `router.replace('/analysis?symbol=TICKER', { scroll: false })` → shareable, reload-safe, back/forward-navigable.
- A `lastLoadedRef` guard on the `?symbol=` effect prevents the programmatic URL change from re-triggering a duplicate `/predict` (verified: exactly one `/api/predict` per search).

### Improvement C — Watchlist quick-launch
- Watchlist chips now call `handlePredict(sym)` (full analysis + URL update) instead of only `setTicker`.

### Tests
- New `backend/tests/test_history.py` (5 tests): intraday shape + metrics + VWAP presence, daily InfluxDB→yfinance fallback, and 400/404 validation. yfinance/Influx/Redis all mocked.

## Verification
- Backend: `74 passed` (incl. 5 new), `ruff check backend/` clean.
- Frontend: `eslint .` 0 errors, `next build` clean TypeScript.
- Live browser (NVDA):
  - Initial `/analysis?symbol=NVDA` → loads, 2Y default, VWAP toggle hidden.
  - Switch to **1D** → `/api/history → 200`, metric chips update to interval values, VWAP toggle appears; enabling it renders the dashed orange line (no console errors).
  - Switch back to **2Y** → VWAP toggle hidden, original view restored.
  - Manual search **AAPL** → URL updates to `/analysis?symbol=AAPL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added VWAP (Volume Weighted Average Price) overlay toggle for intraday charts on 1D, 5D, and 1-month ranges.
  * Ticker selection now syncs with the URL, enabling easy sharing of analysis views and seamless back/forward navigation.

* **Improvements**
  * Watchlist ticker selection now immediately triggers analysis fetch for faster exploration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->