### PR TITLE
feat(ensemble): skill-based model weighting (beat-naive-or-zero)

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -713,6 +713,36 @@ def run_monte_carlo(
 
 
 # ---------------------------------------------------------------------------
+# Ensemble weight helper
+# ---------------------------------------------------------------------------
+
+def _skill_to_weights(
+    maes: List[float],
+    naive_mae: Optional[float],
+) -> List[float]:
+    """
+    Convert [prophet_mae, sarima_mae, rf_mae] + naive_mae into normalised
+    ensemble weights.
+
+    If naive_mae is available: weight ∝ max(0, 1 − model_mae/naive_mae).
+    Models at or below naive persistence get weight 0.  If ALL are at or
+    below naive (degenerate case) fall back to equal weights.
+
+    If naive_mae is None or 0: fall back to 1/mae (original RL behaviour).
+    """
+    eps = 1e-6
+    if naive_mae and naive_mae > 0:
+        skills = [max(0.0, 1.0 - m / naive_mae) for m in maes]
+        total  = sum(skills)
+        if total > 0:
+            return [s / total for s in skills]
+        return [1 / 3, 1 / 3, 1 / 3]   # all ≤ naive — equal fallback
+    inv   = [1.0 / (m + eps) for m in maes]
+    total = sum(inv)
+    return [v / total for v in inv] if total > 0 else [1 / 3, 1 / 3, 1 / 3]
+
+
+# ---------------------------------------------------------------------------
 # Main ensemble entry point
 # ---------------------------------------------------------------------------
 

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -1012,10 +1012,18 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
     # ── RL: load historical model accuracy for weight calibration ────────────
     # All three queries run concurrently — no inter-dependency.
     logger.debug(f"[RL] Querying historical model accuracy for {symbol} ...")
+
+    async def _rl_query(fn, default):
+        try:
+            return await asyncio.wait_for(asyncio.to_thread(fn, symbol), timeout=12.0)
+        except Exception as exc:
+            logger.warning("[RL] metric query failed (%s): %s — using default", fn.__name__, exc)
+            return default
+
     model_acc, ensemble_mae, naive_mae_val = await asyncio.gather(
-        asyncio.to_thread(forecast_store.query_model_accuracy, symbol),
-        asyncio.to_thread(forecast_store.query_ensemble_mae,   symbol),
-        asyncio.to_thread(forecast_store.query_naive_mae,      symbol),
+        _rl_query(forecast_store.query_model_accuracy, {}),
+        _rl_query(forecast_store.query_ensemble_mae,   {}),
+        _rl_query(forecast_store.query_naive_mae,      None),
     )
 
     historical_weights = None

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -15,6 +15,7 @@ from models import (
     calculate_rsi, calculate_rsi_series, run_ensemble_forecast,
     calculate_macd, calculate_bollinger_bands, calculate_sma_series,
     calculate_ema_series, calculate_support_resistance,
+    _skill_to_weights,
 )
 from services import DataCleaner, ANALYST_PERSONAS
 from dependencies import (
@@ -1009,9 +1010,13 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
     )
 
     # ── RL: load historical model accuracy for weight calibration ────────────
+    # All three queries run concurrently — no inter-dependency.
     logger.debug(f"[RL] Querying historical model accuracy for {symbol} ...")
-    model_acc = await asyncio.to_thread(forecast_store.query_model_accuracy, symbol)
-    ensemble_mae = await asyncio.to_thread(forecast_store.query_ensemble_mae, symbol)
+    model_acc, ensemble_mae, naive_mae_val = await asyncio.gather(
+        asyncio.to_thread(forecast_store.query_model_accuracy, symbol),
+        asyncio.to_thread(forecast_store.query_ensemble_mae,   symbol),
+        asyncio.to_thread(forecast_store.query_naive_mae,      symbol),
+    )
 
     historical_weights = None
     rl_sample_count    = 0
@@ -1028,19 +1033,20 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
         )
         rl_sample_count = min_samples
         if rl_sample_count > 0:
-            eps      = 1e-6
-            inv_maes = [
-                1.0 / (p_acc.get("mae", 999.0) + eps),
-                1.0 / (s_acc.get("mae", 999.0) + eps),
-                1.0 / (r_acc.get("mae", 999.0) + eps),
+            maes = [
+                p_acc.get("mae", 999.0),
+                s_acc.get("mae", 999.0),
+                r_acc.get("mae", 999.0),
             ]
-            total_inv          = sum(inv_maes)
-            historical_weights = [v / total_inv for v in inv_maes] if total_inv > 0 else None
+            historical_weights = _skill_to_weights(maes, naive_mae_val)
+            using_skill = naive_mae_val is not None and naive_mae_val > 0
             logger.debug(
-                f"[RL] Historical weights (inv-MAE) — "
-                f"prophet={historical_weights[0]:.3f}, "
-                f"sarima={historical_weights[1]:.3f}, "
-                f"rf={historical_weights[2]:.3f} | samples={rl_sample_count}"
+                "[RL] %s weights — prophet=%.3f sarima=%.3f rf=%.3f | "
+                "naive_mae=%s | samples=%d",
+                "Skill-based" if using_skill else "Inv-MAE (no naive baseline yet)",
+                historical_weights[0], historical_weights[1], historical_weights[2],
+                "N/A" if naive_mae_val is None else f"{naive_mae_val:.4f}",
+                rl_sample_count,
             )
         # Build track record string for analyst jury context
         parts = []

--- a/backend/services.py
+++ b/backend/services.py
@@ -726,6 +726,30 @@ class ForecastStore:
             logger.error(f"[RL] ✗ query_price_outcomes error for {symbol}: {e}")
             return {}
 
+    def query_naive_mae(self, symbol: str, days: int = 90) -> Optional[float]:
+        """
+        Naive-persistence MAE: mean(|actual_close - last_price|) over matched d1
+        forecast records.  Returns None when there are no matched records.
+        """
+        records  = self.query_forecast_records(symbol, days=days)
+        outcomes = self.query_price_outcomes(symbol, days=days + 10)
+        outcomes_sorted = sorted(outcomes.items())
+        errors: list = []
+        for rec in records:
+            pred_time  = rec.get("_time")
+            last_price = rec.get("last_price")
+            if pred_time is None or last_price is None or last_price <= 0:
+                continue
+            try:
+                pred_date = pred_time.date()
+            except AttributeError:
+                continue
+            for d, close in outcomes_sorted:
+                if d > pred_date and close > 0:
+                    errors.append(abs(close - float(last_price)))
+                    break
+        return round(sum(errors) / len(errors), 4) if errors else None
+
     def query_model_accuracy(self, symbol: str, lookback_days: int = 90) -> Dict[str, dict]:
         """
         Returns most-recent per-model accuracy record.

--- a/backend/services.py
+++ b/backend/services.py
@@ -730,25 +730,33 @@ class ForecastStore:
         """
         Naive-persistence MAE: mean(|actual_close - last_price|) over matched d1
         forecast records.  Returns None when there are no matched records.
+        Fails closed — any exception logs a warning and returns None.
         """
-        records  = self.query_forecast_records(symbol, days=days)
-        outcomes = self.query_price_outcomes(symbol, days=days + 10)
-        outcomes_sorted = sorted(outcomes.items())
-        errors: list = []
-        for rec in records:
-            pred_time  = rec.get("_time")
-            last_price = rec.get("last_price")
-            if pred_time is None or last_price is None or last_price <= 0:
-                continue
-            try:
-                pred_date = pred_time.date()
-            except AttributeError:
-                continue
-            for d, close in outcomes_sorted:
-                if d > pred_date and close > 0:
-                    errors.append(abs(close - float(last_price)))
-                    break
-        return round(sum(errors) / len(errors), 4) if errors else None
+        try:
+            records  = self.query_forecast_records(symbol, days=days)
+            outcomes = self.query_price_outcomes(symbol, days=days + 10)
+            outcomes_sorted = sorted(outcomes.items())
+            errors: List[float] = []
+            for rec in records:
+                pred_time      = rec.get("_time")
+                last_price_raw = rec.get("last_price")
+                if pred_time is None or last_price_raw is None:
+                    continue
+                try:
+                    pred_date  = pred_time.date()
+                    last_price = float(last_price_raw)
+                except (AttributeError, TypeError, ValueError):
+                    continue
+                if last_price <= 0:
+                    continue
+                for d, close in outcomes_sorted:
+                    if d > pred_date and close > 0:
+                        errors.append(abs(float(close) - last_price))
+                        break
+            return round(sum(errors) / len(errors), 4) if errors else None
+        except Exception as exc:
+            logger.warning("[RL] query_naive_mae failed for %s: %s", symbol, exc)
+            return None
 
     def query_model_accuracy(self, symbol: str, lookback_days: int = 90) -> Dict[str, dict]:
         """

--- a/backend/tests/test_skill_weights.py
+++ b/backend/tests/test_skill_weights.py
@@ -1,0 +1,64 @@
+"""
+Unit tests for _skill_to_weights — ensemble weighting helper.
+Pure logic, no I/O, no mocks needed.
+"""
+from backend.models import _skill_to_weights
+
+
+def test_proportional_to_skill() -> None:
+    """Weights are proportional to skill when all models beat naive."""
+    # naive=4.0 → skills: [1-2/4, 1-3/4, 1-1/4] = [0.5, 0.25, 0.75]
+    w = _skill_to_weights([2.0, 3.0, 1.0], naive_mae=4.0)
+    assert abs(sum(w) - 1.0) < 1e-9
+    assert w[2] > w[0] > w[1]   # rf > prophet > sarima
+
+
+def test_below_naive_zeroed() -> None:
+    """A model worse than naive persistence receives weight 0."""
+    # naive=3.0 → skills: [1-1/3≈0.667, max(0,1-5/3)=0, 1-2/3≈0.333]
+    w = _skill_to_weights([1.0, 5.0, 2.0], naive_mae=3.0)
+    assert w[1] == 0.0
+    assert w[0] > 0.0 and w[2] > 0.0
+    assert abs(sum(w) - 1.0) < 1e-9
+
+
+def test_all_below_naive_equal_fallback() -> None:
+    """When all models are ≤ naive, equal weights are returned."""
+    w = _skill_to_weights([5.0, 6.0, 7.0], naive_mae=1.0)
+    assert w == [1 / 3, 1 / 3, 1 / 3]
+
+
+def test_no_naive_mae_inv_mae_fallback() -> None:
+    """Without a naive baseline, fall back to inverse-MAE weighting."""
+    w = _skill_to_weights([2.0, 4.0, 1.0], naive_mae=None)
+    # inv-MAE: rf (1.0) gets highest weight, sarima (4.0) lowest
+    assert w[2] > w[0] > w[1]
+    assert abs(sum(w) - 1.0) < 1e-9
+
+
+def test_zero_naive_mae_inv_mae_fallback() -> None:
+    """naive_mae=0 is treated the same as None (no division by zero)."""
+    w = _skill_to_weights([2.0, 3.0, 1.0], naive_mae=0.0)
+    assert abs(sum(w) - 1.0) < 1e-9
+    assert w[2] > w[0] > w[1]
+
+
+def test_weights_always_sum_to_one() -> None:
+    """Invariant: weights sum to 1.0 for all inputs."""
+    cases = [
+        ([1.0, 2.0, 3.0], 2.5),
+        ([0.5, 0.5, 0.5], 1.0),
+        ([999.0, 999.0, 999.0], None),
+        ([1.0, 1.0, 1.0], 0.0),
+    ]
+    for maes, naive in cases:
+        w = _skill_to_weights(maes, naive_mae=naive)
+        assert abs(sum(w) - 1.0) < 1e-9, f"Failed for maes={maes} naive={naive}"
+
+
+def test_equal_skill_equal_weights() -> None:
+    """Models with identical skill scores get equal weights."""
+    w = _skill_to_weights([1.0, 1.0, 1.0], naive_mae=2.0)
+    assert abs(w[0] - 1 / 3) < 1e-9
+    assert abs(w[1] - 1 / 3) < 1e-9
+    assert abs(w[2] - 1 / 3) < 1e-9


### PR DESCRIPTION
## Summary

- Replaces `1/MAE` historical weights with `max(0, 1 − model_mae/naive_mae)` — weights proportional to how much each model beats naive persistence
- Adds `ForecastStore.query_naive_mae()` — computes persistence MAE from existing `forecast_record` + `price_outcome` InfluxDB data (no new measurements)
- Runs all 3 RL queries concurrently via `asyncio.gather` (minor latency improvement)
- Falls back to `1/MAE` for tickers with no naive baseline yet; falls back to equal weights when all models are ≤ naive

## Why

The previous `1/MAE` weighting can reward persistence-mimicry: a model that just predicts `last_price` each day gets a low MAE on random-walk assets and therefore a high weight. The scoreboard (PR #245) made this visible. This PR fixes it — a model must beat the trivial baseline to earn weight in the ensemble.

## API contract

No changes to request/response shapes. The `modelWeights` field in `/predict` continues to return `{prophet, sarima, rf}` fractions — they now reflect skill rather than raw inverse-MAE.

## Test plan

- [ ] `python -m pytest backend/tests/test_skill_weights.py -v` — 7 unit tests, all pure logic
- [ ] `python -m pytest backend/tests/ --tb=short` — full suite (132 tests)
- [ ] `ruff check backend/` — clean
- [ ] Verify `/predict AAPL` logs show `[RL] Skill-based weights` once the ticker has resolved forecast records; new tickers log `Inv-MAE (no naive baseline yet)` as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced ensemble forecast weighting with skill-based calibration that accounts for naive baseline performance metrics.
  * Improved concurrent metric retrieval for faster forecast calculations.

* **Tests**
  * Added comprehensive test coverage for ensemble weight calibration logic to ensure stability across edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->