### PR TITLE
feat(insights): naive-persistence baseline + per-model skill scores

### DIFF
--- a/backend/routers/analytics.py
+++ b/backend/routers/analytics.py
@@ -72,6 +72,7 @@ def _compute_accuracy(
     dir_counts = {k: [0, 0] for k in ("prophet", "sarima", "random_forest", "ensemble")}
     field_map = {"prophet": "p_d1", "sarima": "s_d1", "random_forest": "r_d1", "ensemble": "e_d1"}
     matched = 0
+    naive_errors: list[float] = []
 
     for rec in records:
         pred_time = rec.get("_time")
@@ -94,6 +95,7 @@ def _compute_accuracy(
         if actual is None:
             continue
         matched += 1
+        naive_errors.append(abs(actual - last_price))
 
         e_d1 = rec.get("e_d1")
         if e_d1 is not None and e_d1 > _MISSING:
@@ -119,6 +121,15 @@ def _compute_accuracy(
     }
     forecast_vs_actual = [fva_by_date[d] for d in sorted(fva_by_date)]
 
+    # ── Naive-persistence baseline & per-model skill ──────────────────────────
+    # Naive baseline: always predict last_price (yesterday's close).
+    # skill = 1 − model_mae/naive_mae; >0 beats persistence, <0 is worse.
+    naive_mae: float | None = round(sum(naive_errors) / len(naive_errors), 2) if naive_errors else None
+    model_skill: dict = {}
+    if naive_mae and naive_mae > 0:
+        for model, mae in model_mae.items():
+            model_skill[model] = round(1.0 - mae / naive_mae, 3)
+
     return {
         "model_mae":               model_mae,
         "best_model":              best_model,
@@ -126,6 +137,8 @@ def _compute_accuracy(
         "directional_accuracy":    directional_accuracy,
         "forecast_vs_actual":      forecast_vs_actual,
         "samples":                 matched,
+        "naive_mae":               naive_mae,
+        "model_skill":             model_skill,
     }
 
 
@@ -160,6 +173,7 @@ async def accuracy_analytics(request: Request, symbol: str):
         result = {
             "model_mae": {}, "best_model": None, "ensemble_mae_by_horizon": [],
             "directional_accuracy": {}, "forecast_vs_actual": [], "samples": 0,
+            "naive_mae": None, "model_skill": {},
         }
 
     payload = {

--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -142,6 +142,34 @@ def test_accuracy_empty_returns_200_samples_zero() -> None:
     assert d["best_model"] is None
     assert d["ensemble_mae_by_horizon"] == []
     assert d["forecast_vs_actual"] == []
+    assert d["naive_mae"] is None
+    assert d["model_skill"] == {}
+
+
+def test_accuracy_skill_score_positive() -> None:
+    """Model MAE < naive → positive skill score (beats persistence)."""
+    # last_price=100, actual=110 → naive_error=10; rf MAE=4 → skill=1-4/10=0.6
+    model_acc = {"rf": {"mae": 4.0, "samples": 5}}
+    records = [_forecast_record(3, 100.0, 105.0, 0.0, 104.0, 103.0)]
+    outcomes = {_ts(2).date(): 110.0}
+    with _patch_store(model_acc=model_acc, records=records, outcomes=outcomes):
+        resp = client.get("/analytics/accuracy/NVDA")
+    d = resp.json()
+    assert d["naive_mae"] == 10.0
+    assert d["model_skill"]["random_forest"] == 0.6
+
+
+def test_accuracy_skill_score_negative() -> None:
+    """Model MAE > naive → negative skill score (worse than persistence)."""
+    # last_price=100, actual=101 → naive_error=1; rf MAE=4 → skill=1-4/1=-3.0
+    model_acc = {"rf": {"mae": 4.0, "samples": 5}}
+    records = [_forecast_record(3, 100.0, 102.0, 0.0, 104.0, 103.0)]
+    outcomes = {_ts(2).date(): 101.0}
+    with _patch_store(model_acc=model_acc, records=records, outcomes=outcomes):
+        resp = client.get("/analytics/accuracy/NVDA")
+    d = resp.json()
+    assert d["naive_mae"] == 1.0
+    assert d["model_skill"]["random_forest"] == -3.0
 
 
 def test_accuracy_invalid_symbol_422() -> None:

--- a/frontend/app/(app)/insights/page.tsx
+++ b/frontend/app/(app)/insights/page.tsx
@@ -9,7 +9,7 @@ import {
 } from '@mui/material';
 import {
   BarChart, Bar, LineChart, Line, XAxis, YAxis, CartesianGrid,
-  ResponsiveContainer, Tooltip, ReferenceLine, Cell, Legend, LabelList,
+  ResponsiveContainer, Tooltip, ReferenceLine, Cell, Legend,
 } from 'recharts';
 import { Activity, Search, Target, TrendingUp, Gauge } from 'lucide-react';
 import { useAppShell } from '../../../contexts/AppShellContext';

--- a/frontend/app/(app)/insights/page.tsx
+++ b/frontend/app/(app)/insights/page.tsx
@@ -9,7 +9,7 @@ import {
 } from '@mui/material';
 import {
   BarChart, Bar, LineChart, Line, XAxis, YAxis, CartesianGrid,
-  ResponsiveContainer, Tooltip, ReferenceLine, Cell, Legend,
+  ResponsiveContainer, Tooltip, ReferenceLine, Cell, Legend, LabelList,
 } from 'recharts';
 import { Activity, Search, Target, TrendingUp, Gauge } from 'lucide-react';
 import { useAppShell } from '../../../contexts/AppShellContext';
@@ -99,7 +99,12 @@ function InsightsContent() {
   // ── Derived chart data ───────────────────────────────────────────────────────
   const modelMaeData = accuracy
     ? Object.entries(accuracy.model_mae)
-        .map(([model, mae]) => ({ model: MODEL_LABELS[model] ?? model, key: model, mae }))
+        .map(([model, mae]) => ({
+          model: MODEL_LABELS[model] ?? model,
+          key: model,
+          mae,
+          skill: accuracy.model_skill?.[model as keyof typeof accuracy.model_skill] ?? null,
+        }))
         .sort((a, b) => a.mae - b.mae)
     : [];
 
@@ -206,14 +211,28 @@ function InsightsContent() {
                   {modelMaeData.length > 0 ? (
                     <>
                       <ResponsiveContainer width="100%" height={240}>
-                        <BarChart layout="vertical" data={modelMaeData} margin={{ top: 16, right: 24, bottom: 0, left: 8 }}>
+                        <BarChart layout="vertical" data={modelMaeData} margin={{ top: 16, right: 32, bottom: 0, left: 8 }}>
                           <CartesianGrid strokeDasharray="3 3" stroke={gridColor} horizontal={false} />
                           <XAxis type="number" stroke={axisColor} tick={{ fontSize: 12 }} />
                           <YAxis type="category" dataKey="model" stroke={axisColor} tick={{ fontSize: 12 }} width={90} />
                           <Tooltip
                             contentStyle={{ background: isDark ? '#0f172a' : '#fff', border: `1px solid ${gridColor}`, borderRadius: 8 }}
-                            formatter={(v: number) => [`$${v.toFixed(2)}`, 'MAE']}
+                            formatter={(v: number, _n: string, props: { payload?: { skill: number | null } }) => {
+                              const skill = props.payload?.skill;
+                              const skillStr = skill != null
+                                ? `  (skill: ${skill >= 0 ? '+' : ''}${Math.round(skill * 100)}%)`
+                                : '';
+                              return [`$${v.toFixed(2)}${skillStr}`, 'MAE'];
+                            }}
                           />
+                          {accuracy?.naive_mae != null && (
+                            <ReferenceLine
+                              x={accuracy.naive_mae}
+                              stroke={isDark ? '#f59e0b' : '#d97706'}
+                              strokeDasharray="4 4"
+                              label={{ value: `Naive $${accuracy.naive_mae}`, fill: isDark ? '#f59e0b' : '#d97706', fontSize: 10, position: 'insideTopRight' }}
+                            />
+                          )}
                           <Bar dataKey="mae" radius={[0, 6, 6, 0]}>
                             {modelMaeData.map(d => (
                               <Cell key={d.key} fill={accuracy && d.key === accuracy.best_model ? (isDark ? '#00ffa3' : '#16a34a') : primaryColor} />
@@ -226,6 +245,24 @@ function InsightsContent() {
                           Most accurate: <strong style={{ color: isDark ? '#00ffa3' : '#16a34a' }}>{MODEL_LABELS[accuracy.best_model]}</strong>
                           {' · '}{accuracy.samples} resolved sample{accuracy.samples === 1 ? '' : 's'}
                         </Typography>
+                      )}
+                      {/* Skill score chips — how much each model beats naive persistence */}
+                      {accuracy?.model_skill && Object.keys(accuracy.model_skill).length > 0 && (
+                        <Stack direction="row" spacing={0.5} sx={{ mt: 1, flexWrap: 'wrap', gap: 0.5 }}>
+                          {modelMaeData.map(d => {
+                            if (d.skill == null) return null;
+                            const pct = Math.round(d.skill * 100);
+                            const col = pct > 0 ? (isDark ? '#00ffa3' : '#16a34a') : (isDark ? '#ff6b6b' : '#dc2626');
+                            return (
+                              <Chip
+                                key={d.key}
+                                size="small"
+                                label={`${d.model}: ${pct >= 0 ? '+' : ''}${pct}% vs naive`}
+                                sx={{ fontSize: 11, height: 22, color: col, bgcolor: `${col}1a`, fontWeight: 600 }}
+                              />
+                            );
+                          })}
+                        </Stack>
                       )}
                     </>
                   ) : <EmptyChart label="No per-model accuracy yet" isDark={isDark} />}

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -280,6 +280,10 @@ export interface AccuracyAnalytics {
   directional_accuracy: Partial<Record<'prophet' | 'sarima' | 'random_forest' | 'ensemble', number | null>>;
   forecast_vs_actual: ForecastVsActualPoint[];
   samples: number;
+  /** MAE of the naive persistence forecast (predict last_price → tomorrow). */
+  naive_mae?: number | null;
+  /** Per-model skill score: 1 − model_mae/naive_mae. >0 beats persistence, <0 is worse than a coin-flip baseline. */
+  model_skill?: Partial<Record<'prophet' | 'sarima' | 'random_forest', number>>;
   generated_at: string;
 }
 


### PR DESCRIPTION
## Summary

- Adds **naive-persistence MAE** to `/analytics/accuracy/{symbol}`: the baseline of always predicting "tomorrow = today" (`last_price`). This is the floor any useful model must beat.
- Computes a **per-model skill score** (`1 − model_mae / naive_mae`): positive = beats persistence, negative = worse than a coin-flip baseline.
- **Model Performance bar chart** now shows a dashed amber reference line at `naive_mae` — any bar shorter than the line is adding real signal.
- **Skill-score chips** below the chart show `+X% / −X% vs naive` per model (green/red).
- MAE tooltip extended inline: `$4.20 (skill: +12%)`.

## Why it matters

The Forecast vs Actual chart (Feature 12) revealed the forecaster exhibits a persistence artifact — predicted values closely track actual with a ~1-day lag, yielding ~44–51% directional accuracy (coin-flip). The skill score makes this visible: if all models show negative skill, the forecaster is under-skilled vs a trivially cheap baseline and the user knows to interpret predictions with appropriate skepticism. This is also the measurement foundation before building the reversal classifier (Step 3).

## Test plan

- [ ] 12 analytics tests pass (2 new: `test_accuracy_skill_score_positive`, `test_accuracy_skill_score_negative`); full suite 117 passed.
- [ ] TypeScript build clean.
- [ ] On /insights with a ticker that has history: amber `Naive $X.XX` reference line visible on the Model Performance bar chart; skill chips appear below it.
- [ ] Empty state (no history yet): no naive_mae line, no chips — graceful.
- [ ] Stacks cleanly on top of PR #244 (base branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model skill score analytics that measure each model's performance relative to a naive persistence baseline.
  * Enhanced the Insights page with a baseline reference line in performance charts.
  * Added skill percentage indicators displayed in chart tooltips and as visual chips for quick model comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->