### PR TITLE
feat(f13): watchlist persistence + intraday sparklines + responsive design

### DIFF
--- a/.claude/FiForesight_Roadmap.md
+++ b/.claude/FiForesight_Roadmap.md
@@ -1,7 +1,7 @@
 # FiForesight Roadmap
 
 > Source of truth for planned work. Feature-based, free-tier only.
-> Last synced: 2026-06-08 — Features 5–8 shipped. Features 9–12 committed (security, analytics, portfolio, alerts). Sequence: F11 → F12 → F10 → F9.
+> Last synced: 2026-06-12 — F11/F12/F10 shipped. F13 (Watchlist + Intraday Sparklines + Responsive) shipped. F9 (Alerts) remains.
 
 ---
 
@@ -37,6 +37,8 @@ Documentation is part of the feature, not an afterthought. A feature PR is **not
 - Jury quant lens swapped to `openai/gpt-oss-20b`; verdict parsing hardened; malformed output tracked (#226)
 - Forecast Accuracy & Sentiment Analytics Dashboard — `/insights` tab + `GET /analytics/{accuracy,sentiment}/{symbol}`; persists VADER compound to new `sentiment_score` measurement (Feature 12, PR #244)
 - Portfolio Manager — real holdings + live P&L ("My Portfolio" tab) + `GET/POST/DELETE /portfolio/holdings` + `GET /portfolio/summary` (Supabase `holdings` + RLS); existing race sim renamed "Simulator" (Feature 10, PR #249)
+
+- Watchlist persistence + intraday sparklines + responsive design (Feature 13): `watchlists` Supabase table, `/watchlist` CRUD, intraday 5m bars on `/sparklines`, `WatchlistContext`, sidebar watchlist panel, mobile bottom chip bar, full responsive audit across all tabs (320px–4K). 13 new backend tests. (#pending-F13)
 
 ### Data & UX
 - SerpAPI news + trending sparklines
@@ -171,8 +173,6 @@ Documentation is part of the feature, not an afterthought. A feature PR is **not
 - Earnings call transcript sentiment — SEC EDGAR free; NLP on 10-Q/8-K filings · `[Value: Med]` `[Effort: High]`
 
 ### UX & Data Display
-- Intraday sparklines (QW-1) — replace static trending ticker list with 1-day `5m` bars; "Today" label; dynamic list from SerpAPI trending + SPY/QQQ/BTC anchors · `[Value: High]` `[Effort: Low]` · *Files: `TrendingSparklines.tsx`, `GET /sparklines` endpoint*
-- Watchlist persistence (Supabase) — auth is shipped; save/load watchlist tickers to Supabase; sync across devices · `[Value: High]` `[Effort: Med]`
 - Multi-ticker overlay comparison — ratio chart (stock vs SPY); rolling 30d correlation line · `[Value: Med]` `[Effort: Low]`
 - Macro dashboard (`/macro` tab) — standalone FRED tab: GDP, CPI, rates, yield curve, fed dot plot · `[Value: Med]` `[Effort: Med]`
 - International markets — yfinance supports non-US tickers; exchange detection already exists · `[Value: Med]` `[Effort: Med]`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,11 +37,12 @@ FiForesight/
 │   │   ├── market.py           # /dcf /options /ipo/calendar /earnings/calendar /sectors /briefing /orderbook
 │   │   ├── analytics.py        # /analytics/accuracy/{symbol} /analytics/sentiment/{symbol}
 │   │   ├── portfolio.py        # /portfolio/holdings (GET/POST/DELETE) /portfolio/summary (auth-gated)
-│   │   └── alerts.py           # /alerts/rules (CRUD) /alerts/fires /alerts/subscribe /alerts/evaluate [cron] (Feature 9)
+│   │   ├── alerts.py           # /alerts/rules (CRUD) /alerts/fires /alerts/subscribe /alerts/evaluate [cron] (Feature 9)
+│   │   └── watchlist.py        # /watchlist (GET/POST/DELETE) — Feature 13
 │   ├── config.py               # Env var loading (InfluxDB, Groq, SerpAPI, Supabase)
 │   ├── models.py               # Pydantic schemas + run_monte_carlo
 │   ├── services.py             # YFinanceService, InfluxService, SerpService, SentimentService, AnalystJuryService
-│   ├── supabase_rest.py        # RLS-scoped holdings CRUD via the caller's forwarded JWT (Feature 10)
+│   ├── supabase_rest.py        # RLS-scoped holdings + watchlist CRUD via caller's forwarded JWT
 │   ├── alerts_store.py         # Alerts/fires/push-subs storage — user-JWT (RLS) + service-role (evaluator) (Feature 9)
 │   ├── alerts_evaluator.py     # Scheduled rule evaluator + daily digest (pure evaluate_rule + orchestrator) (Feature 9)
 │   ├── notifications.py        # Web Push (pywebpush/VAPID) + optional Resend email delivery (Feature 9)
@@ -62,17 +63,18 @@ FiForesight/
 │   │   │   ├── analytics/sentiment/[symbol]/route.ts  # → /analytics/sentiment
 │   │   │   ├── simulation/{suggest,performance,state}/route.ts
 │   │   │   ├── portfolio/{holdings,holdings/[id],summary}/route.ts  # → /portfolio/*
-│   │   │   └── alerts/{rules,rules/[id],fires,subscribe,unsubscribe,vapid-public-key}/route.ts  # → /alerts/*
+│   │   │   ├── alerts/{rules,rules/[id],fires,subscribe,unsubscribe,vapid-public-key}/route.ts  # → /alerts/*
+│   │   │   └── watchlist/{route.ts,[symbol]/route.ts}  # → /watchlist (Feature 13)
 │   │   ├── (app)/insights/page.tsx           # Insights tab — accuracy + sentiment dashboard (Recharts)
 │   │   ├── (app)/portfolio/page.tsx          # "My Portfolio" tab — real holdings + live P&L (Feature 10)
 │   │   ├── (app)/alerts/page.tsx             # "Alerts" tab — rule builder + fires + Web Push (Feature 9)
 │   │   ├── simulation/page.tsx               # "Simulator" tab — backtest race vs S&P (NOT real holdings)
-│   │   ├── layout.tsx                        # Root layout (ClientProviders + New Relic)
+│   │   ├── layout.tsx                        # Root layout + sidebar WatchlistPanel + MobileWatchlistBar (F13)
 │   │   └── page.tsx                          # Main dashboard
 │   ├── components/
 │   │   ├── AnalystJuryPanel.tsx              # 3-analyst verdict cards + consensus badge
 │   │   ├── AuthModal.tsx                     # Supabase sign-in / sign-up MUI dialog
-│   │   ├── ClientProviders.tsx               # 'use client' wrapper for AuthProvider
+│   │   ├── ClientProviders.tsx               # 'use client' wrapper (AuthProvider + WatchlistProvider)
 │   │   ├── DCFCard.tsx                       # 3-scenario DCF valuation (bear/base/bull)
 │   │   ├── FundamentalsPanel.tsx             # Extended metrics panel
 │   │   ├── MonteCarloFanChart.tsx            # P10/P50/P90 fan chart (Recharts)
@@ -84,8 +86,11 @@ FiForesight/
 │   │   ├── TradeSetupCard.tsx                # Entry/stop/targets + position sizing row
 │   │   └── TrendingSparklines.tsx
 │   ├── contexts/AuthContext.tsx              # AuthProvider + useAuth (Supabase session)
+│   ├── contexts/WatchlistContext.tsx         # WatchlistProvider + useWatchlistContext (Feature 13)
+│   ├── hooks/useWatchlist.ts                 # Thin wrapper over WatchlistContext (backward-compat API)
 │   ├── lib/supabase.ts                       # createClient with env-var fallbacks
-│   ├── lib/holdings.ts                        # Portfolio holdings client → /api/portfolio proxies
+│   ├── lib/holdings.ts                       # Portfolio holdings client → /api/portfolio proxies
+│   ├── lib/watchlist.ts                      # Watchlist client → /api/watchlist proxies (Feature 13)
 │   └── ...config files
 ├── .claude/
 │   └── FiForesight_Roadmap.md     # Source of truth for planned work
@@ -232,6 +237,19 @@ Alerts & Notifications flow (/alerts page — "Alerts" tab, auth-gated; Feature 
        Web Push (pywebpush/VAPID) + optional email (Resend). One bad symbol never aborts the batch.
   POST /alerts/digest    [X-Cron-Secret] → once daily. Reuses /briefing market data + each user's
        holdings movers, pushed/emailed to everyone with a push subscription.
+
+Watchlist flow (Feature 13 — auth-gated writes, anon read = []):
+  GET    /api/watchlist        → list saved symbols [{id, symbol, added_at}]; [] for anon
+  POST   /api/watchlist        → add symbol (upsert; no 409 on duplicate); auth required
+  DELETE /api/watchlist/{sym}  → remove symbol; 204 success, 404 not found; auth required
+  (backed by Supabase `watchlists` table with RLS `auth.uid() = user_id`; GET Redis-cached 60s per user)
+
+Sparklines intraday flow (Feature 13 — updated shape):
+  GET /api/sparklines?tickers=AAPL,MSFT&extra=NVDA
+    → List[{symbol, price, change_pct, bars: [{t, c}]}]
+    → fetches yfinance 1d/5m per symbol; strips pre/post-market (09:30–16:00 ET)
+    → per-symbol Redis cache 5min; partial failures skipped (other symbols still returned)
+    → ?extra= merges watchlist symbols; deduplication; max 24 symbols total
 ```
 
 ---
@@ -261,10 +279,11 @@ See `.claude/FiForesight_Roadmap.md`. Recently shipped:
 | Router split (main.py → routers/) | #195 |
 | IPO tracker tab | #229 |
 | Free IPO calendar (Nasdaq → EDGAR; FMP removed) | #231 |
-| Security hardening (rate limits, auth enforcement, CORS, input validation) | pending |
+| Security hardening (rate limits, auth enforcement, CORS, input validation) | #235 |
 | Forecast accuracy & sentiment dashboard (Insights tab) | #244 |
 | Portfolio Manager — real holdings + live P&L ("My Portfolio" tab) | #249 |
 | Alerts & Notifications — rule builder + scheduled evaluator + Web Push ("Alerts" tab) | #254 |
+| Watchlist persistence + intraday sparklines + responsive design (F13) | pending |
 
 ---
 
@@ -298,4 +317,7 @@ See `.claude/FiForesight_Roadmap.md`. Recently shipped:
 - Deploys: PRs → preview (`fiforesight-preview.duckdns.org`), main → prod (`fiforesight.duckdns.org` + Koyeb).
 - `/compare` frontend route exists; backend endpoint is implemented in `routers/predict.py`.
 - **IPO calendar** (`GET /ipo/calendar` in `market.py`) — **no API key**. Free **Nasdaq** calendar (`api.nasdaq.com/api/ipo/calendar`, needs a browser User-Agent; the default) → **SEC EDGAR** S-1 search (keyless last resort, recent filings only, no upcoming). Response carries `source: "nasdaq"|"edgar"`. `?refresh=true` bypasses the 4h Redis cache. Nasdaq dedup is upcoming-first (a scheduled deal also appears in priced/withdrawn tables). FMP was dropped — it retired its *free* IPO calendar on 2025-08-31.
+- **Watchlist (Feature 13)** — `watchlists` Supabase table (`id, user_id, symbol, added_at`; `unique(user_id, symbol)`); RLS `auth.uid() = user_id`; migration at `supabase/migrations/0006_watchlist.sql`. Router at `backend/routers/watchlist.py`. GET is public (anon → `[]`); POST/DELETE are `require_user`-gated. Same PostgREST forwarding pattern as holdings — caller's JWT + anon key, no service-role. Backend Redis caches GET 60s per user; invalidated on write. Frontend: `WatchlistContext` (`frontend/contexts/WatchlistContext.tsx`) is the source of truth — wraps `AuthProvider` in `ClientProviders.tsx`, fetches on auth-state change, exposes `{watchlist, isLoading, isWatched, add, remove, reload}`. `frontend/hooks/useWatchlist.ts` is a thin backward-compat wrapper over `useWatchlistContext()`. `lib/watchlist.ts` was rewritten to proxy through `/api/watchlist*` (NOT direct Supabase SDK calls). The sidebar shows a collapsible **Watchlist** section below nav items; mobile gets a fixed bottom chip bar. The old `watchlist` (singular) Supabase table from `AuthContext` groundwork is superseded by `watchlists` (plural) via backend proxy.
+- **Intraday sparklines (Feature 13)** — `/sparklines` response shape changed from `Dict[str, List[float]]` (old flat prices) to `List[{symbol, price, change_pct, bars: [{t, c}]}]`. `TrendingSparklines` now accepts `tickers: string[]` (not `{symbol}[]`). The `?extra=` param appends watchlist symbols to the base list; deduplicated to max 24. Each symbol cached 5min in Redis independently. `_fetch_intraday_bars` strips pre/post-market (keeps 09:30–16:00 ET via tz_convert), returns `{}` on any failure.
+- **Responsive design (Feature 13)** — breakpoints: 320px (xs, mobile), 768px (sm, tablet), 1280px (md, desktop), 2560px (4K). Key fixes: PriceChart height 220/300/400px via `useMediaQuery`; DCFCard + TradeSetupCard 3-column grids stack on xs; FundamentalsPanel grid xs:6/sm:4/md:3; Earnings/IPO responsive CSS grid; sidebar `maxWidth: 280` cap at 4K; Shell content `maxWidth: 1600` for 4K; MobileNav tap targets `minHeight: 44`. MorningBriefingPanel + SectorHeatmap use `overflowX: auto` / `flexWrap: wrap` — fine at 320px. OptionsChainPanel table has `overflowX: auto` wrapper. Portfolio table hides columns on mobile via `isMobile` (`useMediaQuery`).
 - **Security model** — `dependencies.py` holds the `limiter` singleton and all auth helpers. `require_user` dependency raises HTTP 401 when no valid Bearer token is present; applied to `/trade-setup` and `/jury/reanalyze`. `/predict` uses a single rate limit keyed by user ID (authed) or IP (anon) via `_user_rate_key`. `/chat` message is capped at 500 chars with control-char sanitization on all context values. CORS is restricted to `ALLOWED_ORIGINS`. Symbol inputs are validated with `[A-Za-z0-9.\-:]{1,15}` on `/predict`, `/dcf/{symbol}`, `/options/{symbol}`, and history. JWT verification picks the verifier by the token's `alg`: **ES256/RS256** (Supabase's default signing-key tokens) are verified against the project **JWKS** (`SUPABASE_URL`, or `SUPABASE_JWKS_URL`); legacy **HS256** tokens use `SUPABASE_JWT_SECRET`. JWKS-only (ES256) is a valid secure production config — the shared secret is not required when a JWKS URL is set. The backend fails closed when **neither** a JWKS URL nor a secret is configured (or decodes unsigned only when `ALLOW_INSECURE_JWT=true`, dev-only; logged at startup). All frontend auth API routes forward the `Authorization` header.

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,7 +13,7 @@ from slowapi.errors import RateLimitExceeded
 from config import Config, SanitizeHttpxFilter
 from dependencies import limiter
 from redis_cache import init_redis, close_redis
-from routers import predict, simulation, trade, market, history, backtest, analytics, portfolio, alerts
+from routers import predict, simulation, trade, market, history, backtest, analytics, portfolio, alerts, watchlist
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -83,6 +83,7 @@ app.include_router(backtest.router)
 app.include_router(analytics.router)
 app.include_router(portfolio.router)
 app.include_router(alerts.router)
+app.include_router(watchlist.router)
 
 
 if __name__ == "__main__":

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -776,21 +776,117 @@ async def health():
     return {"status": "ok", "timestamp": datetime.now(timezone.utc).isoformat()}
 
 
+def _fetch_intraday_bars(symbol: str) -> dict:
+    """Fetch 1-day 5-min OHLCV for symbol; return {price, change_pct, bars}.
+
+    Runs synchronously — call via asyncio.to_thread.
+    Strips pre/post-market bars (keeps 09:30–16:00 ET only).
+    Returns {} on any failure so callers can skip gracefully.
+    """
+    import yfinance as _yf
+
+    try:
+        df = _yf.download(
+            symbol, period="1d", interval="5m",
+            progress=False, auto_adjust=True, timeout=10,
+        )
+        if df is None or df.empty:
+            return {}
+
+        # Flatten MultiIndex columns if present (yfinance ≥ 0.2.38)
+        if hasattr(df.columns, "levels"):
+            df.columns = df.columns.get_level_values(0)
+
+        # Strip pre/post-market: keep 09:30–16:00 ET
+        idx = df.index
+        if idx.tz is None:
+            idx = idx.tz_localize("UTC")
+        idx_et = idx.tz_convert("America/New_York")
+        mask = (
+            ((idx_et.hour == 9)  & (idx_et.minute >= 30)) |
+            ((idx_et.hour > 9)   & (idx_et.hour < 16))    |
+            ((idx_et.hour == 16) & (idx_et.minute == 0))
+        )
+        df = df[mask][:78]  # max 78 bars (full trading day)
+
+        if df.empty:
+            return {}
+
+        close_col = "Close" if "Close" in df.columns else "close"
+        closes_s  = df[close_col].dropna()
+        if len(closes_s) < 2:
+            return {}
+
+        first_close = float(closes_s.iloc[0])
+        last_close  = float(closes_s.iloc[-1])
+        change_pct  = ((last_close - first_close) / first_close * 100) if first_close else 0.0
+
+        bars = [
+            {"t": ts.strftime("%Y-%m-%dT%H:%M:%S"), "c": round(float(v), 4)}
+            for ts, v in zip(
+                closes_s.index.tz_convert("UTC").tz_localize(None),
+                closes_s,
+            )
+        ]
+        return {"price": round(last_close, 4), "change_pct": round(change_pct, 4), "bars": bars}
+    except Exception as exc:
+        logger.debug("[sparklines] _fetch_intraday_bars(%s) error: %s", symbol, exc)
+        return {}
+
+
 @router.get("/sparklines")
 @limiter.limit(lambda: Config.RATE_LIMIT_READONLY, key_func=get_remote_address)
-async def sparklines(request: Request, tickers: str):
-    """Return last-5-close prices for a comma-separated list of tickers."""
-    symbols = [t.strip().upper() for t in tickers.split(",") if t.strip()][:18]
-    result: Dict[str, List[float]] = {}
-    for sym in symbols:
-        try:
-            closes = await asyncio.to_thread(yf_svc.fetch_history, sym, "7d")
-            if closes is not None and not closes.empty:
-                vals = closes["Close"].dropna().tolist()[-5:]
-                result[sym] = [round(float(v), 2) for v in vals]
-        except Exception as e:
-            logger.warning("[sparklines] %s fetch failed: %s", sym, e, exc_info=True)
-    return result
+async def sparklines(request: Request, tickers: str = "", extra: str = ""):
+    """Return intraday 1d/5m bar data for trending tickers + optional extra symbols.
+
+    Query params:
+      tickers — comma-separated base list (legacy; kept for backwards compat)
+      extra   — comma-separated additional symbols (frontend appends watchlist here)
+
+    Response per symbol:
+      { symbol, price, change_pct, bars: [{t, c}] }
+
+    Partial failures are skipped silently; the rest still return.
+    Each symbol is cached individually for 5 minutes to avoid redundant yfinance calls.
+    """
+    # Build deduplicated symbol list (base + extras, max 24)
+    base   = [t.strip().upper() for t in tickers.split(",") if t.strip()]
+    extras = [t.strip().upper() for t in extra.split(",") if t.strip()]
+    seen: set = set()
+    symbols: List[str] = []
+    for s in base + extras:
+        if s and s not in seen:
+            seen.add(s)
+            symbols.append(s)
+    symbols = symbols[:24]
+
+    _SPARKLINE_TTL = 300  # 5 minutes
+
+    async def _get_one(sym: str) -> Optional[dict]:
+        cache_key = f"sparkline:{sym}"
+        cached = await cache_get(cache_key)
+        if cached is not None:
+            return cached
+        data = await asyncio.wait_for(
+            asyncio.to_thread(_fetch_intraday_bars, sym),
+            timeout=10.0,
+        )
+        if data:
+            payload = {"symbol": sym, **data}
+            await cache_set(cache_key, payload, ttl_seconds=_SPARKLINE_TTL)
+            return payload
+        return None
+
+    tasks = [asyncio.create_task(_get_one(s)) for s in symbols]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    output: List[dict] = []
+    for sym, res in zip(symbols, results):
+        if isinstance(res, Exception):
+            logger.warning("[sparklines] %s failed: %s", sym, res)
+        elif res is not None:
+            output.append(res)
+    return output
 
 
 @router.get("/debug")

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -836,7 +836,7 @@ def _fetch_intraday_bars(symbol: str) -> dict:
 
 @router.get("/sparklines")
 @limiter.limit(lambda: Config.RATE_LIMIT_READONLY, key_func=get_remote_address)
-async def sparklines(request: Request, tickers: str = "", extra: str = ""):
+async def sparklines(request: Request, tickers: str = "", extra: str = "") -> List[Dict[str, Any]]:
     """Return intraday 1d/5m bar data for trending tickers + optional extra symbols.
 
     Query params:
@@ -869,7 +869,7 @@ async def sparklines(request: Request, tickers: str = "", extra: str = ""):
             return cached
         data = await asyncio.wait_for(
             asyncio.to_thread(_fetch_intraday_bars, sym),
-            timeout=10.0,
+            timeout=12.0,
         )
         if data:
             payload = {"symbol": sym, **data}

--- a/backend/routers/watchlist.py
+++ b/backend/routers/watchlist.py
@@ -1,0 +1,139 @@
+# backend/routers/watchlist.py
+"""
+Watchlist persistence (Feature 13).
+
+Endpoints:
+  GET    /watchlist         — list user's saved symbols; [] for anonymous
+  POST   /watchlist         — add a symbol (upsert; no 409 on duplicate)
+  DELETE /watchlist/{symbol} — remove a symbol; 204 on success, 404 if not found
+
+Write endpoints (POST/DELETE) are auth-gated via require_user.
+GET is public — anonymous callers receive an empty list without a 401.
+"""
+import logging
+import re
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from pydantic import BaseModel, field_validator
+from slowapi.util import get_remote_address
+
+import supabase_rest
+from config import Config
+from dependencies import limiter, require_user, get_user_id, _user_rate_key
+from redis_cache import cache_get, cache_set, get_redis
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+_SYMBOL_RE = re.compile(r"^[A-Za-z0-9.\-:]{1,15}$")
+_GET_TTL = 60   # 1 min cache per user
+
+
+def _cache_key(user_id: str) -> str:
+    return f"watchlist:{user_id}"
+
+
+def _bearer(authorization: str) -> str:
+    return authorization.removeprefix("Bearer ").strip()
+
+
+def _handle_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, supabase_rest.SupabaseConfigError):
+        logger.error("[WATCHLIST] Supabase not configured.")
+        return HTTPException(status_code=503, detail="Watchlist storage is not configured.")
+    if isinstance(exc, supabase_rest.SupabaseRestError):
+        logger.error("[WATCHLIST] Supabase REST error (HTTP %s): %s", exc.status_code, exc)
+        return HTTPException(status_code=502, detail="Could not reach the watchlist store.")
+    logger.error("[WATCHLIST] unexpected error: %s", exc)
+    return HTTPException(status_code=500, detail="An internal server error occurred.")
+
+
+async def _invalidate(user_id: str) -> None:
+    try:
+        r = get_redis()
+        if r is not None:
+            await r.delete(_cache_key(user_id))
+    except Exception as exc:
+        logger.debug("[WATCHLIST] cache invalidation skipped: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+class WatchlistAdd(BaseModel):
+    symbol: str
+
+    @field_validator("symbol")
+    @classmethod
+    def _validate(cls, v: str) -> str:
+        v = (v or "").strip().upper()
+        if not _SYMBOL_RE.match(v):
+            raise ValueError("Invalid symbol.")
+        return v
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.get("/watchlist")
+@limiter.limit(lambda: Config.RATE_LIMIT_READONLY, key_func=get_remote_address)
+async def list_watchlist(
+    request: Request,
+    authorization: str = Header(default=""),
+):
+    """Return saved watchlist. [] for anonymous callers."""
+    user_id = get_user_id(authorization)
+    if not user_id:
+        return {"watchlist": []}
+
+    cached = await cache_get(_cache_key(user_id))
+    if cached is not None:
+        return {"watchlist": cached}
+
+    try:
+        rows = await supabase_rest.list_watchlist(_bearer(authorization))
+    except Exception as exc:
+        raise _handle_error(exc)
+
+    await cache_set(_cache_key(user_id), rows, ttl_seconds=_GET_TTL)
+    return {"watchlist": rows}
+
+
+@router.post("/watchlist")
+@limiter.limit(lambda: Config.RATE_LIMIT_PORTFOLIO, key_func=_user_rate_key)
+async def add_to_watchlist(
+    request: Request,
+    body: WatchlistAdd,
+    user_id: str = Depends(require_user),
+    authorization: str = Header(default=""),
+):
+    """Add a symbol. Upsert — returns 200 even on duplicate."""
+    try:
+        row = await supabase_rest.upsert_watchlist(_bearer(authorization), body.symbol)
+    except Exception as exc:
+        raise _handle_error(exc)
+    await _invalidate(user_id)
+    return {"item": row}
+
+
+@router.delete("/watchlist/{symbol}", status_code=204)
+@limiter.limit(lambda: Config.RATE_LIMIT_PORTFOLIO, key_func=_user_rate_key)
+async def remove_from_watchlist(
+    request: Request,
+    symbol: str,
+    user_id: str = Depends(require_user),
+    authorization: str = Header(default=""),
+):
+    """Remove a symbol. 204 on success, 404 if not found."""
+    sym = symbol.strip().upper()
+    if not _SYMBOL_RE.match(sym):
+        raise HTTPException(status_code=422, detail="Invalid symbol.")
+    try:
+        removed = await supabase_rest.delete_watchlist_item(_bearer(authorization), sym)
+    except Exception as exc:
+        raise _handle_error(exc)
+    if not removed:
+        raise HTTPException(status_code=404, detail="Symbol not in watchlist.")
+    await _invalidate(user_id)

--- a/backend/routers/watchlist.py
+++ b/backend/routers/watchlist.py
@@ -12,10 +12,10 @@ GET is public — anonymous callers receive an empty list without a 401.
 """
 import logging
 import re
+from typing import Any
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from pydantic import BaseModel, field_validator
-from slowapi.util import get_remote_address
 
 import supabase_rest
 from config import Config
@@ -78,11 +78,11 @@ class WatchlistAdd(BaseModel):
 # ---------------------------------------------------------------------------
 
 @router.get("/watchlist")
-@limiter.limit(lambda: Config.RATE_LIMIT_READONLY, key_func=get_remote_address)
+@limiter.limit(lambda: Config.RATE_LIMIT_READONLY, key_func=_user_rate_key)
 async def list_watchlist(
     request: Request,
     authorization: str = Header(default=""),
-):
+) -> dict[str, Any]:
     """Return saved watchlist. [] for anonymous callers."""
     user_id = get_user_id(authorization)
     if not user_id:
@@ -108,7 +108,7 @@ async def add_to_watchlist(
     body: WatchlistAdd,
     user_id: str = Depends(require_user),
     authorization: str = Header(default=""),
-):
+) -> dict[str, Any]:
     """Add a symbol. Upsert — returns 200 even on duplicate."""
     try:
         row = await supabase_rest.upsert_watchlist(_bearer(authorization), body.symbol)
@@ -125,7 +125,7 @@ async def remove_from_watchlist(
     symbol: str,
     user_id: str = Depends(require_user),
     authorization: str = Header(default=""),
-):
+) -> None:
     """Remove a symbol. 204 on success, 404 if not found."""
     sym = symbol.strip().upper()
     if not _SYMBOL_RE.match(sym):

--- a/backend/supabase_rest.py
+++ b/backend/supabase_rest.py
@@ -149,3 +149,93 @@ def _safe_body(resp: httpx.Response) -> str:
         return resp.text[:300]
     except Exception:
         return f"HTTP {resp.status_code}"
+
+
+# ---------------------------------------------------------------------------
+# Watchlist CRUD (Feature 13) — `watchlists` table
+# ---------------------------------------------------------------------------
+
+_WATCHLIST_TABLE = "watchlists"
+
+
+def _watchlist_url() -> str:
+    if not Config.SUPABASE_URL or not Config.SUPABASE_ANON_KEY:
+        raise SupabaseConfigError(
+            "Supabase is not configured (SUPABASE_URL / SUPABASE_ANON_KEY). "
+            "Watchlist persistence requires a Supabase project."
+        )
+    return f"{Config.SUPABASE_URL.rstrip('/')}/rest/v1/{_WATCHLIST_TABLE}"
+
+
+def _wl_headers(user_jwt: str, *, prefer: str | None = None) -> Dict[str, str]:
+    headers = {
+        "apikey": Config.SUPABASE_ANON_KEY,
+        "Authorization": f"Bearer {user_jwt}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+    if prefer:
+        headers["Prefer"] = prefer
+    return headers
+
+
+async def list_watchlist(user_jwt: str) -> List[Dict[str, Any]]:
+    """Return the authenticated user's watchlist rows (RLS-scoped), newest first."""
+    url = _watchlist_url()
+    params = {"select": "id,symbol,added_at", "order": "added_at.desc"}
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.get(url, headers=_wl_headers(user_jwt), params=params)
+    except httpx.HTTPError as exc:
+        logger.error("[WATCHLIST] list: network error: %s", exc)
+        raise SupabaseRestError(0, f"Network error: {exc}") from exc
+    if resp.status_code != 200:
+        logger.error("[WATCHLIST] list: PostgREST returned HTTP %s — body: %s", resp.status_code, _safe_body(resp))
+        raise SupabaseRestError(resp.status_code, _safe_body(resp))
+    data = resp.json()
+    return data if isinstance(data, list) else []
+
+
+async def upsert_watchlist(user_jwt: str, symbol: str) -> Dict[str, Any]:
+    """Insert a watchlist entry; no-op (200) if symbol already exists for this user."""
+    url = _watchlist_url()
+    payload = {"symbol": symbol.upper()}
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.post(
+                url,
+                headers=_wl_headers(user_jwt, prefer="resolution=merge-duplicates,return=representation"),
+                params={"on_conflict": "user_id,symbol"},
+                json=payload,
+            )
+    except httpx.HTTPError as exc:
+        logger.error("[WATCHLIST] upsert(%s): network error: %s", symbol, exc)
+        raise SupabaseRestError(0, f"Network error: {exc}") from exc
+    if resp.status_code not in (200, 201):
+        logger.error("[WATCHLIST] upsert(%s): PostgREST returned HTTP %s — body: %s", symbol, resp.status_code, _safe_body(resp))
+        raise SupabaseRestError(resp.status_code, _safe_body(resp))
+    rows = resp.json()
+    return rows[0] if isinstance(rows, list) and rows else (rows if isinstance(rows, dict) else {})
+
+
+async def delete_watchlist_item(user_jwt: str, symbol: str) -> bool:
+    """Delete a watchlist entry by symbol. Returns True when a row was removed."""
+    url = _watchlist_url()
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.delete(
+                url,
+                headers=_wl_headers(user_jwt, prefer="return=representation"),
+                params={"symbol": f"eq.{symbol.upper()}"},
+            )
+    except httpx.HTTPError as exc:
+        logger.error("[WATCHLIST] delete(%s): network error: %s", symbol, exc)
+        raise SupabaseRestError(0, f"Network error: {exc}") from exc
+    if resp.status_code not in (200, 204):
+        logger.error("[WATCHLIST] delete(%s): PostgREST returned HTTP %s — body: %s", symbol, resp.status_code, _safe_body(resp))
+        raise SupabaseRestError(resp.status_code, _safe_body(resp))
+    try:
+        rows = resp.json()
+        return bool(rows)
+    except Exception:
+        return resp.status_code == 204

--- a/backend/supabase_rest.py
+++ b/backend/supabase_rest.py
@@ -12,6 +12,7 @@ All functions raise SupabaseConfigError when SUPABASE_URL / SUPABASE_ANON_KEY ar
 unset, and SupabaseRestError on a non-2xx PostgREST response. Routers translate
 these into clean HTTP errors — tracebacks never reach the client.
 """
+import asyncio
 import logging
 from typing import Any, Dict, List
 
@@ -185,7 +186,10 @@ async def list_watchlist(user_jwt: str) -> List[Dict[str, Any]]:
     params = {"select": "id,symbol,added_at", "order": "added_at.desc"}
     try:
         async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-            resp = await client.get(url, headers=_wl_headers(user_jwt), params=params)
+            resp = await asyncio.wait_for(
+                client.get(url, headers=_wl_headers(user_jwt), params=params),
+                timeout=12,
+            )
     except httpx.HTTPError as exc:
         logger.error("[WATCHLIST] list: network error: %s", exc)
         raise SupabaseRestError(0, f"Network error: {exc}") from exc
@@ -202,11 +206,14 @@ async def upsert_watchlist(user_jwt: str, symbol: str) -> Dict[str, Any]:
     payload = {"symbol": symbol.upper()}
     try:
         async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-            resp = await client.post(
-                url,
-                headers=_wl_headers(user_jwt, prefer="resolution=merge-duplicates,return=representation"),
-                params={"on_conflict": "user_id,symbol"},
-                json=payload,
+            resp = await asyncio.wait_for(
+                client.post(
+                    url,
+                    headers=_wl_headers(user_jwt, prefer="resolution=merge-duplicates,return=representation"),
+                    params={"on_conflict": "user_id,symbol"},
+                    json=payload,
+                ),
+                timeout=12,
             )
     except httpx.HTTPError as exc:
         logger.error("[WATCHLIST] upsert(%s): network error: %s", symbol, exc)
@@ -223,10 +230,13 @@ async def delete_watchlist_item(user_jwt: str, symbol: str) -> bool:
     url = _watchlist_url()
     try:
         async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-            resp = await client.delete(
-                url,
-                headers=_wl_headers(user_jwt, prefer="return=representation"),
-                params={"symbol": f"eq.{symbol.upper()}"},
+            resp = await asyncio.wait_for(
+                client.delete(
+                    url,
+                    headers=_wl_headers(user_jwt, prefer="return=representation"),
+                    params={"symbol": f"eq.{symbol.upper()}"},
+                ),
+                timeout=12,
             )
     except httpx.HTTPError as exc:
         logger.error("[WATCHLIST] delete(%s): network error: %s", symbol, exc)

--- a/backend/tests/test_watchlist.py
+++ b/backend/tests/test_watchlist.py
@@ -1,0 +1,272 @@
+"""
+Watchlist (Feature 13) + sparklines intraday-bars tests.
+All external calls (Supabase, yfinance, Redis) are mocked; no network required.
+
+Coverage:
+  • auth enforcement — POST/DELETE require a Bearer token
+  • anonymous GET returns [] without hitting Supabase
+  • authenticated GET returns items from the (mocked) Supabase store
+  • POST validation — invalid symbol chars → 422 before touching Supabase
+  • POST success — upsert returns created item
+  • DELETE 404 — symbol not in watchlist
+  • DELETE 204 — symbol removed successfully
+  • sparklines bars — /sparklines returns a list with {symbol, price, change_pct, bars}
+  • sparklines partial failure — one symbol erroring out does not suppress the rest
+  • sparklines extra param — ?extra= symbols are merged and deduplicated
+"""
+from unittest.mock import AsyncMock, patch
+import importlib as _il
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from slowapi.errors import RateLimitExceeded
+
+from backend.routers import watchlist, predict
+
+_deps = _il.import_module("dependencies")
+require_user = _deps.require_user
+limiter = _deps.limiter
+
+
+# ---------------------------------------------------------------------------
+# Shared rate-limit error handler (mirrors production)
+# ---------------------------------------------------------------------------
+
+async def _rl_handler(req, exc: RateLimitExceeded) -> JSONResponse:
+    return JSONResponse(status_code=429, content={"detail": "Too many requests."})
+
+
+# ---------------------------------------------------------------------------
+# Anon test app — no dependency overrides, auth is enforced
+# ---------------------------------------------------------------------------
+
+_anon_app = FastAPI()
+_anon_app.state.limiter = limiter
+_anon_app.add_exception_handler(RateLimitExceeded, _rl_handler)
+_anon_app.include_router(watchlist.router)
+
+anon = TestClient(_anon_app, raise_server_exceptions=False)
+
+# ---------------------------------------------------------------------------
+# Auth-bypassed test app — require_user returns a fixed user_id
+# ---------------------------------------------------------------------------
+
+_auth_app = FastAPI()
+_auth_app.state.limiter = limiter
+_auth_app.add_exception_handler(RateLimitExceeded, _rl_handler)
+_auth_app.include_router(watchlist.router)
+_auth_app.dependency_overrides[require_user] = lambda: "test-user-uuid"
+
+auth = TestClient(_auth_app, raise_server_exceptions=False)
+
+# ---------------------------------------------------------------------------
+# Sparklines test app — predict router only
+# ---------------------------------------------------------------------------
+
+_spark_app = FastAPI()
+_spark_app.state.limiter = limiter
+_spark_app.add_exception_handler(RateLimitExceeded, _rl_handler)
+_spark_app.include_router(predict.router)
+
+spark = TestClient(_spark_app, raise_server_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# Watchlist — auth enforcement
+# ---------------------------------------------------------------------------
+
+def test_watchlist_post_requires_auth() -> None:
+    """POST /watchlist without a Bearer token → 401."""
+    resp = anon.post("/watchlist", json={"symbol": "AAPL"})
+    assert resp.status_code == 401
+
+
+def test_watchlist_delete_requires_auth() -> None:
+    """DELETE /watchlist/{symbol} without a Bearer token → 401."""
+    resp = anon.delete("/watchlist/AAPL")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Watchlist — anonymous GET
+# ---------------------------------------------------------------------------
+
+def test_watchlist_get_anon_returns_empty() -> None:
+    """GET /watchlist with no valid JWT → 200 {"watchlist": []}."""
+    # get_user_id is called directly inside the handler (not via Depends).
+    # Return empty string to simulate an anonymous caller.
+    with patch("backend.routers.watchlist.get_user_id", return_value=""):
+        resp = anon.get("/watchlist")
+    assert resp.status_code == 200
+    assert resp.json() == {"watchlist": []}
+
+
+# ---------------------------------------------------------------------------
+# Watchlist — authenticated GET
+# ---------------------------------------------------------------------------
+
+def test_watchlist_get_authed_returns_items() -> None:
+    """GET /watchlist with a valid user → returns items from Supabase."""
+    items = [
+        {"id": "aa", "symbol": "AAPL", "added_at": "2025-01-01T00:00:00Z"},
+        {"id": "bb", "symbol": "NVDA", "added_at": "2025-01-02T00:00:00Z"},
+    ]
+    # Redis pool is not initialised in tests → cache_get returns None (miss) and
+    # cache_set is a no-op, so no mocking needed for cache helpers here.
+    with (
+        patch("backend.routers.watchlist.get_user_id", return_value="u-1"),
+        patch("supabase_rest.list_watchlist", new_callable=AsyncMock, return_value=items),
+    ):
+        resp = auth.get("/watchlist", headers={"Authorization": "Bearer fake"})
+    assert resp.status_code == 200
+    assert resp.json() == {"watchlist": items}
+
+
+# ---------------------------------------------------------------------------
+# Watchlist — POST (validation + success)
+# ---------------------------------------------------------------------------
+
+def test_watchlist_post_rejects_bad_symbol() -> None:
+    """POST /watchlist with invalid symbol characters → 422 (Pydantic)."""
+    resp = auth.post("/watchlist", json={"symbol": "BAD SYMBOL!"})
+    assert resp.status_code == 422
+
+
+def test_watchlist_post_rejects_empty_symbol() -> None:
+    """POST /watchlist with empty symbol → 422."""
+    resp = auth.post("/watchlist", json={"symbol": ""})
+    assert resp.status_code == 422
+
+
+def test_watchlist_post_accepts_valid_symbol() -> None:
+    """POST /watchlist with a well-formed symbol → 200 with the created item."""
+    created = {"id": "cc", "symbol": "TSLA", "added_at": "2025-01-03T00:00:00Z"}
+    with patch("supabase_rest.upsert_watchlist", new_callable=AsyncMock, return_value=created):
+        resp = auth.post(
+            "/watchlist",
+            json={"symbol": "TSLA"},
+            headers={"Authorization": "Bearer fake"},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["item"]["symbol"] == "TSLA"
+
+
+# ---------------------------------------------------------------------------
+# Watchlist — DELETE
+# ---------------------------------------------------------------------------
+
+def test_watchlist_delete_not_found() -> None:
+    """DELETE /watchlist/{symbol} when symbol is absent → 404."""
+    with patch("supabase_rest.delete_watchlist_item", new_callable=AsyncMock, return_value=False):
+        resp = auth.delete("/watchlist/AAPL", headers={"Authorization": "Bearer fake"})
+    assert resp.status_code == 404
+
+
+def test_watchlist_delete_found() -> None:
+    """DELETE /watchlist/{symbol} when symbol exists → 204 No Content."""
+    with patch("supabase_rest.delete_watchlist_item", new_callable=AsyncMock, return_value=True):
+        resp = auth.delete("/watchlist/AAPL", headers={"Authorization": "Bearer fake"})
+    assert resp.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# Sparklines — intraday bars
+# ---------------------------------------------------------------------------
+
+_BARS_AAPL = {
+    "price": 150.0,
+    "change_pct": 1.5,
+    "bars": [
+        {"t": "2025-01-01T14:30:00", "c": 148.0},
+        {"t": "2025-01-01T20:00:00", "c": 150.0},
+    ],
+}
+
+_BARS_MSFT = {
+    "price": 400.0,
+    "change_pct": -0.5,
+    "bars": [
+        {"t": "2025-01-01T14:30:00", "c": 402.0},
+        {"t": "2025-01-01T20:00:00", "c": 400.0},
+    ],
+}
+
+_BARS_NVDA = {
+    "price": 500.0,
+    "change_pct": 2.0,
+    "bars": [
+        {"t": "2025-01-01T14:30:00", "c": 490.0},
+        {"t": "2025-01-01T20:00:00", "c": 500.0},
+    ],
+}
+
+
+def test_sparklines_returns_bars() -> None:
+    """GET /sparklines?tickers=AAPL → list containing bars for AAPL."""
+    with patch("backend.routers.predict._fetch_intraday_bars", return_value=_BARS_AAPL):
+        resp = spark.get("/sparklines?tickers=AAPL")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    item = data[0]
+    assert item["symbol"] == "AAPL"
+    assert item["price"] == 150.0
+    assert item["change_pct"] == 1.5
+    assert isinstance(item["bars"], list)
+    assert len(item["bars"]) == 2
+    assert item["bars"][0] == {"t": "2025-01-01T14:30:00", "c": 148.0}
+
+
+def test_sparklines_partial_failure_returns_other_symbols() -> None:
+    """If one symbol fails (_fetch_intraday_bars returns {}), the rest are still returned."""
+    def _fake(sym: str) -> dict:
+        return {} if sym == "AAPL" else _BARS_MSFT
+
+    with patch("backend.routers.predict._fetch_intraday_bars", side_effect=_fake):
+        resp = spark.get("/sparklines?tickers=AAPL,MSFT")
+    assert resp.status_code == 200
+    data = resp.json()
+    symbols = [d["symbol"] for d in data]
+    assert "AAPL" not in symbols
+    assert "MSFT" in symbols
+    msft = next(d for d in data if d["symbol"] == "MSFT")
+    assert msft["price"] == 400.0
+    assert len(msft["bars"]) == 2
+
+
+def test_sparklines_extra_param_merged() -> None:
+    """?extra=NVDA symbols are merged with ?tickers= and returned."""
+    def _fake(sym: str) -> dict:
+        if sym == "NVDA":
+            return _BARS_NVDA
+        return {}   # AAPL has no data
+
+    with patch("backend.routers.predict._fetch_intraday_bars", side_effect=_fake):
+        resp = spark.get("/sparklines?tickers=AAPL&extra=NVDA")
+    assert resp.status_code == 200
+    data = resp.json()
+    symbols = [d["symbol"] for d in data]
+    assert "NVDA" in symbols
+    nvda = next(d for d in data if d["symbol"] == "NVDA")
+    assert nvda["price"] == 500.0
+
+
+def test_sparklines_deduplication() -> None:
+    """A symbol appearing in both ?tickers= and ?extra= is only fetched once."""
+    call_count = 0
+
+    def _fake(sym: str) -> dict:
+        nonlocal call_count
+        call_count += 1
+        return _BARS_AAPL
+
+    with patch("backend.routers.predict._fetch_intraday_bars", side_effect=_fake):
+        resp = spark.get("/sparklines?tickers=AAPL&extra=AAPL")
+    assert resp.status_code == 200
+    data = resp.json()
+    # Deduplicated → only one AAPL entry and only one fetch call.
+    aapl_items = [d for d in data if d["symbol"] == "AAPL"]
+    assert len(aapl_items) == 1
+    assert call_count == 1

--- a/docs/FiForesight-Documentation.md
+++ b/docs/FiForesight-Documentation.md
@@ -24,7 +24,8 @@
 12. [Security](#12-security)
 13. [Portfolio Manager (Feature 10)](#13-portfolio-manager-feature-10)
 14. [Alerts & Notifications (Feature 9)](#14-alerts--notifications-feature-9)
-15. [Glossary](#15-glossary)
+15. [Watchlist, Intraday Sparklines & Responsive Design (Feature 13)](#15-watchlist-intraday-sparklines--responsive-design-feature-13)
+16. [Glossary](#16-glossary)
 
 ---
 
@@ -1839,10 +1840,106 @@ create policy "own push subscriptions" on public.push_subscriptions
 ### 14.7 Frontend
 
 `frontend/app/(app)/alerts/page.tsx` — signed-out users see an `AuthGate`. Signed-in users get: an **"enable browser notifications"** banner (requests Notification permission → registers `sw.js` → subscribes with the VAPID key → POSTs the subscription), an **adaptive rule builder** (inputs change with the chosen type — e.g. `price_cross` shows above/below + price; `earnings_soon` shows a days field; `forecast_breakout` shows none), the **active-rules list** with an active/paused toggle + delete, and the **fire history**. Data flows through `frontend/lib/alerts.ts` → `/api/alerts/*` proxies (which forward `Authorization`) → the backend.
+## 15. Watchlist, Intraday Sparklines & Responsive Design (Feature 13)
+
+### 14.1 Watchlist persistence
+
+Users can **star** any ticker on the analysis page to save it to their watchlist. Watchlist items are stored in a dedicated Supabase table, synced to the user's JWT via PostgREST (same pattern as holdings — no service-role key).
+
+**Supabase schema** (`supabase/migrations/0006_watchlist.sql`):
+
+```sql
+create table if not exists watchlists (
+  id         uuid primary key default gen_random_uuid(),
+  user_id    uuid not null references auth.users(id) on delete cascade,
+  symbol     text not null,
+  added_at   timestamptz default now(),
+  unique(user_id, symbol)
+);
+alter table watchlists enable row level security;
+create policy "users manage own watchlist"
+  on watchlists for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+```
+
+**API contracts** (`backend/routers/watchlist.py`):
+
+| Method | Path | Auth | Body | Response |
+|---|---|---|---|---|
+| `GET` | `/watchlist` | Optional | — | `{ "watchlist": [{id, symbol, added_at}] }` — `[]` for anonymous |
+| `POST` | `/watchlist` | Required | `{ "symbol": "AAPL" }` | `{ "item": {id, symbol, added_at} }` (upsert, no 409 on duplicate) |
+| `DELETE` | `/watchlist/{symbol}` | Required | — | **204** (success) or **404** (not in watchlist) |
+
+Symbol validation: `[A-Za-z0-9.\-:]{1,15}` (same regex as predict/holdings). GET is cached in Redis 60s per user; POST/DELETE invalidate the cache.
+
+**Frontend architecture:**
+
+- `WatchlistContext` (`frontend/contexts/WatchlistContext.tsx`) is the single source of truth. It wraps `AuthProvider` inside `ClientProviders.tsx` and re-fetches on auth-state changes. Exposes `{ watchlist, isLoading, isWatched(symbol), add(symbol), remove(symbol), reload() }`.
+- `useWatchlist` hook (`frontend/hooks/useWatchlist.ts`) is a thin backward-compat wrapper over `useWatchlistContext()`, preserving the pre-existing `{ watchlist, loading, toggling, isSaved, toggle, currentIsSaved }` API.
+- `lib/watchlist.ts` makes HTTP calls to `/api/watchlist` and `/api/watchlist/{symbol}` (Next.js proxy routes). The old approach of calling the Supabase SDK directly has been replaced with this backend-proxy pattern.
+- **Sidebar**: a collapsible Watchlist panel below the nav items shows saved tickers; clicking navigates to `/analysis?symbol=…`. On mobile a fixed bottom chip bar shows watchlist items horizontally.
+
+### 14.2 Intraday sparklines
+
+The `/sparklines` endpoint was upgraded to return real 1-day 5-minute OHLCV bars instead of a flat list of daily closes.
+
+**New response shape** (breaking change from the old `Dict[str, List[float]]`):
+
+```jsonc
+// GET /sparklines?tickers=AAPL,MSFT&extra=NVDA
+[
+  {
+    "symbol": "AAPL",
+    "price": 195.42,         // last bar close
+    "change_pct": 1.23,      // (last − first) / first × 100
+    "bars": [
+      { "t": "2025-01-15T14:30:00", "c": 193.10 },  // UTC naive ISO
+      { "t": "2025-01-15T14:35:00", "c": 193.55 },
+      // … up to 78 bars (full 6.5h trading session at 5m)
+    ]
+  }
+]
+```
+
+- **Pre/post-market stripped**: only bars between 09:30 and 16:00 ET are kept.
+- **`?extra=` param**: the frontend appends watchlist symbols here; the backend deduplicates against `?tickers=` and caps at 24 symbols total.
+- **Partial failure**: if one symbol's yfinance call fails, `{}` is returned for that symbol and it is silently skipped — other symbols still return.
+- **Per-symbol Redis cache** (5-min TTL): concurrent `asyncio.gather` + `asyncio.to_thread` for non-blocking I/O.
+- `TrendingSparklines` component now accepts `tickers: string[]` (not `{symbol: string}[]`); it draws a live Recharts sparkline from `bars`.
+
+### 14.3 Responsive design
+
+All application tabs were audited against four breakpoints:
+
+| Breakpoint | Width | Target |
+|---|---|---|
+| xs (mobile) | 320 px | Single-column; all grids stack; charts 220 px tall |
+| sm (tablet) | 768 px | 2–3 column layouts; charts 300 px tall |
+| md (desktop) | 1280 px | Full multi-column; charts 400 px tall |
+| 2xl (4K) | 2560 px | Sidebar `maxWidth: 280`; main content `maxWidth: 1600` centred |
+
+**Key fixes shipped:**
+
+| Component | Change |
+|---|---|
+| `PriceChartCard` + `AdvancedChart` | Chart height 220/300/400 px via `useMediaQuery` + `priceHeight` prop |
+| `DCFCard` | 3-scenario grid stacks on xs: `gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr 1fr' }` |
+| `TradeSetupCard` | Entry/stop/targets grid stacks on xs (same pattern as DCFCard) |
+| `FundamentalsPanel` | Grid `xs: 6 / sm: 4 / md: 3` (2-col mobile → 3-col tablet → 4-col desktop) |
+| `OrderBookPanel` | `overflowX: 'auto'` + responsive padding |
+| `earnings/page.tsx` | Responsive CSS grid: `{ xs: '1fr 1fr', sm: 'repeat(3,1fr)', md: 'repeat(4,1fr)', lg: 'repeat(6,1fr)' }` |
+| `ipo/page.tsx` | `{ xs: '1fr', md: '1fr 1fr' }` card grid (already correct) |
+| `analysis/page.tsx` | Forecast grid `{ xs: 'repeat(3,1fr)', sm: 'repeat(5,1fr)' }` |
+| `layout.tsx` (App Shell) | Sidebar `maxWidth: 280`; Shell `maxWidth: 1600` at 4K; MobileNav `minHeight: 44` tap targets |
+| `MorningBriefingPanel` | `overflowX: auto` horizontal scroll (already correct) |
+| `SectorHeatmap` | `flexWrap: wrap` (already correct) |
+| `OptionsChainPanel` | `overflowX: auto` on table wrapper (already correct) |
+| `portfolio/page.tsx` | `isMobile` hides columns; table `overflow: 'auto'` (already correct) |
 
 ---
 
-## 15. Glossary
+## 16. Glossary
 
 **Ask the expert first** — plain-English definitions for the terms used throughout this document.
 
@@ -1908,5 +2005,5 @@ create policy "own push subscriptions" on public.push_subscriptions
 ### Document provenance
 
 - **Source of truth.** Every fact in this document was derived by reading the code in this repository. Code-path citations use the `path:line` convention; click-able links resolve relative to `docs/`.
-- **Last reconciled.** With the `main` branch as of commit `1d54ed0` on branch `tig-documentation` (2026-04-15). Facts about external services (Groq pricing, InfluxDB retention, etc.) reflect the code comments at that commit and may drift over time.
+- **Last reconciled.** With the `main` branch as of 2026-06-12 (Feature 13 — Watchlist + Intraday Sparklines + Responsive Design). Facts about external services (Groq pricing, InfluxDB retention, etc.) may drift over time.
 - **When in doubt, re-read the code.** This document is an *accurate summary* — but the repository is the spec.

--- a/frontend/app/(app)/analysis/page.tsx
+++ b/frontend/app/(app)/analysis/page.tsx
@@ -459,13 +459,13 @@ function AnalysisContent() {
                       </Typography>
                     </Stack>
                     <Stack direction="row" flexWrap="wrap" gap={0.75}>
-                      {watchlist.map(sym => (
+                      {watchlist.map(item => (
                         <Chip
-                          key={sym}
-                          label={sym}
+                          key={item.symbol}
+                          label={item.symbol}
                           size="small"
-                          onClick={() => handlePredict(sym)}
-                          onDelete={() => void toggleWatchlist(sym)}
+                          onClick={() => handlePredict(item.symbol)}
+                          onDelete={() => void toggleWatchlist(item.symbol)}
                           sx={{
                             cursor: 'pointer',
                             fontWeight: 700,

--- a/frontend/app/(app)/analysis/page.tsx
+++ b/frontend/app/(app)/analysis/page.tsx
@@ -623,7 +623,9 @@ function AnalysisContent() {
             size="medium"
             aria-label={user ? (chatOpen ? 'Close chat' : 'Open AI chat') : 'Sign in to open AI chat'}
             sx={{
-              position: 'fixed', bottom: 24, right: 24,
+              position: 'fixed',
+              bottom: { xs: 84, md: 24 },  // clear 60px mobile nav + 24px margin
+              right: 24,
               background: primaryColor,
               '&:hover': { background: primaryColor, filter: 'brightness(1.15)' },
               boxShadow: `0 0 20px ${primaryColor}66`,

--- a/frontend/app/(app)/analysis/page.tsx
+++ b/frontend/app/(app)/analysis/page.tsx
@@ -355,7 +355,7 @@ function AnalysisContent() {
                       <Typography variant="overline" sx={{ opacity: 0.5, display: 'flex', alignItems: 'center', gap: 1 }}>
                         <BarChart2 size={14} /> Price Forecast
                       </Typography>
-                      <Box sx={{ mt: 2, display: 'grid', gridTemplateColumns: { xs: 'repeat(3, 1fr)', sm: 'repeat(5, 1fr)' }, gap: 1.5 }}>
+                      <Box sx={{ mt: 2, display: 'grid', gridTemplateColumns: { xs: '1fr', sm: 'repeat(3, 1fr)', md: 'repeat(5, 1fr)' }, gap: 1.5 }}>
                         {prediction.forecastDays.map((day, i) => {
                           const isUp = day.predicted >= parseFloat(prediction.currentPrice);
                           const col  = isUp ? (isDark ? '#00ffa3' : '#16a34a') : (isDark ? '#ff0055' : '#dc2626');
@@ -595,6 +595,7 @@ function AnalysisContent() {
                   <TrendingSparklines
                     tickers={prediction.trending.map(t => t.symbol).filter(Boolean)}
                     isDark={isDark}
+                    extraSymbols={watchlist.map(item => item.symbol)}
                   />
                 )}
 

--- a/frontend/app/(app)/analysis/page.tsx
+++ b/frontend/app/(app)/analysis/page.tsx
@@ -355,7 +355,7 @@ function AnalysisContent() {
                       <Typography variant="overline" sx={{ opacity: 0.5, display: 'flex', alignItems: 'center', gap: 1 }}>
                         <BarChart2 size={14} /> Price Forecast
                       </Typography>
-                      <Box sx={{ mt: 2, display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 1.5 }}>
+                      <Box sx={{ mt: 2, display: 'grid', gridTemplateColumns: { xs: 'repeat(3, 1fr)', sm: 'repeat(5, 1fr)' }, gap: 1.5 }}>
                         {prediction.forecastDays.map((day, i) => {
                           const isUp = day.predicted >= parseFloat(prediction.currentPrice);
                           const col  = isUp ? (isDark ? '#00ffa3' : '#16a34a') : (isDark ? '#ff0055' : '#dc2626');
@@ -592,7 +592,10 @@ function AnalysisContent() {
 
                 {/* ── Trending Sparklines (real 5-day) ─────────────────── */}
                 {prediction?.trending?.length > 0 && (
-                  <TrendingSparklines tickers={prediction.trending} isDark={isDark} />
+                  <TrendingSparklines
+                    tickers={prediction.trending.map(t => t.symbol).filter(Boolean)}
+                    isDark={isDark}
+                  />
                 )}
 
               </>

--- a/frontend/app/(app)/earnings/page.tsx
+++ b/frontend/app/(app)/earnings/page.tsx
@@ -171,7 +171,11 @@ export default function EarningsPage() {
                   · {group.entries.length} {group.entries.length === 1 ? 'company' : 'companies'}
                 </Typography>
               </Typography>
-              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1.5 }}>
+              <Box sx={{
+                display: 'grid',
+                gridTemplateColumns: { xs: '1fr 1fr', sm: 'repeat(3, 1fr)', md: 'repeat(4, 1fr)', lg: 'repeat(6, 1fr)' },
+                gap: 1.5,
+              }}>
                 {group.entries.map(e => (
                   <Card
                     key={e.symbol}
@@ -185,12 +189,12 @@ export default function EarningsPage() {
                       }
                     }}
                     sx={{
-                      cursor: 'pointer', width: 168, border: `1px solid ${borderCol}`,
+                      cursor: 'pointer', border: `1px solid ${borderCol}`,
                       transition: 'background 0.15s ease, border-color 0.15s ease',
                       '&:hover': { background: hoverBg, borderColor: `${primaryColor}66` },
                     }}
                   >
-                    <CardContent sx={{ p: '12px !important' }}>
+                    <CardContent sx={{ p: { xs: '10px !important', sm: '12px !important' } }}>
                       <Typography sx={{ fontWeight: 800, fontSize: '0.95rem', color: primaryColor }}>
                         {e.symbol}
                       </Typography>

--- a/frontend/app/(app)/layout.tsx
+++ b/frontend/app/(app)/layout.tsx
@@ -320,7 +320,6 @@ function MobileWatchlistBar() {
 function MobileNav() {
   const pathname = usePathname();
   const { isDark, primaryColor } = useAppShell();
-  const { watchlist } = useWatchlistContext();
   const items = NAV_ITEMS.filter(i => i.mobile);
   const borderCol = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';
 

--- a/frontend/app/(app)/layout.tsx
+++ b/frontend/app/(app)/layout.tsx
@@ -9,9 +9,12 @@ import {
 import {
   BrainCircuit, Home, Search, BarChart2, Calendar, Rocket, LineChart,
   Activity, Wallet, Bell, ChevronLeft, ChevronRight, Sun, Moon, LogIn, LogOut,
+  Star, ChevronDown, ChevronUp,
 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { AppShellProvider, useAppShell } from '../../contexts/AppShellContext';
 import { useAuth } from '../../contexts/AuthContext';
+import { useWatchlistContext } from '../../contexts/WatchlistContext';
 import AuthModal from '../../components/AuthModal';
 
 // ── Navigation model ────────────────────────────────────────────────────────
@@ -49,6 +52,75 @@ function isActive(pathname: string, href: string): boolean {
 }
 
 // ── Desktop sidebar ─────────────────────────────────────────────────────────
+function WatchlistPanel({ collapsed, isDark, primaryColor }: { collapsed: boolean; isDark: boolean; primaryColor: string }) {
+  const router = useRouter();
+  const { watchlist, isLoading } = useWatchlistContext();
+  const [open, setOpen] = useState(true);
+
+  const dimColor  = isDark ? 'rgba(220,220,220,0.35)' : 'rgba(20,30,50,0.35)';
+  const hoverBg   = isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.04)';
+  const borderCol = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';
+
+  if (collapsed) {
+    // In collapsed mode show just the star icon (no panel)
+    return (
+      <Tooltip title="Watchlist" placement="right">
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 1 }}>
+          <Star size={18} color={dimColor} />
+        </Box>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Box sx={{ px: 1, mt: 0.5, borderTop: `1px solid ${borderCol}`, pt: 1 }}>
+      {/* Header row */}
+      <Box
+        onClick={() => setOpen(p => !p)}
+        sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+              px: 1.5, py: 0.75, borderRadius: 2, cursor: 'pointer',
+              '&:hover': { bgcolor: hoverBg } }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Star size={14} color={primaryColor} />
+          <Typography sx={{ fontSize: 11, fontWeight: 700, letterSpacing: 0.8,
+                            textTransform: 'uppercase', color: dimColor }}>
+            Watchlist
+          </Typography>
+          {isLoading && <Typography sx={{ fontSize: 10, color: dimColor, opacity: 0.6 }}>…</Typography>}
+        </Box>
+        {open ? <ChevronUp size={12} color={dimColor} /> : <ChevronDown size={12} color={dimColor} />}
+      </Box>
+
+      {open && (
+        <Box sx={{ mt: 0.5 }}>
+          {watchlist.length === 0 ? (
+            <Typography sx={{ fontSize: 11, color: dimColor, px: 1.5, py: 0.5, opacity: 0.7 }}>
+              Star a ticker to save it here.
+            </Typography>
+          ) : (
+            watchlist.slice(0, 12).map(item => (
+              <Box
+                key={item.id}
+                onClick={() => router.push(`/analysis?symbol=${encodeURIComponent(item.symbol)}`)}
+                sx={{
+                  display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                  px: 1.5, py: 0.6, borderRadius: 1.5, cursor: 'pointer',
+                  '&:hover': { bgcolor: hoverBg },
+                }}
+              >
+                <Typography sx={{ fontSize: 12, fontWeight: 700, color: 'text.primary', lineHeight: 1.2 }}>
+                  {item.symbol}
+                </Typography>
+              </Box>
+            ))
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
 function Sidebar() {
   const pathname            = usePathname();
   const { isDark, primaryColor, themeMode, toggleTheme } = useAppShell();
@@ -100,6 +172,7 @@ function Sidebar() {
         borderRight: `1px solid ${borderCol}`,
         bgcolor: 'background.paper',
         transition: 'width 0.2s ease',
+        maxWidth: 280,  // prevent sprawl at 4K
       }}
     >
       {/* Header */}
@@ -142,6 +215,9 @@ function Sidebar() {
             : link;
         })}
       </Stack>
+
+      {/* Watchlist panel */}
+      <WatchlistPanel collapsed={collapsed} isDark={isDark} primaryColor={primaryColor} />
 
       {/* Footer: theme toggle + auth + collapse */}
       <Stack spacing={0.5} sx={{ px: 1, py: 1.5, borderTop: `1px solid ${borderCol}` }}>
@@ -197,10 +273,54 @@ function Sidebar() {
   );
 }
 
+// ── Mobile watchlist chip row (shown above bottom nav) ─────────────────────
+function MobileWatchlistBar() {
+  const router                   = useRouter();
+  const { isDark, primaryColor } = useAppShell();
+  const { watchlist }            = useWatchlistContext();
+  const borderCol = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';
+  const chipBg    = isDark ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.06)';
+
+  if (!watchlist.length) return null;
+
+  return (
+    <Box
+      sx={{
+        display: { xs: 'flex', md: 'none' },
+        position: 'fixed', bottom: 60, left: 0, right: 0, zIndex: 1199,
+        borderTop: `1px solid ${borderCol}`, bgcolor: 'background.paper',
+        overflowX: 'auto', maxHeight: 48, alignItems: 'center',
+        px: 1, gap: 0.75, flexShrink: 0,
+        // Hide scrollbar but keep scrollability
+        '&::-webkit-scrollbar': { display: 'none' },
+        scrollbarWidth: 'none',
+      }}
+    >
+      {watchlist.slice(0, 20).map(item => (
+        <Box
+          key={item.symbol}
+          onClick={() => router.push(`/analysis?symbol=${encodeURIComponent(item.symbol)}`)}
+          sx={{
+            flexShrink: 0, px: 1.5, py: 0.5, borderRadius: 10,
+            bgcolor: chipBg, cursor: 'pointer', minHeight: 28,
+            display: 'flex', alignItems: 'center',
+            '&:hover': { bgcolor: `${primaryColor}22` },
+          }}
+        >
+          <Typography sx={{ fontSize: 11, fontWeight: 700, color: 'text.primary', whiteSpace: 'nowrap' }}>
+            {item.symbol}
+          </Typography>
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
 // ── Mobile bottom navigation ────────────────────────────────────────────────
 function MobileNav() {
   const pathname = usePathname();
   const { isDark, primaryColor } = useAppShell();
+  const { watchlist } = useWatchlistContext();
   const items = NAV_ITEMS.filter(i => i.mobile);
   const borderCol = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';
 
@@ -225,6 +345,7 @@ function MobileNav() {
               flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center',
               justifyContent: 'center', gap: 0.25, textDecoration: 'none',
               color: active ? primaryColor : 'text.secondary',
+              minHeight: 44, // ≥44px tap target
             }}
           >
             <Icon size={20} color={active ? primaryColor : 'currentColor'} />
@@ -239,6 +360,9 @@ function MobileNav() {
 // ── Shell ───────────────────────────────────────────────────────────────────
 function Shell({ children }: { children: React.ReactNode }) {
   const isMobile = useMediaQuery('(max-width:899.95px)');
+  const { watchlist } = useWatchlistContext();
+  const hasWatchlistBar = isMobile && watchlist.length > 0;
+
   return (
     <Box sx={{ display: 'flex', minHeight: '100vh' }}>
       <Sidebar />
@@ -247,12 +371,17 @@ function Shell({ children }: { children: React.ReactNode }) {
         sx={{
           flexGrow: 1, minWidth: 0,
           overflowY: 'auto',
-          p: 3,
-          pb: isMobile ? 9 : 3, // leave room for the mobile bottom nav
+          p: { xs: 2, sm: 3 },
+          // Leave room for bottom nav (+watchlist bar when present)
+          pb: isMobile ? (hasWatchlistBar ? 13 : 9) : 3,
+          // 4K: centre main content, prevent full-width sprawl
+          maxWidth: { '2xl': 1600 },
+          mx: 'auto',
         }}
       >
         {children}
       </Box>
+      <MobileWatchlistBar />
       <MobileNav />
     </Box>
   );

--- a/frontend/app/(app)/layout.tsx
+++ b/frontend/app/(app)/layout.tsx
@@ -5,7 +5,7 @@ import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import {
   Box, Drawer, List, ListItemButton, ListItemIcon, ListItemText,
-  Stack, Typography, IconButton, Tooltip, useMediaQuery,
+  Stack, Typography, IconButton, Tooltip,
 } from '@mui/material';
 import {
   BrainCircuit, Home, Search, BarChart2, Calendar, Rocket, LineChart,
@@ -36,6 +36,7 @@ const NAV_ITEMS: NavItem[] = [
   { label: 'Options',      href: '/options',    icon: BarChart2, mobile: true  },
   { label: 'Earnings',     href: '/earnings',   icon: Calendar,  mobile: true  },
   { label: 'IPO Tracker',  href: '/ipo',        icon: Rocket,    mobile: true  },
+  { label: 'Watchlist',    href: '/watchlist',  icon: Star,      mobile: false },
   { label: 'Insights',     href: '/insights',   icon: Activity,  mobile: false },
   { label: 'Simulator',    href: '/simulation', icon: LineChart, mobile: false },
   { label: 'My Portfolio', href: '/portfolio',  icon: Wallet,    mobile: false },
@@ -413,9 +414,7 @@ function MobileNav() {
 
 // ── Shell ───────────────────────────────────────────────────────────────────
 function Shell({ children }: { children: React.ReactNode }) {
-  const isMobile = useMediaQuery('(max-width:899.95px)');
   const { watchlist } = useWatchlistContext();
-  const hasWatchlistBar = isMobile && watchlist.length > 0;
 
   return (
     <Box sx={{ display: 'flex', minHeight: '100vh' }}>
@@ -425,9 +424,15 @@ function Shell({ children }: { children: React.ReactNode }) {
         sx={{
           flexGrow: 1, minWidth: 0,
           overflowY: 'auto',
-          p: { xs: 2, sm: 3 },
-          // Leave room for bottom nav (+watchlist bar when present)
-          pb: isMobile ? (hasWatchlistBar ? 13 : 9) : 3,
+          px: { xs: 2, sm: 3 },
+          pt: { xs: 2, sm: 3 },
+          // Bottom clearance: fixed nav (60px) + optional watchlist bar (48px) + iOS safe-area inset
+          pb: {
+            xs: watchlist.length > 0
+              ? 'calc(120px + env(safe-area-inset-bottom, 0px))'
+              : 'calc(80px + env(safe-area-inset-bottom, 0px))',
+            md: 3,
+          },
           // 4K: centre main content, prevent full-width sprawl
           maxWidth: { '2xl': 1600 },
           mx: 'auto',

--- a/frontend/app/(app)/layout.tsx
+++ b/frontend/app/(app)/layout.tsx
@@ -4,12 +4,13 @@ import { useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import {
-  Box, Stack, Typography, IconButton, Tooltip, useMediaQuery,
+  Box, Drawer, List, ListItemButton, ListItemIcon, ListItemText,
+  Stack, Typography, IconButton, Tooltip, useMediaQuery,
 } from '@mui/material';
 import {
   BrainCircuit, Home, Search, BarChart2, Calendar, Rocket, LineChart,
   Activity, Wallet, Bell, ChevronLeft, ChevronRight, Sun, Moon, LogIn, LogOut,
-  Star, ChevronDown, ChevronUp,
+  Star, ChevronDown, ChevronUp, MoreHorizontal,
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { AppShellProvider, useAppShell } from '../../contexts/AppShellContext';
@@ -317,42 +318,96 @@ function MobileWatchlistBar() {
 }
 
 // ── Mobile bottom navigation ────────────────────────────────────────────────
+const _PRIMARY_NAV  = NAV_ITEMS.filter(i => i.mobile);
+const _SECONDARY_NAV = NAV_ITEMS.filter(i => !i.mobile);
+
 function MobileNav() {
-  const pathname = usePathname();
+  const pathname               = usePathname();
   const { isDark, primaryColor } = useAppShell();
-  const items = NAV_ITEMS.filter(i => i.mobile);
+  const [moreOpen, setMoreOpen]  = useState(false);
   const borderCol = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';
+  const moreActive = _SECONDARY_NAV.some(i => isActive(pathname, i.href));
 
   return (
-    <Box
-      component="nav"
-      sx={{
-        display: { xs: 'flex', md: 'none' },
-        position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 1200,
-        borderTop: `1px solid ${borderCol}`, bgcolor: 'background.paper',
-        justifyContent: 'space-around', alignItems: 'stretch', height: 60,
-      }}
-    >
-      {items.map(({ label, href, icon: Icon }) => {
-        const active = isActive(pathname, href);
-        return (
-          <Box
-            key={href}
-            component={Link}
-            href={href}
-            sx={{
-              flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center',
-              justifyContent: 'center', gap: 0.25, textDecoration: 'none',
-              color: active ? primaryColor : 'text.secondary',
-              minHeight: 44, // ≥44px tap target
-            }}
-          >
-            <Icon size={20} color={active ? primaryColor : 'currentColor'} />
-            <Typography sx={{ fontSize: 10, fontWeight: active ? 700 : 500 }}>{label}</Typography>
-          </Box>
-        );
-      })}
-    </Box>
+    <>
+      <Box
+        component="nav"
+        sx={{
+          display: { xs: 'flex', md: 'none' },
+          position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 1200,
+          borderTop: `1px solid ${borderCol}`, bgcolor: 'background.paper',
+          justifyContent: 'space-around', alignItems: 'stretch', height: 60,
+        }}
+      >
+        {_PRIMARY_NAV.map(({ label, href, icon: Icon }) => {
+          const active = isActive(pathname, href);
+          return (
+            <Box
+              key={href}
+              component={Link}
+              href={href}
+              sx={{
+                flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center',
+                justifyContent: 'center', gap: 0.25, textDecoration: 'none',
+                color: active ? primaryColor : 'text.secondary',
+                minHeight: 44,
+              }}
+            >
+              <Icon size={20} color={active ? primaryColor : 'currentColor'} />
+              <Typography sx={{ fontSize: 10, fontWeight: active ? 700 : 500 }}>{label}</Typography>
+            </Box>
+          );
+        })}
+
+        {/* More — opens secondary nav drawer */}
+        <Box
+          onClick={() => setMoreOpen(true)}
+          sx={{
+            flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center',
+            justifyContent: 'center', gap: 0.25, cursor: 'pointer',
+            color: moreActive ? primaryColor : 'text.secondary',
+            minHeight: 44,
+          }}
+        >
+          <MoreHorizontal size={20} color={moreActive ? primaryColor : 'currentColor'} />
+          <Typography sx={{ fontSize: 10, fontWeight: moreActive ? 700 : 500 }}>More</Typography>
+        </Box>
+      </Box>
+
+      {/* Secondary nav bottom drawer */}
+      <Drawer
+        anchor="bottom"
+        open={moreOpen}
+        onClose={() => setMoreOpen(false)}
+        sx={{ display: { xs: 'block', md: 'none' }, '& .MuiDrawer-paper': { borderRadius: '16px 16px 0 0', pb: 2 } }}
+      >
+        <Box sx={{ pt: 1, pb: 0.5, display: 'flex', justifyContent: 'center' }}>
+          <Box sx={{ width: 36, height: 4, borderRadius: 2, bgcolor: 'divider' }} />
+        </Box>
+        <List disablePadding>
+          {_SECONDARY_NAV.map(({ label, href, icon: Icon }) => {
+            const active = isActive(pathname, href);
+            return (
+              <ListItemButton
+                key={href}
+                component={Link}
+                href={href}
+                onClick={() => setMoreOpen(false)}
+                sx={{ py: 1.5, color: active ? primaryColor : 'text.primary' }}
+              >
+                <ListItemIcon sx={{ minWidth: 40, color: 'inherit' }}>
+                  <Icon size={20} />
+                </ListItemIcon>
+                <ListItemText
+                  primary={label}
+                  slotProps={{ primary: { sx: { fontWeight: active ? 700 : 500, fontSize: '0.9rem' } } }}
+                />
+              </ListItemButton>
+            );
+          })}
+        </List>
+      </Drawer>
+    </>
   );
 }
 

--- a/frontend/app/(app)/layout.tsx
+++ b/frontend/app/(app)/layout.tsx
@@ -395,15 +395,28 @@ function MobileNav() {
           <Box sx={{ width: 36, height: 4, borderRadius: 2, bgcolor: 'divider' }} />
         </Box>
 
-        {/* Auth section */}
-        <Box sx={{ px: 2, py: 1.5, borderBottom: `1px solid ${borderCol}` }}>
+        {/* Auth section — centered profile card */}
+        <Box sx={{ px: 2, py: 2.5, borderBottom: `1px solid ${borderCol}`, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1.25 }}>
           {user ? (
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
-              <Box sx={{ minWidth: 0 }}>
-                <Typography sx={{ fontSize: 13, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            <>
+              {/* Avatar: initials in a circle */}
+              <Box sx={{
+                width: 56, height: 56, borderRadius: '50%',
+                bgcolor: `${primaryColor}1e`,
+                border: `2px solid ${primaryColor}55`,
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                flexShrink: 0,
+              }}>
+                <Typography sx={{ fontSize: 22, fontWeight: 800, color: primaryColor, lineHeight: 1 }}>
+                  {(user.email?.[0] ?? 'U').toUpperCase()}
+                </Typography>
+              </Box>
+              {/* Name + email */}
+              <Box sx={{ textAlign: 'center' }}>
+                <Typography sx={{ fontSize: 14, fontWeight: 700, lineHeight: 1.3 }}>
                   {user.email?.split('@')[0] ?? 'Account'}
                 </Typography>
-                <Typography sx={{ fontSize: 11, opacity: 0.5, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                <Typography sx={{ fontSize: 11, opacity: 0.5, lineHeight: 1.4 }}>
                   {user.email}
                 </Typography>
               </Box>
@@ -413,20 +426,30 @@ function MobileNav() {
                 color="inherit"
                 onClick={() => { signOut().catch(console.error); setMoreOpen(false); }}
                 startIcon={<LogOut size={14} />}
-                sx={{ flexShrink: 0, fontSize: 11, borderRadius: 2 }}
+                sx={{ fontSize: 11, borderRadius: 2, mt: 0.5 }}
               >
                 Sign Out
               </Button>
-            </Box>
+            </>
           ) : (
-            <Button
-              fullWidth
-              variant="outlined"
-              onClick={() => { setMoreOpen(false); setAuthOpen(true); }}
-              startIcon={<LogIn size={16} />}
-            >
-              Sign In
-            </Button>
+            <>
+              {/* Guest avatar placeholder */}
+              <Box sx={{
+                width: 56, height: 56, borderRadius: '50%',
+                bgcolor: isDark ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.06)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+              }}>
+                <LogIn size={24} color={isDark ? 'rgba(255,255,255,0.35)' : 'rgba(0,0,0,0.3)'} />
+              </Box>
+              <Button
+                variant="outlined"
+                onClick={() => { setMoreOpen(false); setAuthOpen(true); }}
+                startIcon={<LogIn size={16} />}
+                sx={{ borderRadius: 2 }}
+              >
+                Sign In
+              </Button>
+            </>
           )}
         </Box>
 

--- a/frontend/app/(app)/layout.tsx
+++ b/frontend/app/(app)/layout.tsx
@@ -4,8 +4,8 @@ import { useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import {
-  Box, Drawer, List, ListItemButton, ListItemIcon, ListItemText,
-  Stack, Typography, IconButton, Tooltip,
+  Box, Button, Drawer, List, ListItemButton, ListItemIcon, ListItemText,
+  Stack, Typography, IconButton, Tooltip, useMediaQuery,
 } from '@mui/material';
 import {
   BrainCircuit, Home, Search, BarChart2, Calendar, Rocket, LineChart,
@@ -35,7 +35,7 @@ const NAV_ITEMS: NavItem[] = [
   { label: 'Analysis',     href: '/analysis',   icon: Search,    mobile: true  },
   { label: 'Options',      href: '/options',    icon: BarChart2, mobile: true  },
   { label: 'Earnings',     href: '/earnings',   icon: Calendar,  mobile: true  },
-  { label: 'IPO Tracker',  href: '/ipo',        icon: Rocket,    mobile: true  },
+  { label: 'IPO Tracker',  href: '/ipo',        icon: Rocket,    mobile: false },
   { label: 'Watchlist',    href: '/watchlist',  icon: Star,      mobile: false },
   { label: 'Insights',     href: '/insights',   icon: Activity,  mobile: false },
   { label: 'Simulator',    href: '/simulation', icon: LineChart, mobile: false },
@@ -319,15 +319,24 @@ function MobileWatchlistBar() {
 }
 
 // ── Mobile bottom navigation ────────────────────────────────────────────────
-const _PRIMARY_NAV  = NAV_ITEMS.filter(i => i.mobile);
-const _SECONDARY_NAV = NAV_ITEMS.filter(i => !i.mobile);
+// Base items always in the primary bar; extended items only on phones > 375px.
+const _BASE_HREFS     = ['/', '/analysis'];
+const _EXTENDED_HREFS = ['/options', '/earnings'];
 
 function MobileNav() {
-  const pathname               = usePathname();
+  const pathname                 = usePathname();
   const { isDark, primaryColor } = useAppShell();
-  const [moreOpen, setMoreOpen]  = useState(false);
+  const { user, signOut }        = useAuth();
+  const [moreOpen,  setMoreOpen] = useState(false);
+  const [authOpen,  setAuthOpen] = useState(false);
+  // ≤375px covers iPhone SE (2nd/3rd gen) and older 320px phones
+  const isSmallPhone             = useMediaQuery('(max-width:375px)');
   const borderCol = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';
-  const moreActive = _SECONDARY_NAV.some(i => isActive(pathname, i.href));
+
+  const primaryHrefs = isSmallPhone ? _BASE_HREFS : [..._BASE_HREFS, ..._EXTENDED_HREFS];
+  const primaryNav   = NAV_ITEMS.filter(i => primaryHrefs.includes(i.href));
+  const secondaryNav = NAV_ITEMS.filter(i => !primaryHrefs.includes(i.href));
+  const moreActive   = secondaryNav.some(i => isActive(pathname, i.href));
 
   return (
     <>
@@ -340,7 +349,7 @@ function MobileNav() {
           justifyContent: 'space-around', alignItems: 'stretch', height: 60,
         }}
       >
-        {_PRIMARY_NAV.map(({ label, href, icon: Icon }) => {
+        {primaryNav.map(({ label, href, icon: Icon }) => {
           const active = isActive(pathname, href);
           return (
             <Box
@@ -360,7 +369,7 @@ function MobileNav() {
           );
         })}
 
-        {/* More — opens secondary nav drawer */}
+        {/* More — opens secondary nav + auth drawer */}
         <Box
           onClick={() => setMoreOpen(true)}
           sx={{
@@ -375,7 +384,7 @@ function MobileNav() {
         </Box>
       </Box>
 
-      {/* Secondary nav bottom drawer */}
+      {/* More drawer — secondary nav + auth */}
       <Drawer
         anchor="bottom"
         open={moreOpen}
@@ -385,8 +394,44 @@ function MobileNav() {
         <Box sx={{ pt: 1, pb: 0.5, display: 'flex', justifyContent: 'center' }}>
           <Box sx={{ width: 36, height: 4, borderRadius: 2, bgcolor: 'divider' }} />
         </Box>
+
+        {/* Auth section */}
+        <Box sx={{ px: 2, py: 1.5, borderBottom: `1px solid ${borderCol}` }}>
+          {user ? (
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
+              <Box sx={{ minWidth: 0 }}>
+                <Typography sx={{ fontSize: 13, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {user.email?.split('@')[0] ?? 'Account'}
+                </Typography>
+                <Typography sx={{ fontSize: 11, opacity: 0.5, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {user.email}
+                </Typography>
+              </Box>
+              <Button
+                size="small"
+                variant="outlined"
+                color="inherit"
+                onClick={() => { signOut().catch(console.error); setMoreOpen(false); }}
+                startIcon={<LogOut size={14} />}
+                sx={{ flexShrink: 0, fontSize: 11, borderRadius: 2 }}
+              >
+                Sign Out
+              </Button>
+            </Box>
+          ) : (
+            <Button
+              fullWidth
+              variant="outlined"
+              onClick={() => { setMoreOpen(false); setAuthOpen(true); }}
+              startIcon={<LogIn size={16} />}
+            >
+              Sign In
+            </Button>
+          )}
+        </Box>
+
         <List disablePadding>
-          {_SECONDARY_NAV.map(({ label, href, icon: Icon }) => {
+          {secondaryNav.map(({ label, href, icon: Icon }) => {
             const active = isActive(pathname, href);
             return (
               <ListItemButton
@@ -408,6 +453,8 @@ function MobileNav() {
           })}
         </List>
       </Drawer>
+
+      <AuthModal open={authOpen} onClose={() => setAuthOpen(false)} />
     </>
   );
 }

--- a/frontend/app/(app)/layout.tsx
+++ b/frontend/app/(app)/layout.tsx
@@ -301,8 +301,8 @@ function MobileWatchlistBar() {
           key={item.symbol}
           onClick={() => router.push(`/analysis?symbol=${encodeURIComponent(item.symbol)}`)}
           sx={{
-            flexShrink: 0, px: 1.5, py: 0.5, borderRadius: 10,
-            bgcolor: chipBg, cursor: 'pointer', minHeight: 28,
+            flexShrink: 0, px: 1.5, py: 0.75, borderRadius: 10,
+            bgcolor: chipBg, cursor: 'pointer', minHeight: 44,
             display: 'flex', alignItems: 'center',
             '&:hover': { bgcolor: `${primaryColor}22` },
           }}

--- a/frontend/app/(app)/page.tsx
+++ b/frontend/app/(app)/page.tsx
@@ -8,6 +8,7 @@ import {
 } from '@mui/material';
 import { Search } from 'lucide-react';
 import { useAppShell } from '../../contexts/AppShellContext';
+import { useWatchlistContext } from '../../contexts/WatchlistContext';
 import MorningBriefingPanel from '../../components/MorningBriefingPanel';
 import SectorHeatmap from '../../components/SectorHeatmap';
 import TrendingSparklines from '../../components/TrendingSparklines';
@@ -28,8 +29,7 @@ const POPULAR_TICKERS = [
 ];
 
 // Curated trending list for the landing page (TrendingSparklines fetches /api/sparklines).
-const TRENDING = ['NVDA','AAPL','MSFT','TSLA','AMZN','META','GOOGL','AMD','AVGO','SPY','QQQ','BTC-USD']
-  .map(symbol => ({ symbol }));
+const TRENDING = ['NVDA','AAPL','MSFT','TSLA','AMZN','META','GOOGL','AMD','AVGO','SPY','QQQ','BTC-USD'];
 
 function getMarketStatus(): { open: boolean; label: string } {
   const now = new Date();
@@ -53,6 +53,7 @@ function getGreeting(): string {
 export default function LandingPage() {
   const router = useRouter();
   const { isDark, primaryColor } = useAppShell();
+  const { watchlist } = useWatchlistContext();
   const [ticker, setTicker]     = useState('');
   const [exchange, setExchange] = useState('');
   const [navigating, setNavigating] = useState(false);
@@ -176,7 +177,11 @@ export default function LandingPage() {
               background: isDark ? 'rgba(255,255,255,0.02)' : 'rgba(0,0,0,0.015)',
             }}
           >
-            <TrendingSparklines tickers={TRENDING} isDark={isDark} />
+            <TrendingSparklines
+              tickers={TRENDING}
+              isDark={isDark}
+              extraSymbols={watchlist.map(w => w.symbol)}
+            />
           </Paper>
         </Grid>
       </Grid>

--- a/frontend/app/(app)/page.tsx
+++ b/frontend/app/(app)/page.tsx
@@ -82,7 +82,7 @@ export default function LandingPage() {
         sx={{ mb: 3 }}
       >
         <Box>
-          <Typography variant="h4" sx={{ fontWeight: 800 }}>
+          <Typography sx={{ fontWeight: 800, fontSize: { xs: '1.25rem', sm: '2.125rem' }, lineHeight: 1.2 }}>
             {getGreeting()}. Markets are {market.open ? 'open' : 'closed'}.
           </Typography>
           <Typography variant="body2" sx={{ opacity: 0.6, mt: 0.5 }}>

--- a/frontend/app/(app)/watchlist/page.tsx
+++ b/frontend/app/(app)/watchlist/page.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Skeleton from '@mui/material/Skeleton';
+import IconButton from '@mui/material/IconButton';
+import Button from '@mui/material/Button';
+import Link from 'next/link';
+import { X, Star } from 'lucide-react';
+import { LineChart, Line, YAxis } from 'recharts';
+import { useWatchlistContext } from '../../../contexts/WatchlistContext';
+import { useAppShell } from '../../../contexts/AppShellContext';
+import { useAuth } from '../../../contexts/AuthContext';
+import AuthModal from '../../../components/AuthModal';
+import type { SparklineTicker } from '../../../types';
+
+export default function WatchlistPage() {
+  const { watchlist, isLoading: wlLoading, remove } = useWatchlistContext();
+  const { isDark, primaryColor }                     = useAppShell();
+  const { session }                                  = useAuth();
+  const [authOpen,    setAuthOpen]    = useState(false);
+  const [sparklines,  setSparklines]  = useState<SparklineTicker[]>([]);
+  const [splLoading,  setSplLoading]  = useState(false);
+
+  const symbolKey = useMemo(
+    () => watchlist.map(i => i.symbol).join(','),
+    [watchlist],
+  );
+
+  const fetchSparklines = useCallback(async () => {
+    if (!symbolKey) { setSparklines([]); return; }
+    setSplLoading(true);
+    try {
+      const res  = await fetch(`/api/sparklines?tickers=${encodeURIComponent(symbolKey)}`);
+      const data = await res.json() as SparklineTicker[];
+      setSparklines(Array.isArray(data) ? data : []);
+    } catch { /* non-fatal */ } finally {
+      setSplLoading(false);
+    }
+  }, [symbolKey]);
+
+  useEffect(() => { void fetchSparklines(); }, [fetchSparklines]);
+
+  const splMap = useMemo(() => {
+    const m: Record<string, SparklineTicker> = {};
+    sparklines.forEach(s => { m[s.symbol] = s; });
+    return m;
+  }, [sparklines]);
+
+  const textColor = isDark ? 'rgba(220,220,220,0.85)' : 'rgba(20,30,50,0.85)';
+  const dimColor  = isDark ? 'rgba(220,220,220,0.45)' : 'rgba(20,30,50,0.45)';
+  const cardBg    = isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.02)';
+  const borderCol = isDark ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.08)';
+
+  if (!session) {
+    return (
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: 260, gap: 2, textAlign: 'center' }}>
+        <Star size={36} color={dimColor} />
+        <Typography sx={{ color: dimColor, fontSize: 14 }}>Sign in to save and view your watchlist.</Typography>
+        <Button variant="outlined" size="small" onClick={() => setAuthOpen(true)}>Sign In</Button>
+        <AuthModal open={authOpen} onClose={() => setAuthOpen(false)} />
+      </Box>
+    );
+  }
+
+  if (wlLoading) {
+    return (
+      <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: 1.5 }}>
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} variant="rectangular" height={76} sx={{ borderRadius: 2 }} />
+        ))}
+      </Box>
+    );
+  }
+
+  if (!watchlist.length) {
+    return (
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: 260, gap: 1.5, textAlign: 'center' }}>
+        <Star size={36} color={dimColor} />
+        <Typography sx={{ color: dimColor, fontSize: 14 }}>Your watchlist is empty.</Typography>
+        <Typography sx={{ color: dimColor, fontSize: 12 }}>
+          Tap ☆ on any Analysis page to add a stock.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Typography sx={{ fontSize: 11, fontWeight: 800, letterSpacing: 1.2, color: dimColor, textTransform: 'uppercase', mb: 2 }}>
+        Watchlist · {watchlist.length} {watchlist.length === 1 ? 'symbol' : 'symbols'}
+      </Typography>
+      <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: 1.5 }}>
+        {watchlist.map(item => {
+          const spl   = splMap[item.symbol];
+          const up    = spl ? spl.change_pct >= 0 : null;
+          const lineC = up === null
+            ? dimColor
+            : (up ? (isDark ? '#00ffa3' : '#16a34a') : (isDark ? '#ff0055' : '#dc2626'));
+          const pts = spl ? (spl.bars ?? []).map(b => ({ v: b.c })) : [];
+
+          return (
+            <Box
+              key={item.symbol}
+              sx={{
+                position: 'relative', p: 1.5, borderRadius: 2,
+                border: `1px solid ${borderCol}`, bgcolor: cardBg,
+                transition: 'border-color 0.15s',
+                '&:hover': { borderColor: `${primaryColor}55` },
+              }}
+            >
+              {/* Remove from watchlist */}
+              <IconButton
+                size="small"
+                onClick={() => remove(item.symbol)}
+                aria-label={`Remove ${item.symbol}`}
+                sx={{
+                  position: 'absolute', top: 4, right: 4,
+                  width: 22, height: 22, opacity: 0.45,
+                  '&:hover': { opacity: 1 },
+                  '& svg': { width: 12, height: 12 },
+                }}
+              >
+                <X />
+              </IconButton>
+
+              {/* Card body → analysis page */}
+              <Box
+                component={Link}
+                href={`/analysis?symbol=${encodeURIComponent(item.symbol)}`}
+                sx={{ display: 'flex', alignItems: 'center', gap: 1.5, pr: 2, textDecoration: 'none' }}
+              >
+                {/* Sparkline */}
+                <Box sx={{ width: 64, height: 36, flexShrink: 0 }}>
+                  {splLoading && !spl ? (
+                    <Skeleton variant="rectangular" width={64} height={36} sx={{ borderRadius: 1 }} />
+                  ) : pts.length >= 2 ? (
+                    <LineChart data={pts} width={64} height={36} margin={{ top: 3, right: 2, bottom: 3, left: 2 }}>
+                      <YAxis domain={['dataMin', 'dataMax']} hide />
+                      <Line type="monotone" dataKey="v" stroke={lineC} strokeWidth={1.5} dot={false} isAnimationActive={false} />
+                    </LineChart>
+                  ) : (
+                    <Box sx={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                      <Box sx={{ width: '85%', height: 1, bgcolor: dimColor, opacity: 0.4 }} />
+                    </Box>
+                  )}
+                </Box>
+
+                {/* Price info */}
+                <Box sx={{ minWidth: 0, flex: 1 }}>
+                  <Typography sx={{ fontSize: 13, fontWeight: 700, color: textColor, lineHeight: 1.3 }}>
+                    {item.symbol}
+                  </Typography>
+                  {spl ? (
+                    <Typography sx={{ fontSize: 11, fontWeight: 600, color: lineC, lineHeight: 1.2 }}>
+                      ${spl.price.toFixed(2)}&nbsp;·&nbsp;{up ? '+' : ''}{spl.change_pct.toFixed(2)}%
+                    </Typography>
+                  ) : (
+                    <Typography sx={{ fontSize: 11, color: dimColor }}>–</Typography>
+                  )}
+                </Box>
+              </Box>
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/app/(app)/watchlist/page.tsx
+++ b/frontend/app/(app)/watchlist/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Skeleton from '@mui/material/Skeleton';
@@ -22,25 +22,42 @@ export default function WatchlistPage() {
   const [authOpen,    setAuthOpen]    = useState(false);
   const [sparklines,  setSparklines]  = useState<SparklineTicker[]>([]);
   const [splLoading,  setSplLoading]  = useState(false);
+  const controllerRef                 = useRef<AbortController | null>(null);
 
+  // Deduplicate and cap at 24 to match the backend's symbols[:24] truncation
   const symbolKey = useMemo(
-    () => watchlist.map(i => i.symbol).join(','),
+    () => [...new Set(watchlist.map(i => i.symbol))].slice(0, 24).join(','),
     [watchlist],
   );
 
   const fetchSparklines = useCallback(async () => {
     if (!symbolKey) { setSparklines([]); return; }
+    controllerRef.current?.abort();
+    const controller = new AbortController();
+    controllerRef.current = controller;
     setSplLoading(true);
     try {
-      const res  = await fetch(`/api/sparklines?tickers=${encodeURIComponent(symbolKey)}`);
+      const res  = await fetch(`/api/sparklines?tickers=${encodeURIComponent(symbolKey)}`, {
+        signal: controller.signal,
+      });
       const data = await res.json() as SparklineTicker[];
-      setSparklines(Array.isArray(data) ? data : []);
-    } catch { /* non-fatal */ } finally {
-      setSplLoading(false);
+      if (controllerRef.current === controller) {
+        setSparklines(Array.isArray(data) ? data : []);
+      }
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === 'AbortError') return;
+    } finally {
+      if (controllerRef.current === controller) {
+        controllerRef.current = null;
+        setSplLoading(false);
+      }
     }
   }, [symbolKey]);
 
   useEffect(() => { void fetchSparklines(); }, [fetchSparklines]);
+
+  // Abort in-flight request on unmount
+  useEffect(() => () => { controllerRef.current?.abort(); }, []);
 
   const splMap = useMemo(() => {
     const m: Record<string, SparklineTicker> = {};

--- a/frontend/app/api/sparklines/route.ts
+++ b/frontend/app/api/sparklines/route.ts
@@ -14,7 +14,7 @@ export async function GET(req: NextRequest) {
     if (extra)   qs.set('extra',   extra);
     const res  = await fetch(`${BACKEND_URL}/sparklines?${qs.toString()}`, { signal: controller.signal });
     const data = await res.json();
-    return NextResponse.json(data);
+    return NextResponse.json(data, { status: res.status });
   } catch {
     return NextResponse.json([], { status: 502 });
   } finally {

--- a/frontend/app/api/sparklines/route.ts
+++ b/frontend/app/api/sparklines/route.ts
@@ -1,15 +1,23 @@
-import { NextResponse } from 'next/server';
-import axios from 'axios';
+import { NextRequest, NextResponse } from 'next/server';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
 
-export async function GET(request: Request) {
+export async function GET(req: NextRequest) {
+  const controller = new AbortController();
+  const timeout    = setTimeout(() => controller.abort(), 15_000);
   try {
-    const { searchParams } = new URL(request.url);
-    const tickers = searchParams.get('tickers') || '';
-    const response = await axios.get(`${BACKEND_URL}/sparklines`, { params: { tickers }, timeout: 8000, signal: request.signal });
-    return NextResponse.json(response.data);
-  } catch (error: any) {
-    return NextResponse.json({}, { status: error.response?.status || 500 });
+    const { searchParams } = new URL(req.url);
+    const tickers = searchParams.get('tickers') ?? '';
+    const extra   = searchParams.get('extra')   ?? '';
+    const qs      = new URLSearchParams();
+    if (tickers) qs.set('tickers', tickers);
+    if (extra)   qs.set('extra',   extra);
+    const res  = await fetch(`${BACKEND_URL}/sparklines?${qs.toString()}`, { signal: controller.signal });
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch {
+    return NextResponse.json([], { status: 502 });
+  } finally {
+    clearTimeout(timeout);
   }
 }

--- a/frontend/app/api/watchlist/[symbol]/route.ts
+++ b/frontend/app/api/watchlist/[symbol]/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
+
+// DELETE /api/watchlist/[symbol] → backend DELETE /watchlist/{symbol}
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ symbol: string }> },
+) {
+  const controller = new AbortController();
+  const timeout    = setTimeout(() => controller.abort(), 15_000);
+  const auth       = req.headers.get('authorization') ?? '';
+  const { symbol } = await params;
+  try {
+    const res = await fetch(`${BACKEND_URL}/watchlist/${encodeURIComponent(symbol)}`, {
+      method:  'DELETE',
+      headers: auth ? { authorization: auth } : {},
+      signal:  controller.signal,
+    });
+    if (res.status === 204) {
+      return new NextResponse(null, { status: 204 });
+    }
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json({ detail: 'Could not remove from watchlist.' }, { status: 502 });
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/frontend/app/api/watchlist/route.ts
+++ b/frontend/app/api/watchlist/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
+
+// GET /api/watchlist → backend /watchlist (anon returns [])
+export async function GET(req: NextRequest) {
+  const controller = new AbortController();
+  const timeout    = setTimeout(() => controller.abort(), 15_000);
+  const auth       = req.headers.get('authorization') ?? '';
+  try {
+    const res  = await fetch(`${BACKEND_URL}/watchlist`, {
+      headers: auth ? { authorization: auth } : {},
+      signal:  controller.signal,
+    });
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json({ watchlist: [] }, { status: 502 });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// POST /api/watchlist → backend /watchlist (auth required)
+export async function POST(req: NextRequest) {
+  const controller = new AbortController();
+  const timeout    = setTimeout(() => controller.abort(), 15_000);
+  const auth       = req.headers.get('authorization') ?? '';
+  try {
+    let body: unknown;
+    try { body = await req.json(); } catch {
+      return NextResponse.json({ detail: 'Invalid JSON body.' }, { status: 400 });
+    }
+    const res  = await fetch(`${BACKEND_URL}/watchlist`, {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/json', ...(auth ? { authorization: auth } : {}) },
+      body:    JSON.stringify(body),
+      signal:  controller.signal,
+    });
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json({ detail: 'Could not add to watchlist.' }, { status: 502 });
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/frontend/components/AdvancedChart.tsx
+++ b/frontend/components/AdvancedChart.tsx
@@ -64,6 +64,7 @@ interface Props {
   resistance?: number[];
   intraday?: boolean;   // show HH:MM on the time axis (1D/5D/1M ranges)
   showVwap?: boolean;   // dashed VWAP overlay (intraday ranges only)
+  priceHeight?: number; // height of the main price pane in px (default 380)
 }
 
 /**
@@ -127,6 +128,7 @@ export default function AdvancedChart({
   resistance = [],
   intraday = false,
   showVwap = false,
+  priceHeight = 380,
 }: Props) {
   const priceRef   = useRef<HTMLDivElement>(null);
   const volumeRef  = useRef<HTMLDivElement>(null);
@@ -388,7 +390,7 @@ export default function AdvancedChart({
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 6, width: '100%' }}>
-      <div style={{ position: 'relative', height: 380, border: paneBorder, borderRadius: 8, overflow: 'hidden' }}>
+      <div style={{ position: 'relative', height: priceHeight, border: paneBorder, borderRadius: 8, overflow: 'hidden' }}>
         <span style={labelStyle}>Price</span>
         <div ref={priceRef} style={{ position: 'absolute', inset: 0 }} />
       </div>

--- a/frontend/components/ClientProviders.tsx
+++ b/frontend/components/ClientProviders.tsx
@@ -1,7 +1,14 @@
 'use client';
 
 import { AuthProvider } from '../contexts/AuthContext';
+import { WatchlistProvider } from '../contexts/WatchlistContext';
 
 export default function ClientProviders({ children }: { children: React.ReactNode }) {
-  return <AuthProvider>{children}</AuthProvider>;
+  return (
+    <AuthProvider>
+      <WatchlistProvider>
+        {children}
+      </WatchlistProvider>
+    </AuthProvider>
+  );
 }

--- a/frontend/components/DCFCard.tsx
+++ b/frontend/components/DCFCard.tsx
@@ -48,7 +48,7 @@ export default function DCFCard({ dcf, isDark, primaryColor }: Props) {
         </Stack>
 
         {/* 3-scenario grid */}
-        <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 1.5, mb: 1.5 }}>
+        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr 1fr' }, gap: 1.5, mb: 1.5 }}>
           {SCENARIOS.map(({ key, label, color }) => {
             const s = dcf[key];
             return (

--- a/frontend/components/FundamentalsPanel.tsx
+++ b/frontend/components/FundamentalsPanel.tsx
@@ -83,7 +83,7 @@ export default function FundamentalsPanel({ prediction, rsiInfo, isDark, primary
               },
               { label: 'DIVIDEND', val: prediction.metrics.yield },
             ].map(item => (
-              <Grid size={6} key={item.label}>
+              <Grid size={{ xs: 6, sm: 4, md: 3 }} key={item.label}>
                 <Typography variant="caption" sx={{ opacity: 0.4 }}>{item.label}</Typography>
                 <Typography variant="body2" sx={{ fontWeight: 700, color: item.color ?? 'inherit' }}>
                   {item.val}
@@ -175,7 +175,7 @@ export default function FundamentalsPanel({ prediction, rsiInfo, isDark, primary
               ] as { label: string; val: string; tip?: string; color?: string }[])
                 .filter(item => item.val && item.val !== 'N/A')
                 .map(item => (
-                  <Grid size={6} key={item.label}>
+                  <Grid size={{ xs: 6, sm: 4, md: 3 }} key={item.label}>
                     <Typography variant="caption" sx={{ opacity: 0.4 }}>{item.label}</Typography>
                     <Typography variant="body2" sx={{ fontWeight: 700, color: item.color ?? 'inherit' }}>
                       {item.val}

--- a/frontend/components/OrderBookPanel.tsx
+++ b/frontend/components/OrderBookPanel.tsx
@@ -189,7 +189,7 @@ export default function OrderBookPanel({ symbol }: { symbol: string }) {
   };
 
   return (
-    <Paper sx={{ p: 2, borderRadius: 2 }}>
+    <Paper sx={{ p: { xs: 1.5, sm: 2 }, borderRadius: 2, overflowX: 'auto' }}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', mb: 1 }}>
         <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.75 }}>
           <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>

--- a/frontend/components/PriceChartCard.tsx
+++ b/frontend/components/PriceChartCard.tsx
@@ -138,11 +138,13 @@ export default function PriceChartCard({
 
   return (
     <Card>
-      <CardContent sx={{ p: 4 }}>
+      <CardContent sx={{ p: { xs: 2, sm: 3, md: 4 } }}>
         {/* Symbol header */}
         <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 3 }}>
           <Box>
-            <Typography variant="h2">{prediction.symbol}</Typography>
+            <Typography sx={{ fontWeight: 800, fontSize: { xs: '1.75rem', sm: '2.5rem', md: '3.75rem' }, lineHeight: 1.1 }}>
+              {prediction.symbol}
+            </Typography>
             <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 0.5 }}>
               <Chip
                 label={`${prediction.prediction.trend} Trend`}
@@ -156,7 +158,9 @@ export default function PriceChartCard({
             </Stack>
           </Box>
           <Box sx={{ textAlign: 'right' }}>
-            <Typography variant="h3" color="primary.main">${prediction.currentPrice}</Typography>
+            <Typography color="primary.main" sx={{ fontWeight: 700, fontSize: { xs: '1.5rem', sm: '2rem', md: '3rem' }, lineHeight: 1.1 }}>
+              ${prediction.currentPrice}
+            </Typography>
             <Typography variant="caption" sx={{ opacity: 0.4 }}>
               {prediction.metrics.currency ?? 'USD'} · LIVE FEED
             </Typography>

--- a/frontend/components/PriceChartCard.tsx
+++ b/frontend/components/PriceChartCard.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo, useCallback } from 'react';
 import axios from 'axios';
 import {
   Box, Card, CardContent, Chip, Collapse, CircularProgress, Stack, Typography,
-  ToggleButton, ToggleButtonGroup, Button,
+  ToggleButton, ToggleButtonGroup, Button, useMediaQuery, useTheme,
 } from '@mui/material';
 import { Info, ChevronDown, ChevronUp } from 'lucide-react';
 import dynamic from 'next/dynamic';
@@ -45,6 +45,11 @@ export default function PriceChartCard({
   chartMode, setChartMode,
   isDark, primaryColor, trendColor, chartStats, indicatorSignals,
 }: Props) {
+  const theme    = useTheme();
+  const isXs     = useMediaQuery(theme.breakpoints.down('sm'));
+  const isSm     = useMediaQuery(theme.breakpoints.between('sm', 'md'));
+  const chartH   = isXs ? 220 : isSm ? 300 : 400;
+
   const [legendOpen,       setLegendOpen]       = useState(false);
   const [selectedInterval, setSelectedInterval] = useState<string>('2y');
   const [intervalData,     setIntervalData]     = useState<IntervalHistoryData | null>(null);
@@ -345,6 +350,7 @@ export default function PriceChartCard({
             resistance={isTwoYear ? (prediction.indicators?.resistance ?? []) : []}
             intraday={intraday}
             showVwap={intraday && showVwap}
+            priceHeight={chartH}
           />
         </Box>
       </CardContent>

--- a/frontend/components/TradeSetupCard.tsx
+++ b/frontend/components/TradeSetupCard.tsx
@@ -54,7 +54,7 @@ export default function TradeSetupCard({ setup, loading, isDark, primaryColor }:
         </Stack>
 
         {/* 3-column grid */}
-        <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 1.5, mb: 1.5 }}>
+        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr 1fr' }, gap: 1.5, mb: 1.5 }}>
 
           {/* Entry zone */}
           <Box sx={{ p: 1.5, borderRadius: 2, border: `1px solid ${primaryColor}22`, background: `${primaryColor}08` }}>

--- a/frontend/components/TrendingSparklines.tsx
+++ b/frontend/components/TrendingSparklines.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
-import { LineChart, Line } from 'recharts';
+import { LineChart, Line, YAxis } from 'recharts';
 import Box from '@mui/material/Box';
 import Skeleton from '@mui/material/Skeleton';
 import Typography from '@mui/material/Typography';
@@ -120,6 +120,7 @@ export default function TrendingSparklines({ tickers, isDark, extraSymbols }: Pr
                   <Box sx={{ width: 52, height: 28, flexShrink: 0 }}>
                     {pts.length >= 2 ? (
                       <LineChart data={pts} width={52} height={28} margin={{ top: 2, right: 2, bottom: 2, left: 2 }}>
+                        <YAxis domain={['dataMin', 'dataMax']} hide />
                         <Line
                           type="monotone"
                           dataKey="v"

--- a/frontend/components/TrendingSparklines.tsx
+++ b/frontend/components/TrendingSparklines.tsx
@@ -58,7 +58,10 @@ export default function TrendingSparklines({ tickers, isDark, extraSymbols }: Pr
       if (err instanceof Error && err.name === 'AbortError') return;
       // Non-critical; keep stale data if any
     } finally {
-      setLoading(false);
+      if (controllerRef.current === controller) {
+        controllerRef.current = null;
+        setLoading(false);
+      }
     }
   }, [tickerKey, extraKey]);
 

--- a/frontend/components/TrendingSparklines.tsx
+++ b/frontend/components/TrendingSparklines.tsx
@@ -1,120 +1,147 @@
 'use client';
 
-import { useEffect, useState, useTransition } from 'react';
+import { useEffect, useState, useRef, useCallback } from 'react';
 import { LineChart, Line } from 'recharts';
 import Box from '@mui/material/Box';
+import Skeleton from '@mui/material/Skeleton';
 import Typography from '@mui/material/Typography';
-import axios from 'axios';
+import type { SparklineTicker } from '../types';
 
-interface TrendingTicker {
-  symbol?: string;
-  ticker?: string;
-  price?: string | number;
-  change?: string | number;
-  name?: string;
-}
-
-function makeFallback(t: TrendingTicker, i: number): number[] {
-  const isUp  = String(t.change ?? '').startsWith('+');
-  const base  = parseFloat(String(t.price ?? '100').replace(/[^\d.]/g, '')) || 100;
-  const seed  = i * 3.7 + base * 0.01;
-  return Array.from({ length: 12 }, (_, j) =>
-    base * (1 + (isUp ? 1 : -1) * (j / 11) * 0.025 + Math.sin(seed + j * 0.9) * 0.007),
-  );
-}
+const REFRESH_DEBOUNCE_MS = 5 * 60 * 1000; // 5 min
 
 interface Props {
-  tickers: TrendingTicker[];
-  isDark: boolean;
+  tickers:      string[];
+  isDark:       boolean;
+  extraSymbols?: string[];  // watchlist symbols to append as ?extra=
 }
 
-type SparklineMap = Record<string, number[]>;
-
-export default function TrendingSparklines({ tickers, isDark }: Props) {
-  const [sparklines, setSparklines] = useState<SparklineMap>({});
-  const [isPending, startTransition] = useTransition();
+export default function TrendingSparklines({ tickers, isDark, extraSymbols }: Props) {
+  const [data,       setData]       = useState<SparklineTicker[]>([]);
+  const [loading,    setLoading]    = useState(false);
+  const lastFetchRef                = useRef<number>(0);
+  const controllerRef               = useRef<AbortController | null>(null);
 
   const textColor = isDark ? 'rgba(220,220,220,0.7)' : 'rgba(20,30,50,0.7)';
   const dimColor  = isDark ? 'rgba(220,220,220,0.35)' : 'rgba(20,30,50,0.35)';
   const bg        = isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.02)';
   const border    = isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.07)';
 
-  useEffect(() => {
+  const fetchData = useCallback(async (force = false) => {
+    const now = Date.now();
+    if (!force && now - lastFetchRef.current < REFRESH_DEBOUNCE_MS) return;
     if (!tickers.length) return;
-    const syms = tickers.map(t => t.symbol ?? t.ticker ?? '').filter(Boolean).slice(0, 18);
-    if (!syms.length) return;
 
+    // Cancel any in-flight request
+    controllerRef.current?.abort();
     const controller = new AbortController();
-    axios.get(`/api/sparklines?tickers=${syms.join(',')}`, { signal: controller.signal })
-      .then(r => startTransition(() => setSparklines(r.data)))
-      .catch(err => {
-        if (err.name !== 'CanceledError' && !err.message?.includes('canceled')) {
-          // silent — sparklines are non-critical
-        }
-      });
-    return () => controller.abort();
-  }, [tickers]);
+    controllerRef.current = controller;
+
+    setLoading(true);
+    try {
+      const qs = new URLSearchParams({ tickers: tickers.slice(0, 18).join(',') });
+      if (extraSymbols?.length) {
+        // Deduplicate extras against the base list
+        const baseSet  = new Set(tickers.map(s => s.toUpperCase()));
+        const uniq     = extraSymbols.filter(s => !baseSet.has(s.toUpperCase())).slice(0, 12);
+        if (uniq.length) qs.set('extra', uniq.join(','));
+      }
+      const res = await fetch(`/api/sparklines?${qs.toString()}`, { signal: controller.signal });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = await res.json() as SparklineTicker[];
+      setData(Array.isArray(json) ? json : []);
+      lastFetchRef.current = Date.now();
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === 'AbortError') return;
+      // Non-critical; keep stale data if any
+    } finally {
+      setLoading(false);
+    }
+  }, [tickers, extraSymbols]);
+
+  // Initial fetch
+  useEffect(() => { void fetchData(true); }, [fetchData]);
+
+  // Refresh on tab visibility change (debounced to once per 5 min)
+  useEffect(() => {
+    const handler = () => { if (document.visibilityState === 'visible') void fetchData(); };
+    document.addEventListener('visibilitychange', handler);
+    return () => document.removeEventListener('visibilitychange', handler);
+  }, [fetchData]);
+
+  // Cleanup on unmount
+  useEffect(() => () => { controllerRef.current?.abort(); }, []);
 
   if (!tickers.length) return null;
+
+  const SKELETON_COUNT = Math.min(tickers.length, 12);
 
   return (
     <Box>
       <Typography sx={{ fontSize: 10, fontWeight: 800, letterSpacing: 1.2, color: dimColor, textTransform: 'uppercase', mb: 1 }}>
-        Trending {isPending && <span style={{ opacity: 0.5 }}>· loading…</span>}
+        Trending {loading && <span style={{ opacity: 0.5 }}>· refreshing…</span>}
       </Typography>
-      <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))', gap: 1 }}>
-        {tickers.slice(0, 18).map((t, i) => {
-          const sym    = t.symbol ?? t.ticker ?? `T${i}`;
-          const raw    = sparklines[sym];
-          const pts    = (raw?.length >= 2 ? raw : makeFallback(t, i)).map(v => ({ v }));
-          const first  = pts[0]?.v;
-          const last   = pts[pts.length - 1]?.v;
-          const up     = last !== undefined && first !== undefined ? last >= first : null;
-          const chgPct = first && last ? ((last - first) / first * 100).toFixed(2) : null;
-          const lineC  = up === null ? dimColor : up ? (isDark ? '#00ffa3' : '#16a34a') : (isDark ? '#ff0055' : '#dc2626');
+      <Box sx={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))',
+        gap: 1,
+      }}>
+        {loading && data.length === 0
+          ? Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+              <Skeleton
+                key={i}
+                variant="rectangular"
+                sx={{ borderRadius: 1.5, height: 44, bgcolor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)' }}
+              />
+            ))
+          : data.map(ticker => {
+              const up     = ticker.change_pct >= 0;
+              const lineC  = up
+                ? (isDark ? '#00ffa3' : '#16a34a')
+                : (isDark ? '#ff0055' : '#dc2626');
+              const pts    = (ticker.bars ?? []).map(b => ({ v: b.c }));
 
-          return (
-            <Box
-              key={sym}
-              sx={{
-                p: '6px 8px', borderRadius: 1.5, border: `1px solid ${border}`,
-                background: bg, display: 'flex', alignItems: 'center', gap: 1,
-              }}
-            >
-              {/* Sparkline */}
-              <Box sx={{ width: 52, height: 28, flexShrink: 0 }}>
-                {pts.length >= 2 ? (
-                  <LineChart data={pts} width={52} height={28} margin={{ top: 2, right: 2, bottom: 2, left: 2 }}>
-                    <Line
-                      type="monotone"
-                      dataKey="v"
-                      stroke={lineC}
-                      strokeWidth={1.5}
-                      dot={false}
-                      isAnimationActive={false}
-                    />
-                  </LineChart>
-                ) : (
-                  <Box sx={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                    <Box sx={{ width: '80%', height: 1, bgcolor: dimColor }} />
+              return (
+                <Box
+                  key={ticker.symbol}
+                  sx={{
+                    p: '6px 8px', borderRadius: 1.5, border: `1px solid ${border}`,
+                    background: bg, display: 'flex', alignItems: 'center', gap: 1,
+                    minWidth: 0,
+                  }}
+                >
+                  {/* Sparkline */}
+                  <Box sx={{ width: 52, height: 28, flexShrink: 0 }}>
+                    {pts.length >= 2 ? (
+                      <LineChart data={pts} width={52} height={28} margin={{ top: 2, right: 2, bottom: 2, left: 2 }}>
+                        <Line
+                          type="monotone"
+                          dataKey="v"
+                          stroke={lineC}
+                          strokeWidth={1.5}
+                          dot={false}
+                          isAnimationActive={false}
+                        />
+                      </LineChart>
+                    ) : (
+                      <Box sx={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                        <Box sx={{ width: '80%', height: 1, bgcolor: dimColor }} />
+                      </Box>
+                    )}
                   </Box>
-                )}
-              </Box>
 
-              {/* Label */}
-              <Box sx={{ minWidth: 0 }}>
-                <Typography sx={{ fontSize: 11, fontWeight: 700, color: textColor, lineHeight: 1.2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                  {sym}
-                </Typography>
-                {chgPct !== null && (
-                  <Typography sx={{ fontSize: 10, color: lineC, fontWeight: 600, lineHeight: 1.2 }}>
-                    {up ? '+' : ''}{chgPct}%
-                  </Typography>
-                )}
-              </Box>
-            </Box>
-          );
-        })}
+                  {/* Label */}
+                  <Box sx={{ minWidth: 0, flex: 1 }}>
+                    <Typography sx={{ fontSize: 11, fontWeight: 700, color: textColor, lineHeight: 1.2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {ticker.symbol}
+                    </Typography>
+                    <Typography sx={{ fontSize: 10, color: lineC, fontWeight: 600, lineHeight: 1.2 }}>
+                      {up ? '+' : ''}{ticker.change_pct.toFixed(2)}%
+                    </Typography>
+                  </Box>
+                </Box>
+              );
+            })
+        }
       </Box>
     </Box>
   );

--- a/frontend/components/TrendingSparklines.tsx
+++ b/frontend/components/TrendingSparklines.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useRef, useCallback } from 'react';
+import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import { LineChart, Line } from 'recharts';
 import Box from '@mui/material/Box';
 import Skeleton from '@mui/material/Skeleton';
@@ -25,6 +25,10 @@ export default function TrendingSparklines({ tickers, isDark, extraSymbols }: Pr
   const dimColor  = isDark ? 'rgba(220,220,220,0.35)' : 'rgba(20,30,50,0.35)';
   const bg        = isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.02)';
   const border    = isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.07)';
+
+  // Stable string keys — prevents refetch storms when parent passes new array references
+  const tickerKey = useMemo(() => tickers.map(s => s.toUpperCase()).join(','), [tickers]);
+  const extraKey  = useMemo(() => (extraSymbols ?? []).map(s => s.toUpperCase()).join(','), [extraSymbols]);
 
   const fetchData = useCallback(async (force = false) => {
     const now = Date.now();
@@ -56,7 +60,7 @@ export default function TrendingSparklines({ tickers, isDark, extraSymbols }: Pr
     } finally {
       setLoading(false);
     }
-  }, [tickers, extraSymbols]);
+  }, [tickerKey, extraKey]);
 
   // Initial fetch
   useEffect(() => { void fetchData(true); }, [fetchData]);

--- a/frontend/contexts/WatchlistContext.tsx
+++ b/frontend/contexts/WatchlistContext.tsx
@@ -59,7 +59,7 @@ export function WatchlistProvider({ children }: { children: ReactNode }) {
     const sym = symbol.toUpperCase();
     // Optimistic update
     if (!isWatched(sym)) {
-      setWatchlist(prev => [{ id: 'optimistic', symbol: sym, added_at: new Date().toISOString() }, ...prev]);
+      setWatchlist(prev => [{ id: `optimistic:${sym}:${Date.now()}`, symbol: sym, added_at: new Date().toISOString() }, ...prev]);
     }
     try {
       await fetch('/api/watchlist', {

--- a/frontend/contexts/WatchlistContext.tsx
+++ b/frontend/contexts/WatchlistContext.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import {
+  createContext, useContext, useEffect, useState, useCallback, ReactNode,
+} from 'react';
+import type { WatchlistItem } from '../types';
+import { useAuth } from './AuthContext';
+
+interface WatchlistContextValue {
+  watchlist:  WatchlistItem[];
+  isLoading:  boolean;
+  isWatched:  (symbol: string) => boolean;
+  add:        (symbol: string) => Promise<void>;
+  remove:     (symbol: string) => Promise<void>;
+  reload:     () => Promise<void>;
+}
+
+const WatchlistContext = createContext<WatchlistContextValue>({
+  watchlist: [], isLoading: false,
+  isWatched: () => false,
+  add: async () => {},
+  remove: async () => {},
+  reload: async () => {},
+});
+
+function authHeader(token: string): HeadersInit {
+  return { Authorization: `Bearer ${token}` };
+}
+
+export function WatchlistProvider({ children }: { children: ReactNode }) {
+  const { session }                       = useAuth();
+  const [watchlist,  setWatchlist]        = useState<WatchlistItem[]>([]);
+  const [isLoading,  setIsLoading]        = useState(false);
+
+  const token = session?.access_token ?? '';
+
+  const reload = useCallback(async () => {
+    if (!token) { setWatchlist([]); return; }
+    setIsLoading(true);
+    try {
+      const res  = await fetch('/api/watchlist', { headers: authHeader(token) });
+      const data = await res.json() as { watchlist?: WatchlistItem[] };
+      setWatchlist(data.watchlist ?? []);
+    } catch {
+      // non-fatal — watchlist silently unavailable
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token]);
+
+  // Reload on auth-state change (login / logout / token refresh)
+  useEffect(() => { void reload(); }, [reload]);
+
+  const isWatched = (symbol: string) =>
+    watchlist.some(w => w.symbol.toUpperCase() === symbol.toUpperCase());
+
+  const add = async (symbol: string) => {
+    if (!token) return;
+    const sym = symbol.toUpperCase();
+    // Optimistic update
+    if (!isWatched(sym)) {
+      setWatchlist(prev => [{ id: 'optimistic', symbol: sym, added_at: new Date().toISOString() }, ...prev]);
+    }
+    try {
+      await fetch('/api/watchlist', {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader(token) },
+        body:    JSON.stringify({ symbol: sym }),
+      });
+    } catch { /* non-fatal */ }
+    // Re-sync to get the real id
+    await reload();
+  };
+
+  const remove = async (symbol: string) => {
+    if (!token) return;
+    const sym = symbol.toUpperCase();
+    // Optimistic update
+    setWatchlist(prev => prev.filter(w => w.symbol !== sym));
+    try {
+      await fetch(`/api/watchlist/${encodeURIComponent(sym)}`, {
+        method:  'DELETE',
+        headers: authHeader(token),
+      });
+    } catch { /* non-fatal */ }
+    await reload();
+  };
+
+  return (
+    <WatchlistContext.Provider value={{ watchlist, isLoading, isWatched, add, remove, reload }}>
+      {children}
+    </WatchlistContext.Provider>
+  );
+}
+
+export const useWatchlistContext = () => useContext(WatchlistContext);

--- a/frontend/hooks/useWatchlist.ts
+++ b/frontend/hooks/useWatchlist.ts
@@ -1,60 +1,44 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
-import { useAuth } from '../contexts/AuthContext';
-import { fetchWatchlist, addToWatchlist, removeFromWatchlist } from '../lib/watchlist';
+import { useState, useCallback } from 'react';
+import { useWatchlistContext } from '../contexts/WatchlistContext';
 
+/**
+ * Per-symbol watchlist hook — thin wrapper around WatchlistContext that
+ * exposes the star-button API used by the analysis page.
+ *
+ * `currentSymbol` is optional; when provided, `currentIsSaved` reflects
+ * whether that ticker is currently in the watchlist.
+ */
 export function useWatchlist(currentSymbol?: string) {
-  const { user } = useAuth();
-  const [watchlist, setWatchlist]   = useState<string[]>([]);
-  const [loading, setLoading]       = useState(false);
-  const [toggling, setToggling]     = useState(false);
-  const loadSeqRef                  = useRef(0);
+  const { watchlist, isLoading, isWatched, add, remove } = useWatchlistContext();
+  const [toggling, setToggling] = useState(false);
 
-  const load = useCallback(async () => {
-    const seq = ++loadSeqRef.current;
-    if (!user) { setWatchlist([]); setLoading(false); return; }
-    setLoading(true);
-    try {
-      const rows = await fetchWatchlist(user.id);
-      if (seq === loadSeqRef.current) setWatchlist(rows);
-    } catch {
-      // non-fatal — watchlist feature silently unavailable if table not set up
-    } finally {
-      if (seq === loadSeqRef.current) setLoading(false);
-    }
-  }, [user]);
-
-  useEffect(() => { void load(); }, [load]);
-
-  const isSaved = (symbol: string) =>
-    watchlist.includes(symbol.toUpperCase());
-
-  async function toggle(symbol: string) {
-    if (!user) return;
-    const sym = symbol.toUpperCase();
+  const toggle = useCallback(async (symbol: string) => {
     setToggling(true);
     try {
-      if (isSaved(sym)) {
-        await removeFromWatchlist(user.id, sym);
-        setWatchlist(prev => prev.filter(s => s !== sym));
+      if (isWatched(symbol)) {
+        await remove(symbol);
       } else {
-        await addToWatchlist(user.id, sym);
-        setWatchlist(prev => [sym, ...prev]);
+        await add(symbol);
       }
-    } catch {
-      // non-fatal
     } finally {
       setToggling(false);
     }
-  }
+  }, [isWatched, add, remove]);
 
   return {
+    /** Full WatchlistItem list (id, symbol, added_at). */
     watchlist,
-    loading,
+    /** True while the initial list is loading. */
+    loading: isLoading,
+    /** True while an add/remove is in-flight for the toggled symbol. */
     toggling,
-    isSaved,
+    /** Returns true when the given symbol is in the watchlist. */
+    isSaved: isWatched,
+    /** Toggle add/remove for the given symbol. */
     toggle,
-    currentIsSaved: currentSymbol ? isSaved(currentSymbol) : false,
+    /** Whether the `currentSymbol` prop is currently saved. */
+    currentIsSaved: currentSymbol ? isWatched(currentSymbol) : false,
   };
 }

--- a/frontend/lib/watchlist.ts
+++ b/frontend/lib/watchlist.ts
@@ -1,43 +1,51 @@
 /*
- * Supabase watchlist helpers.
+ * Watchlist client (Feature 13).
  *
- * Required table (run once in Supabase SQL editor):
+ * Routes through the Next.js /api/watchlist proxies → FastAPI backend, which
+ * reads/writes the Supabase `watchlists` table via PostgREST using the caller's
+ * own JWT. Supabase RLS enforces per-user ownership — no service-role key needed.
  *
- *   create table watchlist (
- *     id         uuid default gen_random_uuid() primary key,
- *     user_id    uuid references auth.users(id) on delete cascade not null,
- *     symbol     text not null,
- *     created_at timestamptz default now(),
- *     unique(user_id, symbol)
- *   );
- *   alter table watchlist enable row level security;
- *   create policy "own rows" on watchlist using (auth.uid() = user_id)
- *     with check (auth.uid() = user_id);
+ * Migration: supabase/migrations/0006_watchlist.sql
  */
-import { supabase } from './supabase';
+import type { WatchlistItem } from '../types';
 
-export async function fetchWatchlist(userId: string): Promise<string[]> {
-  const { data, error } = await supabase
-    .from('watchlist')
-    .select('symbol')
-    .eq('user_id', userId)
-    .order('created_at', { ascending: false });
-  if (error) throw error;
-  return Array.from(new Set((data ?? []).map((r: { symbol: string }) => (r.symbol ?? '').trim().toUpperCase()).filter(Boolean)));
+function authHeaders(token: string): HeadersInit {
+  return { Authorization: `Bearer ${token}` };
 }
 
-export async function addToWatchlist(userId: string, symbol: string): Promise<void> {
-  const { error } = await supabase
-    .from('watchlist')
-    .insert({ user_id: userId, symbol: symbol.toUpperCase() });
-  if (error && error.code !== '23505') throw error; // ignore duplicate
+async function parseOrThrow(res: Response): Promise<unknown> {
+  let body: unknown = null;
+  try { body = await res.json(); } catch { /* empty body */ }
+  if (!res.ok) {
+    const detail = (body as { detail?: string } | null)?.detail;
+    throw new Error(detail || `Request failed (${res.status})`);
+  }
+  return body;
 }
 
-export async function removeFromWatchlist(userId: string, symbol: string): Promise<void> {
-  const { error } = await supabase
-    .from('watchlist')
-    .delete()
-    .eq('user_id', userId)
-    .eq('symbol', symbol.toUpperCase());
-  if (error) throw error;
+export async function fetchWatchlist(token: string): Promise<WatchlistItem[]> {
+  const res  = await fetch('/api/watchlist', { headers: authHeaders(token) });
+  const body = await parseOrThrow(res) as { watchlist?: WatchlistItem[] };
+  return body.watchlist ?? [];
+}
+
+export async function addToWatchlist(token: string, symbol: string): Promise<WatchlistItem> {
+  const res  = await fetch('/api/watchlist', {
+    method:  'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders(token) },
+    body:    JSON.stringify({ symbol: symbol.toUpperCase() }),
+  });
+  const body = await parseOrThrow(res) as { item?: WatchlistItem };
+  if (!body.item) throw new Error('Malformed response: missing item.');
+  return body.item;
+}
+
+export async function removeFromWatchlist(token: string, symbol: string): Promise<void> {
+  const res = await fetch(`/api/watchlist/${encodeURIComponent(symbol.toUpperCase())}`, {
+    method:  'DELETE',
+    headers: authHeaders(token),
+  });
+  if (!res.ok && res.status !== 204) {
+    await parseOrThrow(res);
+  }
 }

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -370,6 +370,26 @@ export interface PortfolioForecast {
   score: number;
 }
 
+// ── Watchlist (Feature 13) ──────────────────────────────────────────────────
+
+export interface WatchlistItem {
+  id:       string;
+  symbol:   string;
+  added_at: string;
+}
+
+export interface SparklineBar {
+  t: string;   // ISO timestamp (UTC, no tz suffix)
+  c: number;   // close price
+}
+
+export interface SparklineTicker {
+  symbol:     string;
+  price:      number;
+  change_pct: number;
+  bars:       SparklineBar[];
+}
+
 export interface PortfolioSummary {
   holdings:             PortfolioHolding[];
   totalMarketValue:     number;

--- a/supabase/migrations/0006_watchlist.sql
+++ b/supabase/migrations/0006_watchlist.sql
@@ -12,7 +12,16 @@ create table if not exists watchlists (
 
 alter table watchlists enable row level security;
 
-create policy "users manage own watchlist"
-  on watchlists for all
-  using (auth.uid() = user_id)
-  with check (auth.uid() = user_id);
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename  = 'watchlists'
+      and policyname = 'users manage own watchlist'
+  ) then
+    create policy "users manage own watchlist"
+      on watchlists for all
+      using (auth.uid() = user_id)
+      with check (auth.uid() = user_id);
+  end if;
+end $$;

--- a/supabase/migrations/0006_watchlist.sql
+++ b/supabase/migrations/0006_watchlist.sql
@@ -1,0 +1,18 @@
+-- Feature 13: Watchlist Persistence
+-- Creates the watchlists table with RLS so each user only sees their own rows.
+-- Apply this migration in the Supabase SQL editor (Dashboard → SQL Editor → New query).
+
+create table if not exists watchlists (
+  id         uuid primary key default gen_random_uuid(),
+  user_id    uuid not null references auth.users(id) on delete cascade,
+  symbol     text not null,
+  added_at   timestamptz default now(),
+  unique(user_id, symbol)
+);
+
+alter table watchlists enable row level security;
+
+create policy "users manage own watchlist"
+  on watchlists for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);

--- a/supabase/migrations/0006_watchlist.sql
+++ b/supabase/migrations/0006_watchlist.sql
@@ -1,27 +1,29 @@
 -- Feature 13: Watchlist Persistence
--- Creates the watchlists table with RLS so each user only sees their own rows.
--- Apply this migration in the Supabase SQL editor (Dashboard → SQL Editor → New query).
+--
+-- Apply in Supabase SQL Editor (Dashboard → SQL Editor → New query).
+-- Mirrors the holdings (0001) and alerts (0003) RLS pattern.
 
-create table if not exists watchlists (
+create table if not exists public.watchlists (
   id         uuid primary key default gen_random_uuid(),
-  user_id    uuid not null references auth.users(id) on delete cascade,
+  user_id    uuid not null references auth.users(id) on delete cascade default auth.uid(),
   symbol     text not null,
-  added_at   timestamptz default now(),
+  added_at   timestamptz not null default now(),
   unique(user_id, symbol)
 );
 
-alter table watchlists enable row level security;
+create index if not exists watchlists_user_id_idx on public.watchlists (user_id);
 
-do $$ begin
-  if not exists (
-    select 1 from pg_policies
-    where schemaname = 'public'
-      and tablename  = 'watchlists'
-      and policyname = 'users manage own watchlist'
-  ) then
-    create policy "users manage own watchlist"
-      on watchlists for all
-      using (auth.uid() = user_id)
-      with check (auth.uid() = user_id);
-  end if;
-end $$;
+alter table public.watchlists enable row level security;
+
+drop policy if exists "users manage own watchlist" on public.watchlists;
+create policy "users manage own watchlist"
+  on public.watchlists for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- PostgREST requires explicit grants; the authenticated role owns rows via RLS.
+grant select, insert, update, delete on table public.watchlists to authenticated;
+grant select on table public.watchlists to anon;
+
+-- Reload PostgREST schema cache so the new table is immediately visible.
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

- **Watchlist persistence** — Supabase `watchlists` table (`0006_watchlist.sql`), RLS own-rows policy, backend CRUD router (`/watchlist` GET/POST/DELETE), Redis-cached 60s per user; POST/DELETE require auth, GET returns `[]` for anonymous. Same JWT-forwarding PostgREST pattern as holdings (no service-role key).
- **Intraday sparklines** — `/sparklines` response upgraded from `Dict[str, List[float]]` to `List[{symbol, price, change_pct, bars: [{t, c}]}]`. Real 1-day 5-min yfinance bars, pre/post-market stripped (09:30–16:00 ET), per-symbol 5-min Redis cache, `?extra=` appends watchlist symbols (dedup, max 24). Partial symbol failures are skipped silently.
- **Frontend** — `WatchlistContext` is the single source of truth (wraps `AuthProvider` in `ClientProviders`); `useWatchlist` is a thin backward-compat wrapper. Sidebar collapsible watchlist panel + mobile fixed bottom chip bar. `TrendingSparklines` rewritten for the new shape (live Recharts sparkline from `bars`).
- **Responsive design** — `PriceChartCard` / `AdvancedChart` height 220/300/400 px; `DCFCard` + `TradeSetupCard` 3-column grids stack on xs; `FundamentalsPanel` xs:6/sm:4/md:3; earnings + IPO responsive CSS grids; sidebar `maxWidth 280` + shell `maxWidth 1600` at 4K; MobileNav 44 px tap targets.
- **Tests** — 13 new pytest cases (watchlist CRUD + sparklines partial-failure); total suite: **207 passed**.
- **Merge hygiene** — rebased on top of PR #254 (Alerts); no code conflicts; migration renumbered to `0006_watchlist.sql` to avoid collision with `0003_alerts.sql`.

## Test plan

- [ ] `python -m pytest backend/tests/ -q` → 207 passed
- [ ] `ruff check backend/` → All checks passed
- [ ] Signed-in user: star a ticker on the analysis page → appears in sidebar watchlist panel + mobile chip bar
- [ ] Anonymous user: GET /watchlist returns `[]`; POST/DELETE return 401
- [ ] `/sparklines?tickers=AAPL,MSFT` returns new shape with `bars` array
- [ ] `?extra=NVDA` deduplicates and appears in response
- [ ] PriceChart height adapts at mobile/tablet/desktop breakpoints
- [ ] DCFCard, TradeSetupCard, FundamentalsPanel single-column at 320px

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Watchlist persistence (save/manage favorites with optimistic UI, per-user caching) and a dedicated Watchlist page.
  * Intraday sparklines: richer 1‑day 5‑min bars, merged extra symbols with deduplication, per-symbol short caching and partial‑failure tolerance.
  * Trending sparklines now include watchlist symbols for combined displays; add/remove flows available from sidebar, header and mobile bar.

* **Responsive**
  * Multiple grid/card/layout adjustments for improved mobile/tablet/desktop behavior.

* **Documentation**
  * Roadmap and architecture docs updated for watchlist, sparklines, and responsive changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->