### PR TITLE
fix(ci): forward SUPABASE_JWT_SECRET to the Oracle backend container

### DIFF
--- a/.github/actions/deploy-oracle/action.yml
+++ b/.github/actions/deploy-oracle/action.yml
@@ -83,6 +83,7 @@ runs:
             -e GROQ_API_KEY=${{ env.GROQ_API_KEY }} \
             -e ALPACA_API_KEY=${{ env.ALPACA_API_KEY }} \
             -e ALPACA_SECRET_KEY=${{ env.ALPACA_SECRET_KEY }} \
+            -e SUPABASE_JWT_SECRET=${{ env.SUPABASE_JWT_SECRET }} \
             -e APP_ENV=${{ env.APP_ENV }} \
             -e NEW_RELIC_LICENSE_KEY=${{ env.NEW_RELIC_LICENSE_KEY }} \
             -e NEW_RELIC_APP_NAME=${{ env.NEW_RELIC_APP_NAME }} \

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -237,7 +237,8 @@ jobs:
           X_AI_API_KEY: ${{ secrets.X_AI_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           ALPACA_API_KEY: ${{ secrets.ALPACA_API_KEY }}
-          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}        
+          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
+          SUPABASE_JWT_SECRET: ${{ secrets.SUPABASE_JWT_SECRET }}
           UPSTASH_REDIS_URL: ${{ env.UPSTASH_REDIS_URL }}
           APP_ENV: "preview"
           NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}


### PR DESCRIPTION
## Problem

Signed-in users on the **preview** site (and the **prod Oracle VM**) get 401 on every auth-gated endpoint — Trade Setup is blank and the jury "Use tools" run fails — even with a valid Supabase login.

Root cause: the `deploy-oracle` composite action's `docker run` **never forwarded `SUPABASE_JWT_SECRET`** into the backend container. So `Config.SUPABASE_JWT_SECRET` is empty, and `get_user_id` (which fails closed without a secret) rejects every token.

- `merge.yml` *did* set `SUPABASE_JWT_SECRET` in the deploy-oracle step env — but the action dropped it on the floor, so even the **prod Oracle VM** (`fiforesight.duckdns.org`) was affected. (Prod Koyeb gets it via `deploy-koyeb`, which is why it wasn't noticed.)
- `pull-request.yml` (preview) didn't set it at all.

## Fix

- **`.github/actions/deploy-oracle/action.yml`** — add `-e SUPABASE_JWT_SECRET=${{ env.SUPABASE_JWT_SECRET }}` to `docker run`. This fixes the prod Oracle VM immediately (its env already provides the secret).
- **`.github/workflows/pull-request.yml`** — pass `SUPABASE_JWT_SECRET` to the preview deploy step.

## ⚠️ Required before this works on preview

The `SUPABASE_JWT_SECRET` secret must exist in the **`preview` GitHub environment** (Settings → Environments → preview → Secrets) and its value must match the Supabase project that issues the frontend tokens (Supabase → Settings → API → JWT Secret). If it's currently only a prod-environment secret, add it to `preview` too. Without it, `secrets.SUPABASE_JWT_SECRET` resolves empty and the backend still fails closed.

## Why not `ALLOW_INSECURE_JWT`

The preview URL is public; decoding tokens without signature verification would let anyone forge a user id. Setting the real secret is the correct fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
