### PR TITLE
feat: Advanced Technical Signals (F14) — ATR stops, divergence, earnings surprise, RF importance, Stoch/ADX/OBV

### DIFF
--- a/.claude/FiForesight_Roadmap.md
+++ b/.claude/FiForesight_Roadmap.md
@@ -27,7 +27,7 @@ Documentation is part of the feature, not an afterthought. A feature PR is **not
 - Dynamic chart time intervals (1D/5D/1M/3M/6M/1Y/2Y) — `GET /history`, VWAP overlay, contextual metrics (#208)
 - Chart zoom/pan across all intervals — drop classic view, AdvancedChart timestamp hardening (#221)
 - Walk-forward backtester — rolling 252-day train → 5-day predict, per-model MAE + directional accuracy (#222)
-- Advanced Technical Signals (Feature 14): ATR-14 volatility-adaptive trade stops (2.0×/2.5×, 8% cap), RSI/MACD divergence detection (scipy `find_peaks`, injected into jury context + prompts), earnings surprise history (last 4Q), RF feature importance (top-5), and Stochastic/ADX/OBV sub-panels (`SignalPanels`, localStorage-persisted). New helpers in `models.py`; `indicators` payload extended; 19 new backend tests. (#pending-F14)
+- Advanced Technical Signals (Feature 14): ATR-14 volatility-adaptive trade stops (2.0×/2.5×, 8% cap), RSI/MACD divergence detection (scipy `find_peaks`, injected into jury context + prompts), earnings surprise history (last 4Q), RF feature importance (top-5), and Stochastic/ADX/OBV sub-panels (`SignalPanels`, localStorage-persisted). New helpers in `models.py`; `indicators` payload extended; 19 new backend tests. (#260)
 
 ### Intelligence
 - 3-model LLM Analyst Jury (Llama 4 Scout, Llama 3.3 70B, GPT-OSS 20B) via Groq + LangGraph

--- a/.claude/FiForesight_Roadmap.md
+++ b/.claude/FiForesight_Roadmap.md
@@ -27,6 +27,7 @@ Documentation is part of the feature, not an afterthought. A feature PR is **not
 - Dynamic chart time intervals (1D/5D/1M/3M/6M/1Y/2Y) — `GET /history`, VWAP overlay, contextual metrics (#208)
 - Chart zoom/pan across all intervals — drop classic view, AdvancedChart timestamp hardening (#221)
 - Walk-forward backtester — rolling 252-day train → 5-day predict, per-model MAE + directional accuracy (#222)
+- Advanced Technical Signals (Feature 14): ATR-14 volatility-adaptive trade stops (2.0×/2.5×, 8% cap), RSI/MACD divergence detection (scipy `find_peaks`, injected into jury context + prompts), earnings surprise history (last 4Q), RF feature importance (top-5), and Stochastic/ADX/OBV sub-panels (`SignalPanels`, localStorage-persisted). New helpers in `models.py`; `indicators` payload extended; 19 new backend tests. (#pending-F14)
 
 ### Intelligence
 - 3-model LLM Analyst Jury (Llama 4 Scout, Llama 3.3 70B, GPT-OSS 20B) via Groq + LangGraph

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,7 +288,7 @@ See `.claude/FiForesight_Roadmap.md`. Recently shipped:
 | Portfolio Manager — real holdings + live P&L ("My Portfolio" tab) | #249 |
 | Alerts & Notifications — rule builder + scheduled evaluator + Web Push ("Alerts" tab) | #254 |
 | Watchlist persistence + intraday sparklines + responsive design (F13) | pending |
-| Advanced Technical Signals — ATR stops, divergence, earnings surprise, RF importance, Stoch/ADX/OBV (F14) | pending |
+| Advanced Technical Signals — ATR stops, divergence, earnings surprise, RF importance, Stoch/ADX/OBV (F14) | #260 |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ AI-driven quantitative financial forecasting SaaS. Ticker lookup → ensemble ML
 |-------|-----------|
 | Frontend | Next.js 16, React 19, TypeScript 6, MUI 7, Recharts 3, Tailwind CSS 4, Axios, Lucide React |
 | Backend | Python 3.12, FastAPI, Uvicorn, LangGraph, FastMCP |
-| ML/Forecasting | Prophet, SARIMAX (statsmodels), RandomForestRegressor (scikit-learn) |
+| ML/Forecasting | Prophet, SARIMAX (statsmodels), RandomForestRegressor (scikit-learn), scipy (`signal.find_peaks` — RSI/MACD divergence) |
 | Market Data | yfinance, SerpAPI (news/trending) |
 | Sentiment | VADER (vaderSentiment) — headline scoring, compound score + label |
 | AI / LLM Jury | Groq API — Llama 4 Scout, Llama 3.3 70B, Llama 3.1 8B (3-analyst jury via LangGraph) |
@@ -184,6 +184,8 @@ User enters ticker
     → FastAPI /predict (routers/predict.py)
       → InfluxDB (cached 2Y OHLCV) → fallback: yfinance
       → Technical indicators: RSI, MACD, BB, SMA50/200, EMA20/50, Support/Resistance, Earnings dates
+      → Advanced signals (Feature 14): ATR-14, Stochastic %K/%D, ADX/+DI/−DI, OBV (last 30),
+        RSI/MACD divergence (scipy find_peaks), earnings surprise (last 4Q), RF feature importance (top-5)
       → Ensemble forecast: Prophet + SARIMAX + RandomForest → high/low/confidence
       → Monte Carlo: 1 000 paths, seed=42 → P10/P50/P90, VaR-95, prob_gain
       → SerpAPI: news headlines + trending symbols
@@ -192,6 +194,8 @@ User enters ticker
           Llama 4 Scout (Macro & Risk) · Llama 3.3 70B (Growth) · Llama 3.1 8B Instant (Quant)
           Each isolated — failures degrade to Hold/25, not 500
       → Response: history, fundamentals, indicators, forecasts, jury verdicts, news, sentiment, monte carlo
+        (indicators payload also carries: atr_14, stoch_k/stoch_d, adx_14/plus_di/minus_di, obv_history,
+         divergences {rsi_bullish, rsi_bearish, macd_bullish, macd_bearish}, rf_feature_importance, earnings_surprise)
 
       → Fire-and-forget: write_sentiment_score (sentiment_score measurement) — only if ≥1 headline scored
 
@@ -284,6 +288,7 @@ See `.claude/FiForesight_Roadmap.md`. Recently shipped:
 | Portfolio Manager — real holdings + live P&L ("My Portfolio" tab) | #249 |
 | Alerts & Notifications — rule builder + scheduled evaluator + Web Push ("Alerts" tab) | #254 |
 | Watchlist persistence + intraday sparklines + responsive design (F13) | pending |
+| Advanced Technical Signals — ATR stops, divergence, earnings surprise, RF importance, Stoch/ADX/OBV (F14) | pending |
 
 ---
 
@@ -321,3 +326,4 @@ See `.claude/FiForesight_Roadmap.md`. Recently shipped:
 - **Intraday sparklines (Feature 13)** — `/sparklines` response shape changed from `Dict[str, List[float]]` (old flat prices) to `List[{symbol, price, change_pct, bars: [{t, c}]}]`. `TrendingSparklines` now accepts `tickers: string[]` (not `{symbol}[]`). The `?extra=` param appends watchlist symbols to the base list; deduplicated to max 24. Each symbol cached 5min in Redis independently. `_fetch_intraday_bars` strips pre/post-market (keeps 09:30–16:00 ET via tz_convert), returns `{}` on any failure.
 - **Responsive design (Feature 13)** — breakpoints: 320px (xs, mobile), 768px (sm, tablet), 1280px (md, desktop), 2560px (4K). Key fixes: PriceChart height 220/300/400px via `useMediaQuery`; DCFCard + TradeSetupCard 3-column grids stack on xs; FundamentalsPanel grid xs:6/sm:4/md:3; Earnings/IPO responsive CSS grid; sidebar `maxWidth: 280` cap at 4K; Shell content `maxWidth: 1600` for 4K; MobileNav tap targets `minHeight: 44`. MorningBriefingPanel + SectorHeatmap use `overflowX: auto` / `flexWrap: wrap` — fine at 320px. OptionsChainPanel table has `overflowX: auto` wrapper. Portfolio table hides columns on mobile via `isMobile` (`useMediaQuery`).
 - **Security model** — `dependencies.py` holds the `limiter` singleton and all auth helpers. `require_user` dependency raises HTTP 401 when no valid Bearer token is present; applied to `/trade-setup` and `/jury/reanalyze`. `/predict` uses a single rate limit keyed by user ID (authed) or IP (anon) via `_user_rate_key`. `/chat` message is capped at 500 chars with control-char sanitization on all context values. CORS is restricted to `ALLOWED_ORIGINS`. Symbol inputs are validated with `[A-Za-z0-9.\-:]{1,15}` on `/predict`, `/dcf/{symbol}`, `/options/{symbol}`, and history. JWT verification picks the verifier by the token's `alg`: **ES256/RS256** (Supabase's default signing-key tokens) are verified against the project **JWKS** (`SUPABASE_URL`, or `SUPABASE_JWKS_URL`); legacy **HS256** tokens use `SUPABASE_JWT_SECRET`. JWKS-only (ES256) is a valid secure production config — the shared secret is not required when a JWKS URL is set. The backend fails closed when **neither** a JWKS URL nor a secret is configured (or decodes unsigned only when `ALLOW_INSECURE_JWT=true`, dev-only; logged at startup). All frontend auth API routes forward the `Authorization` header.
+- **Advanced Technical Signals (Feature 14)** — five signal upgrades shipped together. Indicator helpers live in `models.py` (`calculate_atr`, `calculate_stochastic`, `calculate_adx`, `calculate_obv`, `detect_divergences`), each self-contained and returning `None`/all-false on failure so a bad indicator never aborts `/predict`. `routers/predict.py` computes them at Step 4b# and adds them to the **`indicators`** payload (`atr_14`, `stoch_k/stoch_d`, `adx_14/plus_di/minus_di`, `obv_history` = last 30, `divergences`, `rf_feature_importance` = RF top-5, `earnings_surprise` = last 4Q). **ATR-based adaptive stop** (`routers/trade.py`): when the frontend passes `atr_14`, the stop is `entry ∓ k×ATR` (k=2.0, or 2.5 when `conservative:true`) instead of a flat %, **hard-capped at 8%** from entry; falls back to the S/R % stop when ATR is absent (legacy/anon callers). Response adds `atr_14` + `atr_multiplier`. **Divergence** (`detect_divergences`, scipy `find_peaks` on price & indicator troughs/peaks ≥5 bars apart over the last 20 bars; all-false under 30 bars) is also injected into the jury context and each analyst's system prompt. **RF feature importance** is threaded out of `_rf_forecast` (now returns `(forecast_array, importances)` — `backtest.py` takes `[0]`) through `run_ensemble_forecast`. **Earnings surprise** comes from `YFinanceService.fetch_earnings_surprise` (yfinance `earnings_history`, Redis-cached 24h, `[]` on failure). Frontend: ATR annotation in `TradeSetupCard`, earnings-surprise Accordion in `FundamentalsPanel`, `ModelFeatureImportanceBar.tsx` below `ModelWeightBar`, and `SignalPanels.tsx` (Stoch/ADX gauges with ref lines, OBV area chart, divergence badges) below the chart in `PriceChartCard` — sub-panel visibility persisted in `localStorage` (`fiforesight:subpanels`), default hidden. Stoch/ADX are latest-value gauges (backend sends scalars, not per-bar series); OBV uses the 30-value history.

--- a/backend/models.py
+++ b/backend/models.py
@@ -287,6 +287,258 @@ def calculate_support_resistance(
     )
     return {"support": support_levels, "resistance": resistance_levels}
 
+# ---------------------------------------------------------------------------
+# Advanced Technical Signals (Feature 14)
+# ATR · Stochastic · ADX · OBV · RSI/MACD divergence
+# Each wrapped so any failure degrades gracefully (None / all-false) and never
+# aborts a /predict request.
+# ---------------------------------------------------------------------------
+
+@newrelic.agent.function_trace()
+def calculate_atr(
+    highs: List[float],
+    lows: List[float],
+    closes: List[float],
+    period: int = 14,
+) -> Optional[float]:
+    """
+    Average True Range (ATR-14) — volatility in price units.
+
+    TR_t = max(high−low, |high−prev_close|, |low−prev_close|); ATR is the
+    `period`-span EMA of TR. Returns the latest value, or None when there is
+    insufficient data / any failure (logged at DEBUG, never raises).
+    """
+    try:
+        if (
+            highs is None or lows is None or closes is None
+            or len(highs) != len(closes) or len(lows) != len(closes)
+            or len(closes) < period + 1
+        ):
+            return None
+        h = pd.Series(highs, dtype=float)
+        lo = pd.Series(lows, dtype=float)
+        c = pd.Series(closes, dtype=float)
+        prev_c = c.shift(1)
+        tr = pd.concat(
+            [(h - lo), (h - prev_c).abs(), (lo - prev_c).abs()], axis=1
+        ).max(axis=1)
+        atr = tr.ewm(span=period, adjust=False).mean().iloc[-1]
+        if pd.isna(atr):
+            return None
+        logger.info(f"[ATR] ✓ ATR-{period}={float(atr):.4f} ({len(closes)} bars)")
+        return round(float(atr), 4)
+    except Exception as exc:
+        logger.debug("[ATR] calculate_atr failed: %s", exc, exc_info=True)
+        return None
+
+
+@newrelic.agent.function_trace()
+def calculate_stochastic(
+    highs: List[float],
+    lows: List[float],
+    closes: List[float],
+    k_period: int = 14,
+    d_period: int = 3,
+) -> Dict[str, Optional[float]]:
+    """
+    Stochastic oscillator. %K = 100 × (close − lowest_low) / (highest_high −
+    lowest_low) over `k_period`; %D = `d_period`-SMA of %K. Returns the latest
+    {stoch_k, stoch_d} (None on insufficient data / failure).
+    """
+    out: Dict[str, Optional[float]] = {"stoch_k": None, "stoch_d": None}
+    try:
+        if (
+            highs is None or lows is None or closes is None
+            or len(highs) != len(closes) or len(lows) != len(closes)
+            or len(closes) < k_period + d_period
+        ):
+            return out
+        h = pd.Series(highs, dtype=float)
+        lo = pd.Series(lows, dtype=float)
+        c = pd.Series(closes, dtype=float)
+        lowest = lo.rolling(window=k_period).min()
+        highest = h.rolling(window=k_period).max()
+        rng = (highest - lowest).replace(0, 1e-9)
+        k = 100 * (c - lowest) / rng
+        d = k.rolling(window=d_period).mean()
+        k_last, d_last = k.iloc[-1], d.iloc[-1]
+        out["stoch_k"] = round(float(k_last), 2) if not pd.isna(k_last) else None
+        out["stoch_d"] = round(float(d_last), 2) if not pd.isna(d_last) else None
+        logger.info(f"[STOCH] ✓ %K={out['stoch_k']} %D={out['stoch_d']}")
+        return out
+    except Exception as exc:
+        logger.debug("[STOCH] calculate_stochastic failed: %s", exc, exc_info=True)
+        return out
+
+
+@newrelic.agent.function_trace()
+def calculate_adx(
+    highs: List[float],
+    lows: List[float],
+    closes: List[float],
+    period: int = 14,
+) -> Dict[str, Optional[float]]:
+    """
+    Average Directional Index using Wilder smoothing (14-period). Returns the
+    latest {adx_14, plus_di, minus_di} (None on insufficient data / failure).
+    """
+    out: Dict[str, Optional[float]] = {"adx_14": None, "plus_di": None, "minus_di": None}
+    try:
+        if (
+            highs is None or lows is None or closes is None
+            or len(highs) != len(closes) or len(lows) != len(closes)
+            or len(closes) < 2 * period + 1
+        ):
+            return out
+        h = pd.Series(highs, dtype=float)
+        lo = pd.Series(lows, dtype=float)
+        c = pd.Series(closes, dtype=float)
+
+        up_move = h.diff()
+        down_move = -lo.diff()
+        plus_dm = ((up_move > down_move) & (up_move > 0)) * up_move
+        minus_dm = ((down_move > up_move) & (down_move > 0)) * down_move
+
+        prev_c = c.shift(1)
+        tr = pd.concat(
+            [(h - lo), (h - prev_c).abs(), (lo - prev_c).abs()], axis=1
+        ).max(axis=1)
+
+        # Wilder smoothing ≈ EMA with alpha = 1/period
+        alpha = 1.0 / period
+        atr = tr.ewm(alpha=alpha, adjust=False).mean()
+        plus_di = 100 * plus_dm.ewm(alpha=alpha, adjust=False).mean() / atr.replace(0, 1e-9)
+        minus_di = 100 * minus_dm.ewm(alpha=alpha, adjust=False).mean() / atr.replace(0, 1e-9)
+        di_sum = (plus_di + minus_di).replace(0, 1e-9)
+        dx = 100 * (plus_di - minus_di).abs() / di_sum
+        adx = dx.ewm(alpha=alpha, adjust=False).mean()
+
+        adx_last, p_last, m_last = adx.iloc[-1], plus_di.iloc[-1], minus_di.iloc[-1]
+        out["adx_14"] = round(float(adx_last), 2) if not pd.isna(adx_last) else None
+        out["plus_di"] = round(float(p_last), 2) if not pd.isna(p_last) else None
+        out["minus_di"] = round(float(m_last), 2) if not pd.isna(m_last) else None
+        logger.info(
+            f"[ADX] ✓ ADX={out['adx_14']} +DI={out['plus_di']} −DI={out['minus_di']}"
+        )
+        return out
+    except Exception as exc:
+        logger.debug("[ADX] calculate_adx failed: %s", exc, exc_info=True)
+        return out
+
+
+@newrelic.agent.function_trace()
+def calculate_obv(
+    closes: List[float],
+    volumes: List[float],
+    history: int = 30,
+) -> Optional[List[float]]:
+    """
+    On-Balance Volume — cumulative volume that adds on up-close days and
+    subtracts on down-close days. Returns the last `history` OBV values, or
+    None on insufficient data / failure.
+    """
+    try:
+        if (
+            closes is None or volumes is None
+            or len(closes) != len(volumes) or len(closes) < 2
+        ):
+            return None
+        c = pd.Series(closes, dtype=float)
+        v = pd.Series(volumes, dtype=float)
+        direction = np.sign(c.diff().fillna(0.0))
+        obv = (direction * v).cumsum()
+        tail = obv.tail(history)
+        result = [round(float(x), 2) for x in tail]
+        logger.info(f"[OBV] ✓ {len(result)} points | last={result[-1] if result else None}")
+        return result
+    except Exception as exc:
+        logger.debug("[OBV] calculate_obv failed: %s", exc, exc_info=True)
+        return None
+
+
+def _tail_clean(series: Optional[List], lookback: int) -> Optional[np.ndarray]:
+    """Last `lookback` values as a float array, or None if any are None/NaN."""
+    if series is None or len(series) < lookback:
+        return None
+    tail = series[-lookback:]
+    if any(v is None for v in tail):
+        return None
+    arr = np.array(tail, dtype=float)
+    if np.any(np.isnan(arr)):
+        return None
+    return arr
+
+
+@newrelic.agent.function_trace()
+def detect_divergences(
+    closes: List[float],
+    rsi_series: List,
+    macd_hist: List,
+    lookback: int = 20,
+    min_distance: int = 5,
+) -> Dict[str, bool]:
+    """
+    RSI/MACD-histogram divergence over the last `lookback` bars.
+
+    Bullish: price prints a lower low while the indicator prints a higher low.
+    Bearish: price prints a higher high while the indicator prints a lower high.
+    Troughs/peaks are located with scipy.signal.find_peaks (≥`min_distance`
+    bars apart) on the price and indicator series independently, then the two
+    most-recent extrema of each are compared.
+
+    Returns all-False when fewer than 30 bars are available or on any failure
+    (logged at DEBUG, never raises).
+    """
+    result = {
+        "rsi_bullish": False, "rsi_bearish": False,
+        "macd_bullish": False, "macd_bearish": False,
+    }
+    try:
+        if closes is None or len(closes) < 30:
+            return result
+        from scipy.signal import find_peaks
+
+        price = _tail_clean(closes, lookback)
+        if price is None:
+            return result
+
+        def _last_two(arr: np.ndarray, invert: bool):
+            """Indices of the two most recent extrema (troughs if invert)."""
+            peaks, _ = find_peaks(-arr if invert else arr, distance=min_distance)
+            return peaks[-2:] if len(peaks) >= 2 else None
+
+        def _bullish(ind: np.ndarray) -> bool:
+            pt = _last_two(price, invert=True)
+            it = _last_two(ind, invert=True)
+            if pt is None or it is None:
+                return False
+            return price[pt[1]] < price[pt[0]] and ind[it[1]] > ind[it[0]]
+
+        def _bearish(ind: np.ndarray) -> bool:
+            pp = _last_two(price, invert=False)
+            ip = _last_two(ind, invert=False)
+            if pp is None or ip is None:
+                return False
+            return price[pp[1]] > price[pp[0]] and ind[ip[1]] < ind[ip[0]]
+
+        rsi_arr = _tail_clean(rsi_series, lookback)
+        if rsi_arr is not None:
+            result["rsi_bullish"] = bool(_bullish(rsi_arr))
+            result["rsi_bearish"] = bool(_bearish(rsi_arr))
+
+        macd_arr = _tail_clean(macd_hist, lookback)
+        if macd_arr is not None:
+            result["macd_bullish"] = bool(_bullish(macd_arr))
+            result["macd_bearish"] = bool(_bearish(macd_arr))
+
+        if any(result.values()):
+            logger.info(f"[DIVERGENCE] ✓ {result}")
+        return result
+    except Exception as exc:
+        logger.debug("[DIVERGENCE] detect_divergences failed: %s", exc, exc_info=True)
+        return result
+
+
 @newrelic.agent.function_trace()
 def calculate_model_stats(prices: List[float]) -> Dict:
     """
@@ -483,6 +735,31 @@ def _sarima_forecast(
     return result
 
 
+def _rf_top_importances(rf, use_ohlcv: bool, window: int, top_n: int = 5) -> List[Dict]:
+    """
+    Top-`top_n` RandomForest feature importances, normalised to sum 1.0 and
+    sorted descending. Feature names encode the lag and (in OHLCV mode) which
+    column they came from, e.g. "Close[t-1]" / "Volume[t-3]".
+    Returns [] on any failure (never raises).
+    """
+    try:
+        imp = rf.feature_importances_
+        if use_ohlcv:
+            cols = ["Open", "High", "Low", "Close", "Volume"]
+            names = [f"{cols[j % 5]}[t-{window - (j // 5)}]" for j in range(len(imp))]
+        else:
+            names = [f"Close[t-{window - j}]" for j in range(len(imp))]
+        pairs = sorted(zip(names, imp), key=lambda x: x[1], reverse=True)[:top_n]
+        total = sum(float(v) for _, v in pairs) or 1.0
+        return [
+            {"feature": n, "importance": round(float(v) / total, 4)}
+            for n, v in pairs
+        ]
+    except Exception as exc:
+        logger.debug("[RF] feature importance extraction failed: %s", exc)
+        return []
+
+
 def _rf_forecast(
     prices: List[float],
     steps: int,
@@ -490,7 +767,7 @@ def _rf_forecast(
     highs: Optional[List[float]] = None,
     lows: Optional[List[float]] = None,
     volumes: Optional[List[float]] = None,
-) -> np.ndarray:
+) -> tuple:
     """
     Random Forest on a sliding window of past observations.
 
@@ -527,7 +804,7 @@ def _rf_forecast(
             np.full(steps, last),
             np.full(steps, last),
             np.full(steps, last),
-        ])
+        ]), []
 
     vol = np.std(prices[-20:]) / np.mean(prices[-20:]) if len(prices) >= 20 else 0.02
 
@@ -568,6 +845,7 @@ def _rf_forecast(
         )
         rf = RandomForestRegressor(n_estimators=100, random_state=42)
         rf.fit(X, y)
+        rf_importance = _rf_top_importances(rf, use_ohlcv=True, window=window)
 
         preds           = []
         last_window_raw = raw[-window:].copy()   # shape (window, 5)
@@ -601,6 +879,7 @@ def _rf_forecast(
         )
         rf = RandomForestRegressor(n_estimators=100, random_state=42)
         rf.fit(X, y)
+        rf_importance = _rf_top_importances(rf, use_ohlcv=False, window=window)
 
         preds       = []
         last_window = list(prices[-window:])
@@ -618,8 +897,9 @@ def _rf_forecast(
         f"[RF] ✓ Forecast complete — "
         f"Day-1: predicted=${result[0, 0]:.2f} band=[{result[0, 1]:.2f}–{result[0, 2]:.2f}] | "
         f"Day-{steps}: predicted=${result[-1, 0]:.2f} band=[{result[-1, 1]:.2f}–{result[-1, 2]:.2f}]"
+        + (f" | top feature: {rf_importance[0]['feature']}" if rf_importance else "")
     )
-    return result
+    return result, rf_importance
 
 
 # ---------------------------------------------------------------------------
@@ -855,6 +1135,7 @@ def run_ensemble_forecast(
             "conf": "low", "stats": stats,
             "weights":       {"prophet": 0.0, "sarima": 0.0, "rf": 0.0},
             "per_model_d1":  {"prophet": None, "sarima": None, "rf": None},
+            "rf_feature_importance": [],
             "monte_carlo":   mc_result,
         }
 
@@ -899,7 +1180,14 @@ def run_ensemble_forecast(
 
     p_fc = results.get("Prophet")
     s_fc = results.get("SARIMA")
-    r_fc = results.get("RF")
+    # _rf_forecast returns (forecast_array, feature_importance); a failed run
+    # left None in the results map (set in the except above).
+    rf_raw = results.get("RF")
+    rf_feature_importance: List[Dict] = []
+    if isinstance(rf_raw, tuple):
+        r_fc, rf_feature_importance = rf_raw
+    else:
+        r_fc = rf_raw
 
     available = [fc for fc in [p_fc, s_fc, r_fc] if fc is not None]
     n_success = len(available)
@@ -936,6 +1224,7 @@ def run_ensemble_forecast(
             "conf":          "low", "stats": stats,
             "weights":       {"prophet": 0.0, "sarima": 0.0, "rf": 0.0},
             "per_model_d1":  {"prophet": None, "sarima": None, "rf": None},
+            "rf_feature_importance": [],
             "monte_carlo":   mc_result,
         }
 
@@ -1113,5 +1402,6 @@ def run_ensemble_forecast(
             "sarima":  float(s_fc[0, 0]) if s_fc is not None else None,
             "rf":      float(r_fc[0, 0]) if r_fc is not None else None,
         },
+        "rf_feature_importance": rf_feature_importance,
         "monte_carlo":   mc_result,
     }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,9 @@ numpy
 statsmodels
 prophet
 scikit-learn
+# scipy.signal.find_peaks powers RSI/MACD divergence detection (Feature 14).
+# Already a transitive dep of prophet/scikit-learn — pinned explicitly here.
+scipy
 yfinance
 newrelic
 # Sentiment analysis

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,7 +9,8 @@ statsmodels
 prophet
 scikit-learn
 # scipy.signal.find_peaks powers RSI/MACD divergence detection (Feature 14).
-# Already a transitive dep of prophet/scikit-learn — pinned explicitly here.
+# Already a transitive dep of prophet/scikit-learn — declared explicitly here
+# (unpinned, matching the rest of this manifest).
 scipy
 yfinance
 newrelic

--- a/backend/routers/backtest.py
+++ b/backend/routers/backtest.py
@@ -86,7 +86,9 @@ def _run_backtest(symbol: str, closes: List[float], dates: List[str]) -> Optiona
     fitters = {
         "prophet":       lambda tr: _prophet_forecast(tr, HORIZON),
         "sarimax":       lambda tr: _sarima_forecast(tr, HORIZON),
-        "random_forest": lambda tr: _rf_forecast(tr, HORIZON),
+        # _rf_forecast now returns (forecast_array, feature_importance); the
+        # backtest only needs the forecast array.
+        "random_forest": lambda tr: _rf_forecast(tr, HORIZON)[0],
     }
 
     start = 0

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -1348,7 +1348,7 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
         try:
             data = await asyncio.wait_for(
                 asyncio.to_thread(yf_svc.fetch_earnings_surprise, symbol),
-                timeout=8.0,
+                timeout=12.0,
             )
         except Exception as exc:
             logger.debug("[STEP-4c] earnings surprise fetch failed: %s", exc)

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -1335,11 +1335,14 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
         )
 
     earnings_task = asyncio.create_task(
-        asyncio.to_thread(yf_svc.fetch_earnings_dates, symbol)
+        asyncio.wait_for(
+            asyncio.to_thread(yf_svc.fetch_earnings_dates, symbol),
+            timeout=12.0,
+        )
     )
 
     # Earnings surprise history (last 4 quarters) — Redis-cached 24h since it
-    # only changes once per quarter. Fired concurrently, 8s timeout.
+    # only changes once per quarter. Fired concurrently, 12s timeout.
     async def _get_earnings_surprise() -> List[dict]:
         cache_key = f"earnings_surprise:{symbol.upper()}"
         cached = await cache_get(cache_key)
@@ -1353,7 +1356,10 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
         except Exception as exc:
             logger.debug("[STEP-4c] earnings surprise fetch failed: %s", exc)
             data = []
-        await cache_set(cache_key, data, ttl_seconds=86400)
+        # Cache real results for 24h. An empty list means either a transient
+        # yfinance failure or genuinely no history — cache it only briefly (1h)
+        # so a transient failure self-heals instead of sticking for a full day.
+        await cache_set(cache_key, data, ttl_seconds=86400 if data else 3600)
         return data
 
     earnings_surprise_task = asyncio.create_task(_get_earnings_surprise())

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -15,6 +15,8 @@ from models import (
     calculate_rsi, calculate_rsi_series, run_ensemble_forecast,
     calculate_macd, calculate_bollinger_bands, calculate_sma_series,
     calculate_ema_series, calculate_support_resistance,
+    calculate_atr, calculate_stochastic, calculate_adx, calculate_obv,
+    detect_divergences,
     _skill_to_weights,
 )
 from services import DataCleaner, ANALYST_PERSONAS
@@ -220,6 +222,7 @@ async def _run_analyst_jury(
     track_record: str = "",
     sentiment: Optional[dict] = None,
     stocktwits: Optional[dict] = None,
+    divergences: Optional[dict] = None,
     ctx_only: bool = False,
 ) -> List[dict]:
     """
@@ -356,6 +359,20 @@ async def _run_analyst_jury(
         f"prob_gain={_mc['prob_gain']:.1f}%, VaR95=${_mc['var_95']:.2f}\n"
     ) if _mc else ""
 
+    # Divergence signals (Feature 14) — only surfaced when at least one fired.
+    div_line = ""
+    if divergences:
+        active = [
+            label for key, label in (
+                ("rsi_bullish",  "Bullish RSI divergence"),
+                ("rsi_bearish",  "Bearish RSI divergence"),
+                ("macd_bullish", "Bullish MACD divergence"),
+                ("macd_bearish", "Bearish MACD divergence"),
+            ) if divergences.get(key)
+        ]
+        if active:
+            div_line = f"Divergence signals: {', '.join(active)}\n"
+
     ctx = (
         f"Symbol: {symbol} | Price: ${price:.2f} | RSI: {rsi:.1f} | Sector: {sec_str}\n"
         f"Fundamentals: PE={pe_str} | Cap={cap_str} | Div={div_str} | 52w={rng_str}\n"
@@ -371,6 +388,7 @@ async def _run_analyst_jury(
         f"{sma_line}\n"
         f"Volume: {vol_line}\n"
         f"Support: {sup_str} | Resistance: {res_str}\n"
+        f"{div_line}"
         f"{sentiment_line}"
         f"{news_block}"
         + (f"{track_record}\n" if track_record else "")
@@ -1221,6 +1239,25 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
     # Compute RSI series here (also reused for chart at Step 8) so the reversal
     # classifier has it available without a second pass through closes.
     rsi_full = calculate_rsi_series(closes)
+
+    # ── Step 4b#. Advanced technical signals (Feature 14) ─────────────────────
+    # ATR (volatility stops), Stochastic, ADX, OBV, and RSI/MACD divergence.
+    # Each helper is self-contained and returns None / all-false on failure, so
+    # the whole block is non-fatal — a bad indicator never aborts /predict.
+    atr_14 = await asyncio.to_thread(calculate_atr, highs, lows, closes)
+    stoch  = await asyncio.to_thread(calculate_stochastic, highs, lows, closes)
+    adx    = await asyncio.to_thread(calculate_adx, highs, lows, closes)
+    obv_history = await asyncio.to_thread(calculate_obv, closes, volumes)
+    divergences = await asyncio.to_thread(
+        detect_divergences, closes, rsi_full, macd_data["hist"]
+    )
+    logger.info(
+        "[STEP-4b#] ✓ Advanced signals — ATR-14=%s | Stoch %%K=%s %%D=%s | "
+        "ADX=%s | OBV=%s pts | divergences=%s",
+        atr_14, stoch.get("stoch_k"), stoch.get("stoch_d"),
+        adx.get("adx_14"), len(obv_history) if obv_history else 0, divergences,
+    )
+
     try:
         reversal_risk = await asyncio.to_thread(
             compute_reversal_risk,
@@ -1300,6 +1337,26 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
     earnings_task = asyncio.create_task(
         asyncio.to_thread(yf_svc.fetch_earnings_dates, symbol)
     )
+
+    # Earnings surprise history (last 4 quarters) — Redis-cached 24h since it
+    # only changes once per quarter. Fired concurrently, 8s timeout.
+    async def _get_earnings_surprise() -> List[dict]:
+        cache_key = f"earnings_surprise:{symbol.upper()}"
+        cached = await cache_get(cache_key)
+        if cached is not None:
+            return cached
+        try:
+            data = await asyncio.wait_for(
+                asyncio.to_thread(yf_svc.fetch_earnings_surprise, symbol),
+                timeout=8.0,
+            )
+        except Exception as exc:
+            logger.debug("[STEP-4c] earnings surprise fetch failed: %s", exc)
+            data = []
+        await cache_set(cache_key, data, ttl_seconds=86400)
+        return data
+
+    earnings_surprise_task = asyncio.create_task(_get_earnings_surprise())
 
     # ── Support/resistance — now uses intraday highs/lows ────────────────────
     logger.debug(
@@ -1420,6 +1477,13 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
         logger.warning(f"[STEP-4e] earnings_task failed: {e}")
         earnings_dates = []
 
+    # Resolve earnings surprise history (fired concurrently at Step 4c)
+    try:
+        earnings_surprise: List[dict] = await earnings_surprise_task
+    except Exception as e:
+        logger.warning(f"[STEP-4e] earnings_surprise_task failed: {e}")
+        earnings_surprise = []
+
     # ── Step 4f. "Why did this move?" explainer (async, runs concurrently) ─────
     try:
         _cur_f = float(live_price)
@@ -1491,6 +1555,7 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
                 track_record=track_record,
                 sentiment=sentiment,
                 stocktwits=stocktwits_data,
+                divergences=divergences,
                 ctx_only=True,
             ),
         )
@@ -1511,6 +1576,7 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
                 track_record=track_record,
                 sentiment=sentiment,
                 stocktwits=stocktwits_data,
+                divergences=divergences,
             ),
         )
 
@@ -1660,6 +1726,17 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
             "rsi_series": rsi_series,
             "support":    sr_levels["support"],
             "resistance": sr_levels["resistance"],
+            # ── Advanced technical signals (Feature 14) ──
+            "atr_14":      atr_14,
+            "stoch_k":     stoch.get("stoch_k"),
+            "stoch_d":     stoch.get("stoch_d"),
+            "adx_14":      adx.get("adx_14"),
+            "plus_di":     adx.get("plus_di"),
+            "minus_di":    adx.get("minus_di"),
+            "obv_history": obv_history,
+            "divergences": divergences,
+            "rf_feature_importance": forecast.get("rf_feature_importance", []),
+            "earnings_surprise":     earnings_surprise,
         },
         lastUpdated  = now.isoformat(),
         juryAnalysts  = jury,

--- a/backend/routers/trade.py
+++ b/backend/routers/trade.py
@@ -45,6 +45,18 @@ class TradeSetupRequest(BaseModel):
     trend: str = "Bullish"
     sentiment_label: str = "Neutral"
     var_95: Optional[float] = None
+    # ATR-14 in price units (Feature 14). When supplied, the stop is placed an
+    # ATR multiple away from entry instead of a flat %. Optional for backward
+    # compatibility — falls back to the support/resistance % stop when absent.
+    atr_14: Optional[float] = None
+    conservative: bool = False
+
+    @field_validator("atr_14")
+    @classmethod
+    def validate_atr(cls, v: Optional[float]) -> Optional[float]:
+        if v is not None and v < 0:
+            raise ValueError("atr_14 must be non-negative")
+        return v
 
     @field_validator("current_price")
     @classmethod
@@ -87,12 +99,23 @@ class TradeSetupResponse(BaseModel):
     risk_per_share: float
     risk_pct: float
     suggested_position_pct: float
+    atr_14: Optional[float] = None
+    atr_multiplier: Optional[float] = None
 
 
 @router.post("/trade-setup", response_model=TradeSetupResponse)
 @limiter.limit(lambda: Config.RATE_LIMIT_TRADE, key_func=_user_rate_key)
 async def trade_setup(request: Request, req: TradeSetupRequest, _user: str = Depends(require_user)):
     p = req.current_price
+
+    # ── ATR-based adaptive stop (Feature 14) ──────────────────────────────────
+    # When ATR-14 is supplied, the stop is placed an ATR multiple from entry
+    # (2.0× default, 2.5× conservative) instead of a flat %, so a high-volatility
+    # name gets a wider stop than a quiet one. Hard-capped at 8% from entry so a
+    # huge ATR can't suggest a reckless stop. Falls back to the S/R % stop when
+    # ATR is absent (anonymous/legacy callers).
+    use_atr        = req.atr_14 is not None and req.atr_14 > 0
+    atr_multiplier = (2.5 if req.conservative else 2.0) if use_atr else None
 
     if req.trend == "Bearish":
         # Entry zone: nearest resistance within 3% above price, else price ± 0.5%
@@ -114,8 +137,14 @@ async def trade_setup(request: Request, req: TradeSetupRequest, _user: str = Dep
             raw_stop = round(resistance_above[0] * 1.015, 2)
         else:
             raw_stop = round(entry_high * 1.03, 2)
-        max_stop  = round(entry_mid * 1.05, 2)
-        stop_loss = round(min(raw_stop, max_stop), 2)
+        if use_atr:
+            # Short stop sits above entry; never more than 8% above.
+            atr_stop  = entry_mid + atr_multiplier * req.atr_14
+            ceil_stop = entry_mid * 1.08
+            stop_loss = round(min(atr_stop, ceil_stop), 2)
+        else:
+            max_stop  = round(entry_mid * 1.05, 2)
+            stop_loss = round(min(raw_stop, max_stop), 2)
 
         # Targets: descending below entry_mid toward low_range
         target_1 = round(entry_mid - (entry_mid - req.low_range) / 3, 2)
@@ -156,10 +185,16 @@ async def trade_setup(request: Request, req: TradeSetupRequest, _user: str = Dep
         target_2 = round(req.high_range, 2)
         target_3 = round(req.high_range + (req.high_range - entry_low), 2)
 
-        # R:R — cap stop at 5% below entry so R:R stays meaningful
-        raw_stop    = stop_loss
-        min_stop    = round(entry_mid * 0.95, 2)
-        stop_loss   = round(max(raw_stop, min_stop), 2)
+        # Stop: ATR-based when available, else cap the S/R stop at 5% below entry.
+        if use_atr:
+            # Long stop sits below entry; never more than 8% below.
+            atr_stop   = entry_mid - atr_multiplier * req.atr_14
+            floor_stop = entry_mid * 0.92
+            stop_loss  = round(max(atr_stop, floor_stop), 2)
+        else:
+            raw_stop  = stop_loss
+            min_stop  = round(entry_mid * 0.95, 2)
+            stop_loss = round(max(raw_stop, min_stop), 2)
         risk        = max(entry_mid - stop_loss, 0.01)
         reward      = max(target_2 - entry_mid, 0.01)
         risk_reward = f"1:{reward / risk:.1f}"
@@ -222,6 +257,8 @@ async def trade_setup(request: Request, req: TradeSetupRequest, _user: str = Dep
         risk_per_share=risk_ps,
         risk_pct=risk_pct_val,
         suggested_position_pct=suggested_pct,
+        atr_14=round(req.atr_14, 4) if use_atr else None,
+        atr_multiplier=atr_multiplier,
     )
 
 

--- a/backend/routers/trade.py
+++ b/backend/routers/trade.py
@@ -51,6 +51,16 @@ class TradeSetupRequest(BaseModel):
     atr_14: Optional[float] = None
     conservative: bool = False
 
+    @field_validator("symbol")
+    @classmethod
+    def validate_symbol(cls, v: str) -> str:
+        # Symbol is interpolated into the Groq rationale prompt — validate against
+        # the same allowlist used on /predict, /dcf, etc. and normalise to upper.
+        s = (v or "").strip().upper()
+        if not _SYMBOL_RE.match(s):
+            raise ValueError("symbol must match [A-Za-z0-9.\\-:]{1,15}")
+        return s
+
     @field_validator("atr_14")
     @classmethod
     def validate_atr(cls, v: Optional[float]) -> Optional[float]:

--- a/backend/services.py
+++ b/backend/services.py
@@ -1052,6 +1052,58 @@ class YFinanceService:
             return []
 
     @newrelic.agent.function_trace()
+    def fetch_earnings_surprise(self, symbol: str) -> List[dict]:
+        """
+        Last 4 quarters of earnings surprise from yfinance (free, no API key).
+
+        Returns a list of {quarter, estimate, actual, surprise_pct} dicts,
+        most-recent first. Empty list on any failure or when unavailable
+        (logged at DEBUG, never raises).
+        """
+        if not YFINANCE_AVAILABLE:
+            return []
+        ticker = self._to_yf_symbol(symbol)
+        try:
+            hist = yf.Ticker(ticker).earnings_history
+            if hist is None or getattr(hist, "empty", True):
+                return []
+            # yfinance returns a DataFrame indexed by quarter date with columns
+            # epsEstimate / epsActual / surprisePercent (names vary by version).
+            cols = {c.lower(): c for c in hist.columns}
+            est_col = cols.get("epsestimate")
+            act_col = cols.get("epsactual")
+            sur_col = cols.get("surprisepercent")
+            result: List[dict] = []
+            for idx, row in hist.tail(4).iloc[::-1].iterrows():
+                try:
+                    quarter = (
+                        idx.strftime("%Y-%m-%d") if hasattr(idx, "strftime")
+                        else str(idx)[:10]
+                    )
+                    est = float(row[est_col]) if est_col and pd.notna(row[est_col]) else None
+                    act = float(row[act_col]) if act_col and pd.notna(row[act_col]) else None
+                    if sur_col and pd.notna(row[sur_col]):
+                        surprise = float(row[sur_col])
+                    elif est not in (None, 0) and act is not None:
+                        surprise = (act - est) / abs(est) * 100
+                    else:
+                        surprise = None
+                    result.append({
+                        "quarter":      quarter,
+                        "estimate":     round(est, 4) if est is not None else None,
+                        "actual":       round(act, 4) if act is not None else None,
+                        "surprise_pct": round(surprise, 2) if surprise is not None else None,
+                    })
+                except Exception as _exc:
+                    logger.debug("[YFINANCE] earnings surprise row parse error: %s", _exc)
+                    continue
+            logger.info(f"[YFINANCE] ✓ fetch_earnings_surprise — {ticker}: {len(result)} quarters")
+            return result
+        except Exception as e:
+            logger.debug(f"[YFINANCE] fetch_earnings_surprise failed for {ticker}: {e}")
+            return []
+
+    @newrelic.agent.function_trace()
     def fetch_news(self, symbol: str) -> List[dict]:
         """
         Fetch recent news headlines from yfinance (free, no API key).
@@ -1623,6 +1675,8 @@ ANALYST_PERSONAS = [
             "Flag RSI extremes, negative trend slope, elevated volatility, or concerning forecast skew. "
             "Examine BB band squeeze/expansion, proximity to support/resistance, whether volume confirms "
             "or contradicts the move, and any fundamental red flags. "
+            "If a bearish RSI or MACD divergence is flagged, treat it as a warning of a potential "
+            "reversal lower and weight your risk stance accordingly. "
             "Focus on what could go wrong, not growth upside. "
             "Be specific, actionable, and advisory — not generic. "
             "Conclude with a clear rating (Strong Sell / Sell / Hold) and your recommended risk stance."
@@ -1648,6 +1702,8 @@ ANALYST_PERSONAS = [
             "Identify fundamental tailwinds, earnings momentum, product or sector catalysts, "
             "and breakout potential. Correlate positive news flow with price momentum and volume trends. "
             "Reference MACD momentum, SMA50/200 positioning, RSI strength, and forecast confidence. "
+            "If a bullish RSI or MACD divergence is flagged, treat it as confirmation that downside "
+            "momentum may be exhausting and an upside reversal is forming. "
             "Ignore macro doomsday scenarios — focus on this asset's specific growth trajectory "
             "and why it has the potential to outperform. "
             "Be specific, actionable, and advisory — not generic. "
@@ -1676,6 +1732,8 @@ ANALYST_PERSONAS = [
             "Interpret RSI regime, MACD histogram crossover state, Bollinger Band width and price position, "
             "SMA50/200 crossover proximity and % distance, annualised volatility, "
             "and volume confirmation of the trend. Cite the forecast confidence label explicitly. "
+            "When an RSI or MACD divergence is flagged, state its directional implication and factor it "
+            "into your probabilistic read. "
             "Map each signal to a clear probabilistic implication. Be precise and data-first. "
             "Conclude with a clear quantitative rating (Accumulate / Hold / Distribute) "
             "and identify specific technical entry and exit levels where applicable."

--- a/backend/tests/test_advanced_signals.py
+++ b/backend/tests/test_advanced_signals.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 from backend.models import (
+    MODELS_AVAILABLE,
     calculate_atr, calculate_stochastic, calculate_adx, calculate_obv,
     detect_divergences, run_ensemble_forecast,
 )
@@ -153,6 +154,7 @@ def test_divergence_insufficient_bars_all_false():
 
 # ── RF feature importance ────────────────────────────────────────────────────
 
+@pytest.mark.skipif(not MODELS_AVAILABLE, reason="ML models unavailable in this environment")
 @pytest.mark.parametrize("seed", [0, 1])
 def test_rf_feature_importance_sorted_and_normalised(seed):
     """run_ensemble_forecast exposes top-5 RF importances, sorted, summing ~1.0."""
@@ -168,16 +170,16 @@ def test_rf_feature_importance_sorted_and_normalised(seed):
         closes, "TEST", opens=opens, highs=highs, lows=lows, volumes=vols
     )
     imp = result.get("rf_feature_importance", [])
-    # RF may not be the active model if it failed, but on this clean fixture it
-    # should fit; if present, validate the contract.
-    if imp:
-        assert len(imp) <= 5
-        importances = [d["importance"] for d in imp]
-        assert importances == sorted(importances, reverse=True)
-        # Normalised to 1.0; tolerance covers 4-decimal rounding of 5 terms.
-        assert abs(sum(importances) - 1.0) < 1e-3
-        for d in imp:
-            assert isinstance(d["feature"], str) and d["feature"]
+    # On this clean fixture with models available, RF should fit and report
+    # importances — assert non-empty so a regression can't silently pass.
+    assert imp, "Expected non-empty rf_feature_importance on clean fixture"
+    assert len(imp) <= 5
+    importances = [d["importance"] for d in imp]
+    assert importances == sorted(importances, reverse=True)
+    # Normalised to 1.0; tolerance covers 4-decimal rounding of 5 terms.
+    assert abs(sum(importances) - 1.0) < 1e-3
+    for d in imp:
+        assert isinstance(d["feature"], str) and d["feature"]
 
 
 # ── Earnings surprise (graceful degradation) ─────────────────────────────────

--- a/backend/tests/test_advanced_signals.py
+++ b/backend/tests/test_advanced_signals.py
@@ -1,0 +1,206 @@
+"""Feature 14 — Advanced Technical Signals.
+
+Covers ATR, Stochastic, ADX, OBV, RSI/MACD divergence, RF feature importance,
+and the earnings-surprise graceful-degradation path.
+"""
+import numpy as np
+import pytest
+
+from backend.models import (
+    calculate_atr, calculate_stochastic, calculate_adx, calculate_obv,
+    detect_divergences, run_ensemble_forecast,
+)
+
+
+# ── ATR ──────────────────────────────────────────────────────────────────────
+
+def test_atr_constant_true_range():
+    """Flat closes with a constant 2.0 high-low range → ATR == 2.0."""
+    highs  = [102.0] * 30
+    lows   = [100.0] * 30
+    closes = [101.0] * 30
+    atr = calculate_atr(highs, lows, closes, period=14)
+    assert atr is not None
+    assert abs(atr - 2.0) < 0.01
+
+
+def test_atr_insufficient_data_returns_none():
+    assert calculate_atr([1, 2], [1, 2], [1, 2], period=14) is None
+
+
+def test_atr_mismatched_lengths_returns_none():
+    assert calculate_atr([1, 2, 3], [1, 2], [1, 2, 3]) is None
+
+
+# ── Stochastic ───────────────────────────────────────────────────────────────
+
+def test_stochastic_known_fixture():
+    """Close at the top of a flat range → %K == 100."""
+    highs  = [10.0] * 20
+    lows   = [0.0] * 20
+    closes = [5.0] * 19 + [10.0]   # last close at the high
+    out = calculate_stochastic(highs, lows, closes, k_period=14, d_period=3)
+    assert out["stoch_k"] is not None
+    assert abs(out["stoch_k"] - 100.0) < 0.01
+
+
+def test_stochastic_bottom_of_range():
+    highs  = [10.0] * 20
+    lows   = [0.0] * 20
+    closes = [5.0] * 19 + [0.0]    # last close at the low
+    out = calculate_stochastic(highs, lows, closes)
+    assert out["stoch_k"] is not None
+    assert abs(out["stoch_k"] - 0.0) < 0.01
+
+
+def test_stochastic_insufficient_data():
+    out = calculate_stochastic([1, 2], [1, 2], [1, 2])
+    assert out == {"stoch_k": None, "stoch_d": None}
+
+
+# ── ADX ──────────────────────────────────────────────────────────────────────
+
+def test_adx_strong_uptrend_high():
+    """A clean, monotone uptrend should yield a high ADX (strong trend)."""
+    closes = [100.0 + i for i in range(60)]
+    highs  = [c + 1 for c in closes]
+    lows   = [c - 1 for c in closes]
+    out = calculate_adx(highs, lows, closes, period=14)
+    assert out["adx_14"] is not None
+    assert out["plus_di"] is not None and out["minus_di"] is not None
+    # In a pure uptrend +DI dominates −DI and the trend is strong.
+    assert out["plus_di"] > out["minus_di"]
+    assert out["adx_14"] > 25
+
+
+def test_adx_insufficient_data():
+    out = calculate_adx([1, 2, 3], [1, 2, 3], [1, 2, 3])
+    assert out == {"adx_14": None, "plus_di": None, "minus_di": None}
+
+
+# ── OBV ──────────────────────────────────────────────────────────────────────
+
+def test_obv_accumulates_on_up_days():
+    closes  = [10.0, 11.0, 12.0, 13.0]   # all up days
+    volumes = [100.0, 100.0, 100.0, 100.0]
+    obv = calculate_obv(closes, volumes, history=30)
+    assert obv is not None
+    # First bar contributes 0 (no prior close); then +100 ×3.
+    assert obv[-1] == 300.0
+
+
+def test_obv_history_capped():
+    closes  = list(range(1, 60))
+    volumes = [1.0] * 59
+    obv = calculate_obv([float(c) for c in closes], volumes, history=30)
+    assert obv is not None
+    assert len(obv) == 30
+
+
+def test_obv_mismatched_lengths_returns_none():
+    assert calculate_obv([1, 2, 3], [1, 2]) is None
+
+
+# ── Divergence ───────────────────────────────────────────────────────────────
+
+def _bullish_div_inputs():
+    closes = [100.0] * 40
+    rsi    = [50.0] * 40
+    for i in range(20, 40):
+        closes[i] = 110.0
+        rsi[i]    = 55.0
+    closes[25], closes[33] = 95.0, 90.0   # price: lower low
+    rsi[25],    rsi[33]    = 30.0, 40.0    # rsi:   higher low
+    return closes, rsi
+
+
+def test_divergence_bullish_detected():
+    closes, rsi = _bullish_div_inputs()
+    out = detect_divergences(closes, rsi, [0.0] * 40)
+    assert out["rsi_bullish"] is True
+    assert out["rsi_bearish"] is False
+
+
+def test_divergence_bearish_detected():
+    closes = [100.0] * 40
+    rsi    = [50.0] * 40
+    for i in range(20, 40):
+        closes[i] = 90.0
+        rsi[i]    = 45.0
+    closes[25], closes[33] = 105.0, 110.0  # price: higher high
+    rsi[25],    rsi[33]    = 70.0, 60.0    # rsi:   lower high
+    out = detect_divergences(closes, rsi, [0.0] * 40)
+    assert out["rsi_bearish"] is True
+    assert out["rsi_bullish"] is False
+
+
+def test_divergence_flat_series_all_false():
+    closes = [100.0] * 40
+    out = detect_divergences(closes, [50.0] * 40, [0.0] * 40)
+    assert out == {
+        "rsi_bullish": False, "rsi_bearish": False,
+        "macd_bullish": False, "macd_bearish": False,
+    }
+
+
+def test_divergence_insufficient_bars_all_false():
+    out = detect_divergences([1.0, 2.0, 3.0], [50.0, 51.0, 52.0], [0.0, 0.0, 0.0])
+    assert out == {
+        "rsi_bullish": False, "rsi_bearish": False,
+        "macd_bullish": False, "macd_bearish": False,
+    }
+
+
+# ── RF feature importance ────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("seed", [0, 1])
+def test_rf_feature_importance_sorted_and_normalised(seed):
+    """run_ensemble_forecast exposes top-5 RF importances, sorted, summing ~1.0."""
+    rng = np.random.default_rng(seed)
+    n = 120
+    closes = list(100.0 + np.cumsum(rng.normal(0, 1, n)))
+    opens  = [c - 0.2 for c in closes]
+    highs  = [c + 1.0 for c in closes]
+    lows   = [c - 1.0 for c in closes]
+    vols   = list(1_000_000 + rng.integers(0, 100_000, n).astype(float))
+
+    result = run_ensemble_forecast(
+        closes, "TEST", opens=opens, highs=highs, lows=lows, volumes=vols
+    )
+    imp = result.get("rf_feature_importance", [])
+    # RF may not be the active model if it failed, but on this clean fixture it
+    # should fit; if present, validate the contract.
+    if imp:
+        assert len(imp) <= 5
+        importances = [d["importance"] for d in imp]
+        assert importances == sorted(importances, reverse=True)
+        # Normalised to 1.0; tolerance covers 4-decimal rounding of 5 terms.
+        assert abs(sum(importances) - 1.0) < 1e-3
+        for d in imp:
+            assert isinstance(d["feature"], str) and d["feature"]
+
+
+# ── Earnings surprise (graceful degradation) ─────────────────────────────────
+
+def test_fetch_earnings_surprise_graceful_on_none(monkeypatch):
+    from backend import services
+    svc = services.YFinanceService()
+
+    class _FakeTicker:
+        earnings_history = None
+
+    monkeypatch.setattr(services, "yf", type("YF", (), {"Ticker": staticmethod(lambda t: _FakeTicker())}))
+    monkeypatch.setattr(services, "YFINANCE_AVAILABLE", True)
+    assert svc.fetch_earnings_surprise("AAPL") == []
+
+
+def test_fetch_earnings_surprise_graceful_on_raise(monkeypatch):
+    from backend import services
+    svc = services.YFinanceService()
+
+    def _boom(_t):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(services, "yf", type("YF", (), {"Ticker": staticmethod(_boom)}))
+    monkeypatch.setattr(services, "YFINANCE_AVAILABLE", True)
+    assert svc.fetch_earnings_surprise("AAPL") == []

--- a/backend/tests/test_routers.py
+++ b/backend/tests/test_routers.py
@@ -201,6 +201,21 @@ def test_trade_setup_no_atr_falls_back() -> None:
     assert d["atr_multiplier"] is None
 
 
+def test_trade_setup_negative_atr_rejected() -> None:
+    """A negative atr_14 must be rejected by the validator (422)."""
+    resp = client.post(
+        "/trade-setup",
+        json=_trade_payload(rsi=50.0, trend="Bullish", atr_14=-1.0),
+    )
+    assert resp.status_code == 422
+
+
+def test_trade_setup_invalid_symbol_rejected() -> None:
+    """A symbol outside the allowlist must be rejected (422)."""
+    resp = client.post("/trade-setup", json=_trade_payload(symbol="AAPL; DROP TABLE"))
+    assert resp.status_code == 422
+
+
 def test_trade_setup_invalid_price() -> None:
     resp = client.post("/trade-setup", json=_trade_payload(current_price=-5.0))
     assert resp.status_code == 422

--- a/backend/tests/test_routers.py
+++ b/backend/tests/test_routers.py
@@ -152,6 +152,55 @@ def test_trade_setup_groq_failure_uses_fallback_rationale() -> None:
     assert len(resp.json()["rationale"]) > 0
 
 
+def test_trade_setup_atr_stop_widens_with_volatility() -> None:
+    """A larger ATR should place the long stop further from entry (volatility-adaptive)."""
+    with patch("backend.routers.trade.analyst_jury_svc", _mock_jury()):
+        low_vol = client.post(
+            "/trade-setup",
+            json=_trade_payload(rsi=50.0, trend="Bullish", atr_14=0.5),
+        ).json()
+        high_vol = client.post(
+            "/trade-setup",
+            json=_trade_payload(rsi=50.0, trend="Bullish", atr_14=4.0),
+        ).json()
+    assert low_vol["atr_14"] == 0.5 and low_vol["atr_multiplier"] == 2.0
+    assert high_vol["atr_14"] == 4.0
+    entry_low_lv  = (low_vol["entry_low"] + low_vol["entry_high"]) / 2 - low_vol["stop_loss"]
+    entry_low_hv  = (high_vol["entry_low"] + high_vol["entry_high"]) / 2 - high_vol["stop_loss"]
+    # Higher ATR → wider stop distance.
+    assert entry_low_hv > entry_low_lv
+
+
+def test_trade_setup_atr_stop_8pct_hard_cap() -> None:
+    """An enormous ATR must still keep the stop within 8% of entry."""
+    with patch("backend.routers.trade.analyst_jury_svc", _mock_jury()):
+        d = client.post(
+            "/trade-setup",
+            json=_trade_payload(rsi=50.0, trend="Bullish", current_price=150.0, atr_14=50.0),
+        ).json()
+    entry_mid = (d["entry_low"] + d["entry_high"]) / 2
+    # Stop is below entry but capped at 8% away.
+    assert d["stop_loss"] < entry_mid
+    assert d["stop_loss"] >= entry_mid * 0.92 - 0.01
+
+
+def test_trade_setup_conservative_uses_2_5_multiplier() -> None:
+    with patch("backend.routers.trade.analyst_jury_svc", _mock_jury()):
+        d = client.post(
+            "/trade-setup",
+            json=_trade_payload(rsi=50.0, trend="Bullish", atr_14=1.0, conservative=True),
+        ).json()
+    assert d["atr_multiplier"] == 2.5
+
+
+def test_trade_setup_no_atr_falls_back() -> None:
+    """Without ATR, the response carries null ATR fields (legacy % stop path)."""
+    with patch("backend.routers.trade.analyst_jury_svc", _mock_jury()):
+        d = client.post("/trade-setup", json=_trade_payload(rsi=50.0, trend="Bullish")).json()
+    assert d["atr_14"] is None
+    assert d["atr_multiplier"] is None
+
+
 def test_trade_setup_invalid_price() -> None:
     resp = client.post("/trade-setup", json=_trade_payload(current_price=-5.0))
     assert resp.status_code == 422

--- a/docs/FiForesight-Documentation.md
+++ b/docs/FiForesight-Documentation.md
@@ -16,6 +16,7 @@
 4. [Architecture — Low-Level Design (LLD)](#4-architecture--low-level-design-lld)
 5. [Data Flow & Pipeline](#5-data-flow--pipeline)
 6. [Math & Calculations Reference](#6-math--calculations-reference)
+   - 6A. [Advanced Technical Signals (Feature 14)](#6a-advanced-technical-signals-feature-14)
 7. [ML Model Details](#7-ml-model-details)
 8. [API Reference](#8-api-reference)
 9. [Database Schema (InfluxDB)](#9-database-schema-influxdb)

--- a/docs/FiForesight-Documentation.md
+++ b/docs/FiForesight-Documentation.md
@@ -845,6 +845,106 @@ These are computed in [frontend/app/page.tsx](../frontend/app/page.tsx) and are 
 
 ---
 
+## 6A. Advanced Technical Signals (Feature 14)
+
+Five signal upgrades that sharpen the trade setup and surface reversal/strength
+cues. All indicator helpers live in [backend/models.py](../backend/models.py) and
+are computed in [backend/routers/predict.py](../backend/routers/predict.py) Step 4b#.
+Each helper is defensive: it returns `None` / all-false on insufficient data or any
+exception (logged at DEBUG), so a single bad indicator never aborts `/predict`.
+
+### 6A.1 ATR-14 (Average True Range) + adaptive stop
+
+True Range per bar and its 14-period EMA:
+
+```
+TR_t = max( high_t − low_t,  |high_t − close_{t-1}|,  |low_t − close_{t-1}| )
+ATR  = EMA_14(TR)               # ewm(span=14, adjust=False)
+```
+
+Returned as `indicators.atr_14`. The frontend forwards it to `POST /trade-setup`,
+where it replaces the flat-% stop with a **volatility-adaptive stop**:
+
+```
+long  : stop = max( entry_mid − k·ATR,  entry_mid · 0.92 )    # ≤ 8 % below
+short : stop = min( entry_mid + k·ATR,  entry_mid · 1.08 )    # ≤ 8 % above
+k = 2.0  (default)  |  2.5  (conservative:true)
+```
+
+The 8 % hard cap stops a huge ATR from suggesting a reckless stop. When `atr_14`
+is absent (anonymous/legacy callers) the endpoint falls back to the previous
+support/resistance % stop. The response echoes `atr_14` and `atr_multiplier`.
+
+### 6A.2 Stochastic oscillator (%K / %D)
+
+```
+%K = 100 · (close − lowest_low_14) / (highest_high_14 − lowest_low_14)
+%D = SMA_3(%K)
+```
+
+Returned as the latest `stoch_k` / `stoch_d`. UI renders gauges with reference
+lines at **20 / 80** (oversold / overbought).
+
+### 6A.3 ADX / +DI / −DI (Wilder, 14)
+
+Directional movement with Wilder smoothing (`ewm(alpha=1/14)`):
+
+```
++DM = up_move   if up_move > down_move and > 0 else 0
+−DM = down_move if down_move > up_move and > 0 else 0
++DI = 100 · EMA(+DM) / ATR        −DI = 100 · EMA(−DM) / ATR
+DX  = 100 · |+DI − −DI| / (+DI + −DI)
+ADX = EMA_14(DX)
+```
+
+Returned as `adx_14`, `plus_di`, `minus_di`. Reference line at **25**
+(below = ranging, above = trending).
+
+### 6A.4 OBV (On-Balance Volume)
+
+```
+OBV_t = OBV_{t-1} ± volume_t      (+ on up-close, − on down-close)
+```
+
+Returned as `obv_history` (last 30 values) and drawn as an area chart.
+
+### 6A.5 RSI / MACD-histogram divergence
+
+Uses `scipy.signal.find_peaks` over the **last 20 bars** (troughs found on the
+inverted series), peaks/troughs ≥ **5 bars apart**, comparing the two most recent
+extrema of the price series and the indicator series independently:
+
+- **Bullish**: price prints a *lower low* while the indicator prints a *higher low*.
+- **Bearish**: price prints a *higher high* while the indicator prints a *lower high*.
+
+Run for both RSI and the MACD histogram → `divergences = {rsi_bullish, rsi_bearish,
+macd_bullish, macd_bearish}`. All-false when fewer than 30 bars are available. The
+labels are injected into the analyst-jury context and each persona's system prompt,
+and surfaced as coloured badges ("RSI Div ↑/↓", "MACD Div ↑/↓") under the chart.
+
+### 6A.6 RandomForest feature importance
+
+After the RF is fit, `rf.feature_importances_` is paired with feature names
+(lagged OHLCV columns, e.g. `Close[t-1]`, `Volume[t-3]`), the **top-5** are taken
+and **normalised to sum 1.0**, sorted descending → `rf_feature_importance`.
+Rendered as a horizontal bar chart (`ModelFeatureImportanceBar`) below the
+ensemble-weights bar.
+
+### 6A.7 Earnings surprise history
+
+`YFinanceService.fetch_earnings_surprise` reads yfinance `earnings_history`
+(last 4 quarters) → `earnings_surprise = [{quarter, estimate, actual,
+surprise_pct}]` (Redis-cached 24 h, `[]` on failure). Rendered as a collapsible
+table in the fundamentals panel, chip-coloured green (beat ≥ 0 %) / red (miss).
+
+**UI surfaces** — ATR annotation in `TradeSetupCard`; earnings-surprise Accordion
+in `FundamentalsPanel`; `ModelFeatureImportanceBar` below `ModelWeightBar`;
+`SignalPanels` (Stoch/ADX gauges, OBV area chart, divergence badges) below the
+chart in `PriceChartCard`, with sub-panel visibility persisted in `localStorage`
+(`fiforesight:subpanels`, default hidden).
+
+---
+
 ## 7. ML Model Details
 
 ### 7.1 Model 1 — Prophet (univariate, with regressors)

--- a/frontend/app/(app)/analysis/page.tsx
+++ b/frontend/app/(app)/analysis/page.tsx
@@ -18,6 +18,7 @@ import { useAuth } from '../../../contexts/AuthContext';
 import { useAppShell } from '../../../contexts/AppShellContext';
 import AuthModal from '../../../components/AuthModal';
 import ModelWeightBar   from '../../../components/ModelWeightBar';
+import ModelFeatureImportanceBar from '../../../components/ModelFeatureImportanceBar';
 import BacktestPanel    from '../../../components/BacktestPanel';
 import TrendingSparklines from '../../../components/TrendingSparklines';
 import MonteCarloFanChart from '../../../components/MonteCarloFanChart';
@@ -101,6 +102,7 @@ function AnalysisContent() {
       trend:           data.prediction.trend,
       sentiment_label: data.sentiment?.label ?? 'Neutral',
       var_95:          data.monteCarlo?.var_95 ?? null,
+      atr_14:          data.indicators?.atr_14 ?? null,
     }, { headers: authHeaders })
       .then(r  => setTradeSetup(r.data))
       .catch(() => { /* non-fatal */ })
@@ -318,9 +320,16 @@ function AnalysisContent() {
                   />
                 )}
 
-                {/* ── Ensemble model weights ───────────────────────── */}
+                {/* ── Ensemble model weights + RF feature importance ─── */}
                 {prediction.modelWeights && (
-                  <ModelWeightBar weights={prediction.modelWeights} isDark={isDark} />
+                  <Box>
+                    <ModelWeightBar weights={prediction.modelWeights} isDark={isDark} />
+                    <ModelFeatureImportanceBar
+                      importances={prediction.indicators?.rf_feature_importance ?? []}
+                      isDark={isDark}
+                      primaryColor={primaryColor}
+                    />
+                  </Box>
                 )}
 
                 {/* ── Walk-forward backtest (on-demand) ────────────── */}

--- a/frontend/components/FundamentalsPanel.tsx
+++ b/frontend/components/FundamentalsPanel.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import { Box, Card, CardContent, Chip, Divider, Grid, Stack, Typography } from '@mui/material';
+import {
+  Accordion, AccordionDetails, AccordionSummary,
+  Box, Card, CardContent, Chip, Divider, Grid, Stack, Typography,
+} from '@mui/material';
+import { ChevronDown } from 'lucide-react';
 import type { PredictionData } from '../types';
 
 interface Props {
@@ -191,6 +195,78 @@ export default function FundamentalsPanel({ prediction, rsiInfo, isDark, primary
           </CardContent>
         </Card>
       )}
+
+      {/* Earnings Surprise History (Feature 14) — collapsible; default collapsed
+          when no data is available. */}
+      {(() => {
+        const surprises = prediction.indicators?.earnings_surprise ?? [];
+        const hasData = surprises.length > 0;
+        return (
+          <Card>
+            <Accordion
+              disableGutters
+              defaultExpanded={false}
+              sx={{ background: 'transparent', boxShadow: 'none', '&:before': { display: 'none' } }}
+            >
+              <AccordionSummary expandIcon={<ChevronDown size={16} />} sx={{ px: 2 }}>
+                <Typography variant="overline" sx={{ opacity: 0.5 }}>
+                  Earnings Surprise History
+                </Typography>
+              </AccordionSummary>
+              <AccordionDetails sx={{ px: 2, pt: 0 }}>
+                {hasData ? (
+                  <Box component="table" sx={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.72rem' }}>
+                    <Box component="thead">
+                      <Box component="tr" sx={{ opacity: 0.45, textAlign: 'left' }}>
+                        {['Quarter', 'Est', 'Actual', 'Beat/Miss'].map(h => (
+                          <Box component="th" key={h} sx={{ py: 0.5, fontWeight: 700, letterSpacing: 0.5 }}>
+                            {h}
+                          </Box>
+                        ))}
+                      </Box>
+                    </Box>
+                    <Box component="tbody">
+                      {surprises.map((s, i) => {
+                        const beat = s.surprise_pct != null && s.surprise_pct >= 0;
+                        const chipColor = s.surprise_pct == null
+                          ? 'text.secondary'
+                          : beat ? (isDark ? '#00ffa3' : '#16a34a') : (isDark ? '#ff0055' : '#dc2626');
+                        return (
+                          <Box component="tr" key={i} sx={{ borderTop: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}` }}>
+                            <Box component="td" sx={{ py: 0.6, fontWeight: 600 }}>{s.quarter}</Box>
+                            <Box component="td" sx={{ py: 0.6 }}>{s.estimate != null ? s.estimate.toFixed(2) : '—'}</Box>
+                            <Box component="td" sx={{ py: 0.6 }}>{s.actual != null ? s.actual.toFixed(2) : '—'}</Box>
+                            <Box component="td" sx={{ py: 0.6 }}>
+                              {s.surprise_pct == null ? (
+                                <Typography component="span" sx={{ fontSize: '0.7rem', opacity: 0.5 }}>—</Typography>
+                              ) : (
+                                <Chip
+                                  label={`${beat ? '+' : ''}${s.surprise_pct.toFixed(1)}%`}
+                                  size="small"
+                                  sx={{
+                                    height: 18, fontSize: '0.62rem', fontWeight: 700,
+                                    color: chipColor,
+                                    bgcolor: `${beat ? (isDark ? 'rgba(0,255,163,0.12)' : 'rgba(22,163,74,0.12)') : (isDark ? 'rgba(255,0,85,0.12)' : 'rgba(220,38,38,0.12)')}`,
+                                    '& .MuiChip-label': { px: 0.75 },
+                                  }}
+                                />
+                              )}
+                            </Box>
+                          </Box>
+                        );
+                      })}
+                    </Box>
+                  </Box>
+                ) : (
+                  <Typography variant="caption" sx={{ opacity: 0.4 }}>
+                    Earnings surprise data unavailable for this ticker.
+                  </Typography>
+                )}
+              </AccordionDetails>
+            </Accordion>
+          </Card>
+        );
+      })()}
     </>
   );
 }

--- a/frontend/components/ModelFeatureImportanceBar.tsx
+++ b/frontend/components/ModelFeatureImportanceBar.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Box, Button, Collapse, Typography, useMediaQuery, useTheme,
+} from '@mui/material';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import {
+  Bar, BarChart, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis,
+} from 'recharts';
+import type { FeatureImportance } from '../types';
+
+interface Props {
+  importances:  FeatureImportance[];
+  isDark:       boolean;
+  primaryColor: string;
+}
+
+/**
+ * Horizontal bar chart of the RandomForest's top-5 feature importances
+ * (Feature 14). Rendered below ModelWeightBar. Open on desktop, collapsed on
+ * mobile by default.
+ */
+export default function ModelFeatureImportanceBar({ importances, isDark, primaryColor }: Props) {
+  const theme  = useTheme();
+  const isXs   = useMediaQuery(theme.breakpoints.down('sm'));
+  const [open, setOpen] = useState(!isXs);
+
+  if (!importances || importances.length === 0) return null;
+
+  const textColor = isDark ? 'rgba(220,220,220,0.55)' : 'rgba(20,30,50,0.55)';
+  const data = importances.map(d => ({ ...d, pct: +(d.importance * 100).toFixed(1) }));
+
+  return (
+    <Box sx={{ width: '100%', mt: 1.5 }}>
+      <Button
+        size="small"
+        variant="text"
+        onClick={() => setOpen(o => !o)}
+        endIcon={open ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+        sx={{
+          fontSize: 10, fontWeight: 800, letterSpacing: 1.2, p: 0,
+          color: textColor, textTransform: 'uppercase',
+          '&:hover': { background: 'transparent', color: primaryColor },
+        }}
+      >
+        RF Feature Importance
+      </Button>
+      <Collapse in={open}>
+        <Box sx={{ width: '100%', height: data.length * 30 + 20, mt: 1 }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              layout="vertical"
+              data={data}
+              margin={{ top: 0, right: 36, bottom: 0, left: 8 }}
+            >
+              <XAxis type="number" hide domain={[0, 'dataMax']} />
+              <YAxis
+                type="category"
+                dataKey="feature"
+                width={92}
+                tick={{ fontSize: 10, fill: textColor }}
+                axisLine={false}
+                tickLine={false}
+              />
+              <Tooltip
+                cursor={{ fill: `${primaryColor}11` }}
+                contentStyle={{
+                  background: isDark ? '#0d1520' : '#fff',
+                  border: `1px solid ${primaryColor}44`,
+                  borderRadius: 8, fontSize: 11,
+                }}
+                formatter={(v: number) => [`${v}%`, 'Importance']}
+              />
+              <Bar dataKey="pct" radius={[0, 4, 4, 0]} label={{ position: 'right', fontSize: 10, fill: textColor, formatter: (v: number) => `${v}%` }}>
+                {data.map((_, i) => (
+                  <Cell key={i} fill={primaryColor} fillOpacity={1 - i * 0.13} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </Box>
+        <Typography sx={{ fontSize: 9, opacity: 0.35, mt: 0.5 }}>
+          Most influential lagged OHLCV features driving the RF forecast.
+        </Typography>
+      </Collapse>
+    </Box>
+  );
+}

--- a/frontend/components/PriceChartCard.tsx
+++ b/frontend/components/PriceChartCard.tsx
@@ -9,6 +9,7 @@ import {
 import { Info, ChevronDown, ChevronUp } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import type { PredictionData, IndicatorKey, ChartStats, IndicatorSignals, IntervalHistoryData } from '../types';
+import SignalPanels from './SignalPanels';
 
 const AdvancedChart = dynamic(() => import('./AdvancedChart'), { ssr: false });
 
@@ -357,6 +358,23 @@ export default function PriceChartCard({
             priceHeight={chartH}
           />
         </Box>
+
+        {/* Advanced signal sub-panels (Feature 14) — Stoch / ADX / OBV +
+            RSI/MACD divergence badges. Only on the native 2Y view, where the
+            indicator payload (latest scalars + OBV history) applies. */}
+        {isTwoYear && (
+          <SignalPanels
+            stochK={prediction.indicators?.stoch_k}
+            stochD={prediction.indicators?.stoch_d}
+            adx={prediction.indicators?.adx_14}
+            plusDi={prediction.indicators?.plus_di}
+            minusDi={prediction.indicators?.minus_di}
+            obvHistory={prediction.indicators?.obv_history}
+            divergences={prediction.indicators?.divergences}
+            isDark={isDark}
+            primaryColor={primaryColor}
+          />
+        )}
       </CardContent>
     </Card>
   );

--- a/frontend/components/SignalPanels.tsx
+++ b/frontend/components/SignalPanels.tsx
@@ -34,7 +34,7 @@ function Gauge({
   const pct = Math.max(0, Math.min(100, (value / max) * 100));
   const track = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';
   return (
-    <Box sx={{ flex: 1, minWidth: 120 }}>
+    <Box sx={{ flex: '1 1 96px', minWidth: 96 }}>
       <Stack direction="row" justifyContent="space-between" sx={{ mb: 0.3 }}>
         <Typography sx={{ fontSize: '0.6rem', opacity: 0.5, fontWeight: 700 }}>{label}</Typography>
         <Typography sx={{ fontSize: '0.6rem', fontWeight: 800, color }}>{value.toFixed(1)}</Typography>
@@ -141,7 +141,7 @@ export default function SignalPanels({
             <Typography sx={{ fontSize: '0.6rem', opacity: 0.5, fontWeight: 700, mb: 0.75, letterSpacing: 0.5 }}>
               STOCHASTIC (14, 3) — ref 20 / 80
             </Typography>
-            <Stack direction="row" spacing={2}>
+            <Stack direction="row" spacing={2} useFlexGap flexWrap="wrap">
               <Gauge label="%K" value={stochK} color="#3b82f6" refs={[20, 80]} isDark={isDark} />
               {stochD != null && <Gauge label="%D" value={stochD} color="#f97316" refs={[20, 80]} isDark={isDark} />}
             </Stack>
@@ -154,7 +154,7 @@ export default function SignalPanels({
             <Typography sx={{ fontSize: '0.6rem', opacity: 0.5, fontWeight: 700, mb: 0.75, letterSpacing: 0.5 }}>
               ADX (14) — ref 25 · {adx >= 25 ? 'trending' : 'ranging'}
             </Typography>
-            <Stack direction="row" spacing={2}>
+            <Stack direction="row" spacing={2} useFlexGap flexWrap="wrap">
               <Gauge label="ADX" value={adx} color="#a855f7" refs={[25]} isDark={isDark} />
               {plusDi  != null && <Gauge label="+DI" value={plusDi}  color={green} refs={[]} isDark={isDark} />}
               {minusDi != null && <Gauge label="−DI" value={minusDi} color={red}   refs={[]} isDark={isDark} />}

--- a/frontend/components/SignalPanels.tsx
+++ b/frontend/components/SignalPanels.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Box, Stack, ToggleButton, ToggleButtonGroup, Typography,
+} from '@mui/material';
+import { Area, AreaChart, ReferenceLine, ResponsiveContainer, Tooltip, YAxis } from 'recharts';
+import type { Divergences, SubPanelKey } from '../types';
+
+interface Props {
+  stochK?:   number | null;
+  stochD?:   number | null;
+  adx?:      number | null;
+  plusDi?:   number | null;
+  minusDi?:  number | null;
+  obvHistory?: number[] | null;
+  divergences?: Divergences;
+  isDark:       boolean;
+  primaryColor: string;
+}
+
+const LS_KEY = 'fiforesight:subpanels';
+
+const PANELS: { key: SubPanelKey; label: string }[] = [
+  { key: 'stoch', label: 'STOCH' },
+  { key: 'adx',   label: 'ADX'   },
+  { key: 'obv',   label: 'OBV'   },
+];
+
+/** A 0–100 gauge with reference lines (Stochastic / ADX). */
+function Gauge({
+  label, value, color, refs, isDark, max = 100,
+}: { label: string; value: number; color: string; refs: number[]; isDark: boolean; max?: number }) {
+  const pct = Math.max(0, Math.min(100, (value / max) * 100));
+  const track = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';
+  return (
+    <Box sx={{ flex: 1, minWidth: 120 }}>
+      <Stack direction="row" justifyContent="space-between" sx={{ mb: 0.3 }}>
+        <Typography sx={{ fontSize: '0.6rem', opacity: 0.5, fontWeight: 700 }}>{label}</Typography>
+        <Typography sx={{ fontSize: '0.6rem', fontWeight: 800, color }}>{value.toFixed(1)}</Typography>
+      </Stack>
+      <Box sx={{ position: 'relative', height: 8, borderRadius: 4, background: track }}>
+        <Box sx={{ position: 'absolute', inset: 0, width: `${pct}%`, borderRadius: 4, background: color, transition: 'width 0.4s ease' }} />
+        {refs.map(r => (
+          <Box key={r} sx={{ position: 'absolute', top: -2, bottom: -2, left: `${(r / max) * 100}%`, width: '1px', background: isDark ? 'rgba(255,255,255,0.4)' : 'rgba(0,0,0,0.4)' }} />
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * Optional sub-panels for the price chart (Feature 14): Stochastic, ADX, OBV.
+ * Visibility is toggled per panel and persisted in localStorage. Default hidden.
+ * Divergence badges are surfaced above the toggle whenever a signal fires.
+ */
+export default function SignalPanels({
+  stochK, stochD, adx, plusDi, minusDi, obvHistory, divergences, isDark, primaryColor,
+}: Props) {
+  // Lazy initialiser restores the persisted selection without an effect.
+  // SignalPanels only renders after a client-side prediction fetch, so there
+  // is no SSR pass to mismatch against.
+  const [selected, setSelected] = useState<SubPanelKey[]>(() => {
+    if (typeof window === 'undefined') return [];
+    try {
+      const raw = localStorage.getItem(LS_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+          return parsed.filter((k): k is SubPanelKey => ['stoch', 'adx', 'obv'].includes(k));
+        }
+      }
+    } catch { /* ignore malformed storage */ }
+    return [];
+  });
+
+  const handleChange = (_e: unknown, vals: SubPanelKey[]) => {
+    setSelected(vals);
+    try { localStorage.setItem(LS_KEY, JSON.stringify(vals)); } catch { /* ignore */ }
+  };
+
+  const green = isDark ? '#00ffa3' : '#16a34a';
+  const red   = isDark ? '#ff0055' : '#dc2626';
+
+  const divBadges = divergences ? ([
+    { on: divergences.rsi_bullish,  text: 'RSI Div ↑',  color: green },
+    { on: divergences.rsi_bearish,  text: 'RSI Div ↓',  color: red   },
+    { on: divergences.macd_bullish, text: 'MACD Div ↑', color: green },
+    { on: divergences.macd_bearish, text: 'MACD Div ↓', color: red   },
+  ].filter(b => b.on)) : [];
+
+  const obvData = (obvHistory ?? []).map((v, i) => ({ i, v }));
+
+  // Only render panel toggles for which we have data.
+  const available = PANELS.filter(p =>
+    (p.key === 'stoch' && stochK != null) ||
+    (p.key === 'adx'   && adx != null)    ||
+    (p.key === 'obv'   && obvData.length > 0),
+  );
+
+  if (available.length === 0 && divBadges.length === 0) return null;
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      {divBadges.length > 0 && (
+        <Stack direction="row" spacing={1} sx={{ mb: 1.5, flexWrap: 'wrap', gap: 0.5 }}>
+          {divBadges.map(b => (
+            <Box
+              key={b.text}
+              sx={{
+                px: 1, py: 0.3, borderRadius: 1, border: `1px solid ${b.color}55`,
+                background: `${b.color}1a`, color: b.color,
+                fontSize: '0.62rem', fontWeight: 800, letterSpacing: 0.5,
+              }}
+            >
+              {b.text}
+            </Box>
+          ))}
+        </Stack>
+      )}
+
+      {available.length > 0 && (
+        <ToggleButtonGroup
+          value={selected}
+          onChange={handleChange}
+          size="small"
+          sx={{ flexWrap: 'wrap', gap: 0.5, mb: 1 }}
+        >
+          {available.map(p => (
+            <ToggleButton key={p.key} value={p.key} sx={{ fontSize: '0.6rem', py: 0.4, px: 1.5, borderRadius: '8px !important' }}>
+              {p.label}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+      )}
+
+      <Stack spacing={1.5}>
+        {/* Stochastic %K / %D — reference lines at 20 / 80 */}
+        {selected.includes('stoch') && stochK != null && (
+          <Box sx={{ p: 1.5, borderRadius: 2, border: `1px solid ${primaryColor}22`, background: `${primaryColor}08` }}>
+            <Typography sx={{ fontSize: '0.6rem', opacity: 0.5, fontWeight: 700, mb: 0.75, letterSpacing: 0.5 }}>
+              STOCHASTIC (14, 3) — ref 20 / 80
+            </Typography>
+            <Stack direction="row" spacing={2}>
+              <Gauge label="%K" value={stochK} color="#3b82f6" refs={[20, 80]} isDark={isDark} />
+              {stochD != null && <Gauge label="%D" value={stochD} color="#f97316" refs={[20, 80]} isDark={isDark} />}
+            </Stack>
+          </Box>
+        )}
+
+        {/* ADX / +DI / −DI — reference line at 25 (trend-strength threshold) */}
+        {selected.includes('adx') && adx != null && (
+          <Box sx={{ p: 1.5, borderRadius: 2, border: `1px solid ${primaryColor}22`, background: `${primaryColor}08` }}>
+            <Typography sx={{ fontSize: '0.6rem', opacity: 0.5, fontWeight: 700, mb: 0.75, letterSpacing: 0.5 }}>
+              ADX (14) — ref 25 · {adx >= 25 ? 'trending' : 'ranging'}
+            </Typography>
+            <Stack direction="row" spacing={2}>
+              <Gauge label="ADX" value={adx} color="#a855f7" refs={[25]} isDark={isDark} />
+              {plusDi  != null && <Gauge label="+DI" value={plusDi}  color={green} refs={[]} isDark={isDark} />}
+              {minusDi != null && <Gauge label="−DI" value={minusDi} color={red}   refs={[]} isDark={isDark} />}
+            </Stack>
+          </Box>
+        )}
+
+        {/* OBV — area chart of the last 30 values */}
+        {selected.includes('obv') && obvData.length > 0 && (
+          <Box sx={{ p: 1.5, borderRadius: 2, border: `1px solid ${primaryColor}22`, background: `${primaryColor}08` }}>
+            <Typography sx={{ fontSize: '0.6rem', opacity: 0.5, fontWeight: 700, mb: 0.75, letterSpacing: 0.5 }}>
+              ON-BALANCE VOLUME (30d)
+            </Typography>
+            <Box sx={{ width: '100%', height: 90 }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <AreaChart data={obvData} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
+                  <defs>
+                    <linearGradient id="obvFill" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stopColor={primaryColor} stopOpacity={0.5} />
+                      <stop offset="100%" stopColor={primaryColor} stopOpacity={0.02} />
+                    </linearGradient>
+                  </defs>
+                  <YAxis hide domain={['dataMin', 'dataMax']} />
+                  <ReferenceLine y={0} stroke={isDark ? 'rgba(255,255,255,0.2)' : 'rgba(0,0,0,0.2)'} />
+                  <Tooltip
+                    contentStyle={{ background: isDark ? '#0d1520' : '#fff', border: `1px solid ${primaryColor}44`, borderRadius: 8, fontSize: 11 }}
+                    labelFormatter={() => ''}
+                    formatter={(v: number) => [v.toLocaleString(), 'OBV']}
+                  />
+                  <Area type="monotone" dataKey="v" stroke={primaryColor} strokeWidth={2} fill="url(#obvFill)" />
+                </AreaChart>
+              </ResponsiveContainer>
+            </Box>
+          </Box>
+        )}
+      </Stack>
+    </Box>
+  );
+}

--- a/frontend/components/TradeSetupCard.tsx
+++ b/frontend/components/TradeSetupCard.tsx
@@ -79,6 +79,11 @@ export default function TradeSetupCard({ setup, loading, isDark, primaryColor }:
             <Typography sx={{ fontSize: '0.8rem', fontWeight: 800, color: red }}>
               ${setup.stop_loss.toFixed(2)}
             </Typography>
+            {setup.atr_14 != null && setup.atr_multiplier != null && (
+              <Typography sx={{ fontSize: '0.55rem', color: red, opacity: 0.65, mt: 0.25, lineHeight: 1.3 }}>
+                ATR-14: {setup.atr_14.toFixed(2)} · entry − {setup.atr_multiplier}×ATR
+              </Typography>
+            )}
           </Box>
 
           {/* Targets */}

--- a/frontend/components/TradeSetupCard.tsx
+++ b/frontend/components/TradeSetupCard.tsx
@@ -81,7 +81,7 @@ export default function TradeSetupCard({ setup, loading, isDark, primaryColor }:
             </Typography>
             {setup.atr_14 != null && setup.atr_multiplier != null && (
               <Typography sx={{ fontSize: '0.55rem', color: red, opacity: 0.65, mt: 0.25, lineHeight: 1.3 }}>
-                ATR-14: {setup.atr_14.toFixed(2)} · entry − {setup.atr_multiplier}×ATR
+                ATR-14: {setup.atr_14.toFixed(2)} · entry {setup.stop_loss <= (setup.entry_low + setup.entry_high) / 2 ? '−' : '+'} {setup.atr_multiplier.toFixed(1)}×ATR
               </Typography>
             )}
           </Box>

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -102,7 +102,22 @@ export interface PredictionData {
   };
   news:      { title: string; link: string; source: string; thumbnail: string; date: string; source_label?: string }[];
   trending:  { symbol: string; name?: string; price: string | number; change: string; category?: string }[];
-  indicators?: { rsi_series?: number[]; support?: number[]; resistance?: number[] };
+  indicators?: {
+    rsi_series?: number[];
+    support?:    number[];
+    resistance?: number[];
+    // ── Advanced technical signals (Feature 14) ──
+    atr_14?:      number | null;
+    stoch_k?:     number | null;
+    stoch_d?:     number | null;
+    adx_14?:      number | null;
+    plus_di?:     number | null;
+    minus_di?:    number | null;
+    obv_history?: number[] | null;
+    divergences?: Divergences;
+    rf_feature_importance?: FeatureImportance[];
+    earnings_surprise?:     EarningsSurprise[];
+  };
   juryAnalysts?: AnalystJuror[];
   modelWeights?: { prophet: number; sarima: number; rf: number };
   sentiment?:    { compound: number; label: string; headline_count: number };
@@ -141,6 +156,30 @@ export interface ReversalRisk {
 
 export type ChartEntry = Record<string, string | number | undefined>;
 
+// ── Advanced technical signals (Feature 14) ──────────────────────────────────
+
+export interface Divergences {
+  rsi_bullish:  boolean;
+  rsi_bearish:  boolean;
+  macd_bullish: boolean;
+  macd_bearish: boolean;
+}
+
+export interface FeatureImportance {
+  feature:    string;
+  importance: number;   // 0–1, top-5 normalised to sum 1.0
+}
+
+export interface EarningsSurprise {
+  quarter:      string;
+  estimate:     number | null;
+  actual:       number | null;
+  surprise_pct: number | null;
+}
+
+// Sub-panel indicators toggleable on the price chart (persisted in localStorage).
+export type SubPanelKey = 'stoch' | 'adx' | 'obv';
+
 export type IndicatorKey = 'bb' | 'sma' | 'ema' | 'macd' | 'rsi' | 'volume';
 
 export interface TradeSetupResponse {
@@ -156,6 +195,8 @@ export interface TradeSetupResponse {
   risk_per_share:          number;
   risk_pct:                number;
   suggested_position_pct:  number;
+  atr_14?:                 number | null;
+  atr_multiplier?:         number | null;
 }
 
 export interface ChatMessage {


### PR DESCRIPTION
@
## Feature 14 — Advanced Technical Signals

Five targeted signal improvements that sharpen the trade setup and surface reversal/strength cues, shipped together.

### What changed

**1. ATR-based adaptive stops** (`routers/trade.py`)
- New `atr_14` + `conservative` request fields. When `atr_14` is supplied, the stop is placed `entry ∓ k×ATR` (k=**2.0** default, **2.5** conservative) instead of a flat %, **hard-capped at 8%** from entry. Falls back to the support/resistance % stop when ATR is absent (anon/legacy callers).
- Stop formula (long): `stop = max(entry_mid − k·ATR, entry_mid·0.92)`; (short): `stop = min(entry_mid + k·ATR, entry_mid·1.08)`.
- Response adds `atr_14` + `atr_multiplier`.

**2. RSI + MACD divergence** (`models.py::detect_divergences`)
- `scipy.signal.find_peaks` over the last 20 bars (troughs/peaks ≥5 bars apart). Bullish = price lower-low + indicator higher-low; bearish = price higher-high + indicator lower-high. Run for both RSI and the MACD histogram. All-false under 30 bars; wrapped — never raises.
- Injected into the analyst-jury context **and** each persona system prompt; surfaced as coloured chart badges.

**3. Earnings surprise history** — `YFinanceService.fetch_earnings_surprise` (last 4 quarters from yfinance `earnings_history`, Redis-cached 24h, `[]` on failure). Collapsible table in the fundamentals panel.

**4. RF feature importance** — threaded out of `_rf_forecast` (now returns `(forecast, importances)`); top-5 normalised to 1.0, sorted desc. New `ModelFeatureImportanceBar` below the ensemble-weights bar.

**5. Stochastic / ADX / OBV sub-panels** — new `models.py` helpers; rendered in `SignalPanels` (Stoch/ADX gauges with 20/80 & 25 reference lines, OBV 30-value area chart) below the chart, toggle persisted in `localStorage` (default hidden).

### New `/predict` indicator fields
`atr_14`, `stoch_k`, `stoch_d`, `adx_14`, `plus_di`, `minus_di`, `obv_history` (last 30), `divergences` `{rsi_bullish, rsi_bearish, macd_bullish, macd_bearish}`, `rf_feature_importance` (top-5), `earnings_surprise` (last 4Q).

### Testing
- 19 new backend tests (ATR known-fixture within 0.01, synthetic divergence true / flat false, Stochastic/ADX fixtures, OBV, RF top-5 sorted+normalised, earnings graceful `[]`, ATR-stop widening + 8% cap + conservative + fallback).
- Full suite: **230 passed**. `ruff check backend/` clean. `pnpm run lint` 0 errors. `pnpm run build` ✓.

### Notes
- scipy pinned in `requirements.txt` (already a transitive dep of prophet/scikit-learn).
- Backend sends scalar Stoch/ADX (latest values) + OBV history; the sub-panels render gauges accordingly rather than full per-bar lightweight-charts panes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Advanced Technical Signals” to charts: Stochastic, ADX (+DI/−DI), OBV history, plus RSI/MACD divergence badges (shown on the 2Y view).
  * Trade setups now support ATR-14 adaptive stop-loss, including conservative mode and an 8% safety cap; UI shows ATR configuration details.
  * Introduced RandomForest top feature-importance bar and earnings surprise history (last 4 quarters) with beat/miss context.
* **Documentation**
  * Documented Advanced Technical Signals (Feature 14) across the product, including new indicator fields and UI behavior.
* **Tests**
  * Added coverage for advanced indicators, RF importance output, earnings-surprise fallback, and ATR stop-loss rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->