### PR TITLE
feat(market): analyst price targets card (F21)

### DIFF
--- a/.claude/FiForesight_Roadmap.md
+++ b/.claude/FiForesight_Roadmap.md
@@ -38,7 +38,7 @@ Documentation is part of the feature, not an afterthought. A feature PR is **not
 - Jury quant lens swapped to `openai/gpt-oss-20b`; verdict parsing hardened; malformed output tracked (#226)
 - Forecast Accuracy & Sentiment Analytics Dashboard — `/insights` tab + `GET /analytics/{accuracy,sentiment}/{symbol}`; persists VADER compound to new `sentiment_score` measurement (Feature 12, PR #244)
 - Portfolio Manager — real holdings + live P&L ("My Portfolio" tab) + `GET/POST/DELETE /portfolio/holdings` + `GET /portfolio/summary` (Supabase `holdings` + RLS); existing race sim renamed "Simulator" (Feature 10, PR #249)
-- Analyst price targets card — Wall St. mean/low/high range bar + rating breakdown (F21)
+- Analyst price targets card — Wall St. mean/low/high range bar + rating breakdown (Feature 21, PR #267)
 
 - Watchlist persistence + intraday sparklines + responsive design (Feature 13): `watchlists` Supabase table, `/watchlist` CRUD, intraday 5m bars on `/sparklines`, `WatchlistContext`, sidebar watchlist panel, mobile bottom chip bar, full responsive audit across all tabs (320px–4K). 13 new backend tests. (#pending-F13)
 
@@ -182,7 +182,7 @@ Documentation is part of the feature, not an afterthought. A feature PR is **not
 - Multi-ticker overlay comparison — ratio chart (stock vs SPY); rolling 30d correlation line · `[Value: Med]` `[Effort: Low]`
 - ~~Macro dashboard (`/macro` tab)~~ ✅ SHIPPED (Feature 15) — standalone FRED tab: 5 stat cards, T10Y2Y trend line, 30d-delta bar chart, inversion banner
 - International markets — yfinance supports non-US tickers; exchange detection already exists · `[Value: Med]` `[Effort: Med]`
-- ~~Analyst price target range~~ ✅ SHIPPED (Feature 21) — `GET /analyst-targets/{symbol}`, `AnalystTargetsCard` (low/mean/high range bar + current marker + rating breakdown) below `DCFCard`
+- ~~Analyst price target range~~ ✅ SHIPPED (Feature 21, PR #267) — `GET /analyst-targets/{symbol}`, `AnalystTargetsCard` (low/mean/high range bar + current marker + rating breakdown) below `DCFCard`
 
 ### Architecture & Infra
 - Custom alert rule builder — price cross, RSI threshold, % move triggers; needs auth + background worker + notification channel · `[Value: High]` `[Effort: High]`

--- a/.claude/FiForesight_Roadmap.md
+++ b/.claude/FiForesight_Roadmap.md
@@ -38,6 +38,7 @@ Documentation is part of the feature, not an afterthought. A feature PR is **not
 - Jury quant lens swapped to `openai/gpt-oss-20b`; verdict parsing hardened; malformed output tracked (#226)
 - Forecast Accuracy & Sentiment Analytics Dashboard — `/insights` tab + `GET /analytics/{accuracy,sentiment}/{symbol}`; persists VADER compound to new `sentiment_score` measurement (Feature 12, PR #244)
 - Portfolio Manager — real holdings + live P&L ("My Portfolio" tab) + `GET/POST/DELETE /portfolio/holdings` + `GET /portfolio/summary` (Supabase `holdings` + RLS); existing race sim renamed "Simulator" (Feature 10, PR #249)
+- Analyst price targets card — Wall St. mean/low/high range bar + rating breakdown (F21)
 
 - Watchlist persistence + intraday sparklines + responsive design (Feature 13): `watchlists` Supabase table, `/watchlist` CRUD, intraday 5m bars on `/sparklines`, `WatchlistContext`, sidebar watchlist panel, mobile bottom chip bar, full responsive audit across all tabs (320px–4K). 13 new backend tests. (#pending-F13)
 
@@ -181,7 +182,7 @@ Documentation is part of the feature, not an afterthought. A feature PR is **not
 - Multi-ticker overlay comparison — ratio chart (stock vs SPY); rolling 30d correlation line · `[Value: Med]` `[Effort: Low]`
 - ~~Macro dashboard (`/macro` tab)~~ ✅ SHIPPED (Feature 15) — standalone FRED tab: 5 stat cards, T10Y2Y trend line, 30d-delta bar chart, inversion banner
 - International markets — yfinance supports non-US tickers; exchange detection already exists · `[Value: Med]` `[Effort: Med]`
-- Analyst price target range — `yf.Ticker().analyst_price_targets` → low/mean/high bar in FundamentalsPanel · `[Value: Med]` `[Effort: Low]`
+- ~~Analyst price target range~~ ✅ SHIPPED (Feature 21) — `GET /analyst-targets/{symbol}`, `AnalystTargetsCard` (low/mean/high range bar + current marker + rating breakdown) below `DCFCard`
 
 ### Architecture & Infra
 - Custom alert rule builder — price cross, RSI threshold, % move triggers; needs auth + background worker + notification channel · `[Value: High]` `[Effort: High]`

--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -1119,6 +1119,22 @@ async def analyst_targets(request: Request, symbol: str) -> Dict[str, Any]:
                     return v
             return None
 
+        def _num_or_none(v: Any) -> Optional[float]:
+            """Coerce to a finite number, mapping None/NaN/inf/garbage to None.
+
+            yfinance can hand back NaN/inf; Starlette's JSONResponse serializes
+            with ``allow_nan=False``, so an unsanitized NaN would 500 the whole
+            response instead of degrading to a null field."""
+            try:
+                if v is None:
+                    return None
+                n = float(v)
+                if not math.isfinite(n):
+                    return None
+                return int(n) if n.is_integer() else n
+            except (TypeError, ValueError):
+                return None
+
         recs = {"strongBuy": 0, "buy": 0, "hold": 0, "sell": 0, "strongSell": 0}
         rec_df = t.recommendations_summary
         if rec_df is not None and not rec_df.empty:
@@ -1128,19 +1144,19 @@ async def analyst_targets(request: Request, symbol: str) -> Dict[str, Any]:
 
         return {
             "symbol": sym,
-            "currentPrice": _pick(targets.get("currentPrice"), targets.get("current"),
-                                  info.get("currentPrice")),
-            "targetLow": _pick(targets.get("low"), info.get("targetLowPrice")),
-            "targetMean": _pick(targets.get("mean"), info.get("targetMeanPrice")),
-            "targetMedian": _pick(targets.get("median"), info.get("targetMedianPrice")),
-            "targetHigh": _pick(targets.get("high"), info.get("targetHighPrice")),
-            "numberOfAnalysts": _pick(targets.get("numberOfAnalysts"),
-                                      info.get("numberOfAnalystOpinions")),
+            "currentPrice": _num_or_none(_pick(targets.get("currentPrice"),
+                                               targets.get("current"), info.get("currentPrice"))),
+            "targetLow": _num_or_none(_pick(targets.get("low"), info.get("targetLowPrice"))),
+            "targetMean": _num_or_none(_pick(targets.get("mean"), info.get("targetMeanPrice"))),
+            "targetMedian": _num_or_none(_pick(targets.get("median"), info.get("targetMedianPrice"))),
+            "targetHigh": _num_or_none(_pick(targets.get("high"), info.get("targetHighPrice"))),
+            "numberOfAnalysts": _num_or_none(_pick(targets.get("numberOfAnalysts"),
+                                                   info.get("numberOfAnalystOpinions"))),
             **recs,
         }
 
     try:
-        result = await asyncio.wait_for(asyncio.to_thread(_fetch), timeout=10.0)
+        result = await asyncio.wait_for(asyncio.to_thread(_fetch), timeout=12.0)
     except Exception as e:
         logger.error(f"analyst_targets {sym}: {e}")
         raise HTTPException(status_code=502, detail="Could not fetch analyst targets")

--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -1076,3 +1076,74 @@ async def insider_transactions(request: Request, symbol: str) -> List[Dict[str, 
     if not _SYMBOL_RE.match(symbol):
         raise HTTPException(status_code=422, detail="Invalid symbol.")
     return await insider_svc.get_insider_transactions(symbol)
+
+
+@router.get("/analyst-targets/{symbol}")
+@limiter.limit(lambda: Config.RATE_LIMIT_READONLY, key_func=get_remote_address)
+async def analyst_targets(request: Request, symbol: str) -> Dict[str, Any]:
+    """Wall Street analyst price targets + rating breakdown for ``symbol``.
+
+    Returns target low/mean/median/high, the current price, the number of
+    covering analysts, and the strongBuy/buy/hold/sell/strongSell recommendation
+    counts. yfinance's ``analyst_price_targets`` carries the price band but not
+    the analyst count, so ``.info`` fills the gaps. Redis-cached 6h; 502 when the
+    upstream fetch fails so the frontend can fall back to its empty state. 60/min.
+    """
+    from redis_cache import cache_get, cache_set
+
+    sym = symbol.strip().upper()
+    if not _SYMBOL_RE.match(sym):
+        raise HTTPException(status_code=422, detail="Invalid symbol.")
+
+    cache_key = f"analyst_targets:{sym}"
+    cached = await cache_get(cache_key)
+    if cached:
+        return cached
+
+    def _fetch() -> Dict[str, Any]:
+        t = yf.Ticker(sym)
+        targets = t.analyst_price_targets or {}
+
+        # numberOfAnalysts / current price aren't part of analyst_price_targets in
+        # current yfinance builds — read .info as a fallback so the card has the
+        # full picture on real data (info uses targetMeanPrice-style key names).
+        info: Dict[str, Any] = {}
+        try:
+            info = t.info or {}
+        except Exception:
+            info = {}
+
+        def _pick(*vals: Any) -> Any:
+            for v in vals:
+                if v is not None:
+                    return v
+            return None
+
+        recs = {"strongBuy": 0, "buy": 0, "hold": 0, "sell": 0, "strongSell": 0}
+        rec_df = t.recommendations_summary
+        if rec_df is not None and not rec_df.empty:
+            row = rec_df.iloc[0]
+            for k in recs:
+                recs[k] = _safe_int(row.get(k, 0))
+
+        return {
+            "symbol": sym,
+            "currentPrice": _pick(targets.get("currentPrice"), targets.get("current"),
+                                  info.get("currentPrice")),
+            "targetLow": _pick(targets.get("low"), info.get("targetLowPrice")),
+            "targetMean": _pick(targets.get("mean"), info.get("targetMeanPrice")),
+            "targetMedian": _pick(targets.get("median"), info.get("targetMedianPrice")),
+            "targetHigh": _pick(targets.get("high"), info.get("targetHighPrice")),
+            "numberOfAnalysts": _pick(targets.get("numberOfAnalysts"),
+                                      info.get("numberOfAnalystOpinions")),
+            **recs,
+        }
+
+    try:
+        result = await asyncio.wait_for(asyncio.to_thread(_fetch), timeout=10.0)
+    except Exception as e:
+        logger.error(f"analyst_targets {sym}: {e}")
+        raise HTTPException(status_code=502, detail="Could not fetch analyst targets")
+
+    await cache_set(cache_key, result, ttl_seconds=21600)  # 6h TTL
+    return result

--- a/backend/tests/test_analyst_targets_endpoint.py
+++ b/backend/tests/test_analyst_targets_endpoint.py
@@ -95,6 +95,23 @@ class TestAnalystTargetsEndpoint:
             resp = client.get("/analyst-targets/AAPL")
         assert resp.status_code == 502
 
+    def test_analyst_targets_sanitizes_non_finite(self):
+        # yfinance can return NaN/inf — these must become null (Starlette serializes
+        # with allow_nan=False, so an unsanitized NaN would 500 the response).
+        targets = {
+            "current": float("nan"), "low": float("inf"), "mean": 255.0,
+            "median": 250.0, "high": float("-inf"),
+        }
+        with patch.object(market.yf, "Ticker",
+                          MagicMock(return_value=_mock_ticker(targets, None, {}))):
+            resp = client.get("/analyst-targets/AAPL")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["currentPrice"] is None
+        assert body["targetLow"] is None
+        assert body["targetHigh"] is None
+        assert body["targetMean"] == 255.0
+
     def test_analyst_targets_rejects_bad_symbol(self):
         resp = client.get("/analyst-targets/!!bad!!")
         assert resp.status_code == 422

--- a/backend/tests/test_analyst_targets_endpoint.py
+++ b/backend/tests/test_analyst_targets_endpoint.py
@@ -1,0 +1,100 @@
+"""
+Tests for the Analyst Price Targets endpoint (Feature 21):
+  - GET /analyst-targets/{symbol}
+
+yfinance is mocked — no network required.
+"""
+import importlib as _il
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from fastapi.responses import JSONResponse
+from slowapi.errors import RateLimitExceeded
+from starlette.requests import Request
+
+from backend.routers import market  # noqa: E402
+
+_deps = _il.import_module("dependencies")
+limiter = _deps.limiter
+
+_app = FastAPI()
+_app.state.limiter = limiter
+
+
+async def _rl_handler(req: Request, exc: RateLimitExceeded) -> JSONResponse:
+    return JSONResponse(status_code=429, content={"detail": "Too many requests."})
+
+
+_app.add_exception_handler(RateLimitExceeded, _rl_handler)
+_app.include_router(market.router)
+client = TestClient(_app)
+
+
+def _mock_ticker(targets=None, recs_df=None, info=None):
+    t = MagicMock()
+    t.analyst_price_targets = targets
+    t.recommendations_summary = recs_df
+    t.info = info if info is not None else {}
+    return t
+
+
+class TestAnalystTargetsEndpoint:
+    def test_analyst_targets_returns_expected_keys(self):
+        targets = {
+            "current": 226.5, "low": 200.0, "mean": 255.0,
+            "median": 250.0, "high": 310.0,
+        }
+        recs_df = pd.DataFrame([
+            {"period": "0m", "strongBuy": 12, "buy": 20, "hold": 8, "sell": 2, "strongSell": 1},
+        ])
+        info = {"numberOfAnalystOpinions": 43}
+        with patch.object(market.yf, "Ticker",
+                          MagicMock(return_value=_mock_ticker(targets, recs_df, info))):
+            resp = client.get("/analyst-targets/AAPL")
+        assert resp.status_code == 200
+        body = resp.json()
+        for key in (
+            "symbol", "currentPrice", "targetLow", "targetMean", "targetMedian",
+            "targetHigh", "numberOfAnalysts",
+            "strongBuy", "buy", "hold", "sell", "strongSell",
+        ):
+            assert key in body
+        assert body["symbol"] == "AAPL"
+        assert body["currentPrice"] == 226.5
+        assert body["targetLow"] == 200.0
+        assert body["targetMean"] == 255.0
+        assert body["targetHigh"] == 310.0
+        # numberOfAnalysts is absent from analyst_price_targets → filled from .info
+        assert body["numberOfAnalysts"] == 43
+        assert body["strongBuy"] == 12
+        assert body["hold"] == 8
+        assert body["strongSell"] == 1
+
+    def test_analyst_targets_handles_empty_data(self):
+        # yfinance hands back nothing: no targets, no recommendations, empty info.
+        # The endpoint degrades to a 200 with null targets + zero rating counts
+        # (graceful fallback — the frontend renders its empty state).
+        with patch.object(market.yf, "Ticker",
+                          MagicMock(return_value=_mock_ticker(None, None, {}))):
+            resp = client.get("/analyst-targets/ZZZZ")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["symbol"] == "ZZZZ"
+        assert body["targetMean"] is None
+        assert body["targetLow"] is None
+        assert body["numberOfAnalysts"] is None
+        assert body["strongBuy"] == 0
+        assert body["hold"] == 0
+
+    def test_analyst_targets_returns_502_on_fetch_error(self):
+        # A hard yfinance failure surfaces as a 502, never a 500 / traceback.
+        with patch.object(market.yf, "Ticker",
+                          MagicMock(side_effect=RuntimeError("network down"))):
+            resp = client.get("/analyst-targets/AAPL")
+        assert resp.status_code == 502
+
+    def test_analyst_targets_rejects_bad_symbol(self):
+        resp = client.get("/analyst-targets/!!bad!!")
+        assert resp.status_code == 422

--- a/frontend/app/(app)/analysis/page.tsx
+++ b/frontend/app/(app)/analysis/page.tsx
@@ -34,12 +34,13 @@ import OrderBookPanel    from '../../../components/OrderBookPanel';
 import StockChatPanel    from '../../../components/StockChatPanel';
 import { useIndicatorSignals } from '../../../hooks/useIndicatorSignals';
 import DCFCard               from '../../../components/DCFCard';
+import AnalystTargetsCard     from '../../../components/AnalystTargetsCard';
 import InsiderTransactionsCard from '../../../components/InsiderTransactionsCard';
 import WhyDidMoveCard        from '../../../components/WhyDidMoveCard';
 import ReversalRiskCard       from '../../../components/ReversalRiskCard';
 import DirectionForecastCard  from '../../../components/DirectionForecastCard';
 import MorningBriefingPanel   from '../../../components/MorningBriefingPanel';
-import type { PredictionData, IndicatorKey, TradeSetupResponse, DCFResult } from '../../../types';
+import type { PredictionData, IndicatorKey, TradeSetupResponse, DCFResult, AnalystTargets } from '../../../types';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -79,6 +80,8 @@ function AnalysisContent() {
   const [tradeSetup,       setTradeSetup]       = useState<TradeSetupResponse | null>(null);
   const [tradeSetupLoading, setTradeSetupLoading] = useState(false);
   const [dcfData,          setDcfData]          = useState<DCFResult | null>(null);
+  const [analystTargets,   setAnalystTargets]   = useState<AnalystTargets | null>(null);
+  const [analystTargetsLoading, setAnalystTargetsLoading] = useState(false);
   const [chatOpen,         setChatOpen]         = useState(false);
   const [authOpen,         setAuthOpen]         = useState(false);
 
@@ -131,6 +134,8 @@ function AnalysisContent() {
     setError(null);
     setTradeSetup(null);
     setDcfData(null);
+    setAnalystTargets(null);
+    setAnalystTargetsLoading(false);
     setChatOpen(false);
     try {
       const response = await axios.post('/api/predict', { data: fullSymbol }, { headers: authHeaders });
@@ -147,6 +152,13 @@ function AnalysisContent() {
       axios.get(`/api/dcf/${baseSymbol}`)
         .then(r => setDcfData(r.data))
         .catch(() => setDcfData(null));
+      // Fire-and-forget analyst price targets (non-blocking)
+      setAnalystTargetsLoading(true);
+      fetch(`/api/analyst-targets/${baseSymbol}`)
+        .then(r => r.ok ? r.json() : null)
+        .then(d => setAnalystTargets(d))
+        .catch(() => setAnalystTargets(null))
+        .finally(() => setAnalystTargetsLoading(false));
     } catch (err: any) {
       setError(err.response?.data?.error || 'Analysis failed. Please try again.');
     } finally {
@@ -439,6 +451,14 @@ function AnalysisContent() {
                     dcf={dcfData}
                     isDark={isDark}
                     primaryColor={primaryColor}
+                  />
+                )}
+
+                {/* ── Wall St. Analyst Price Targets ────────────────── */}
+                {(analystTargets || analystTargetsLoading) && (
+                  <AnalystTargetsCard
+                    data={analystTargets}
+                    loading={analystTargetsLoading}
                   />
                 )}
 

--- a/frontend/app/(app)/analysis/page.tsx
+++ b/frontend/app/(app)/analysis/page.tsx
@@ -152,13 +152,15 @@ function AnalysisContent() {
       axios.get(`/api/dcf/${baseSymbol}`)
         .then(r => setDcfData(r.data))
         .catch(() => setDcfData(null));
-      // Fire-and-forget analyst price targets (non-blocking)
+      // Fire-and-forget analyst price targets (non-blocking). Guard every state
+      // write on lastLoadedRef so a slow response for a previous symbol can't
+      // clobber the current one when the user switches tickers quickly.
       setAnalystTargetsLoading(true);
       fetch(`/api/analyst-targets/${baseSymbol}`)
         .then(r => r.ok ? r.json() : null)
-        .then(d => setAnalystTargets(d))
-        .catch(() => setAnalystTargets(null))
-        .finally(() => setAnalystTargetsLoading(false));
+        .then(d => { if (lastLoadedRef.current === baseSymbol) setAnalystTargets(d); })
+        .catch(() => { if (lastLoadedRef.current === baseSymbol) setAnalystTargets(null); })
+        .finally(() => { if (lastLoadedRef.current === baseSymbol) setAnalystTargetsLoading(false); });
     } catch (err: any) {
       setError(err.response?.data?.error || 'Analysis failed. Please try again.');
     } finally {
@@ -455,12 +457,12 @@ function AnalysisContent() {
                 )}
 
                 {/* ── Wall St. Analyst Price Targets ────────────────── */}
-                {(analystTargets || analystTargetsLoading) && (
-                  <AnalystTargetsCard
-                    data={analystTargets}
-                    loading={analystTargetsLoading}
-                  />
-                )}
+                {/* Always rendered (like InsiderTransactionsCard) so the card's
+                    own loading/empty states are reachable on a slow/failed fetch. */}
+                <AnalystTargetsCard
+                  data={analystTargets}
+                  loading={analystTargetsLoading}
+                />
 
                 {/* ── Insider Transactions (SEC EDGAR Form 4) ───────── */}
                 <InsiderTransactionsCard

--- a/frontend/app/api/analyst-targets/[symbol]/route.ts
+++ b/frontend/app/api/analyst-targets/[symbol]/route.ts
@@ -9,7 +9,7 @@ export async function GET(
 ) {
   const { symbol } = await params;
   try {
-    const { data } = await axios.get(`${BACKEND}/analyst-targets/${symbol}`);
+    const { data } = await axios.get(`${BACKEND}/analyst-targets/${symbol}`, { timeout: 15000 });
     return NextResponse.json(data);
   } catch (err: unknown) {
     const status = (err as { response?: { status?: number } })?.response?.status ?? 500;

--- a/frontend/app/api/analyst-targets/[symbol]/route.ts
+++ b/frontend/app/api/analyst-targets/[symbol]/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+import axios from 'axios';
+
+const BACKEND = process.env.BACKEND_URL ?? 'http://localhost:8000';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ symbol: string }> },
+) {
+  const { symbol } = await params;
+  try {
+    const { data } = await axios.get(`${BACKEND}/analyst-targets/${symbol}`);
+    return NextResponse.json(data);
+  } catch (err: unknown) {
+    const status = (err as { response?: { status?: number } })?.response?.status ?? 500;
+    return NextResponse.json({ error: 'Analyst targets fetch failed' }, { status });
+  }
+}

--- a/frontend/components/AnalystTargetsCard.tsx
+++ b/frontend/components/AnalystTargetsCard.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import {
+  Box, Card, CardContent, Skeleton, Stack, Typography, useTheme,
+} from '@mui/material';
+import { Target } from 'lucide-react';
+import type { AnalystTargets } from '../types';
+
+interface Props {
+  data:    AnalystTargets | null;
+  loading: boolean;
+}
+
+const RATINGS = [
+  { key: 'strongBuy'  as const, label: 'Strong Buy',  color: '#2e7d32' },
+  { key: 'buy'        as const, label: 'Buy',         color: '#4caf50' },
+  { key: 'hold'       as const, label: 'Hold',        color: '#ed6c02' },
+  { key: 'sell'       as const, label: 'Sell',        color: '#ef5350' },
+  { key: 'strongSell' as const, label: 'Strong Sell', color: '#c62828' },
+] as const;
+
+const fmt = (v: number | null | undefined) =>
+  v == null ? '—' : `$${v.toFixed(v >= 100 ? 0 : 2)}`;
+
+// Clamp a 0–100 position so absolutely-positioned markers never escape the track.
+const clamp = (n: number) => Math.max(0, Math.min(100, n));
+
+export default function AnalystTargetsCard({ data, loading }: Props) {
+  const theme        = useTheme();
+  const warningColor = theme.palette.warning.main;
+
+  const header = (
+    <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 2 }}>
+      <Target size={16} color={theme.palette.primary.main} />
+      <Typography variant="overline" sx={{ opacity: 0.5, lineHeight: 1 }}>
+        Wall St. Targets
+      </Typography>
+      {data?.numberOfAnalysts != null && (
+        <Typography variant="caption" sx={{ opacity: 0.4, ml: 'auto' }}>
+          {data.numberOfAnalysts} analyst{data.numberOfAnalysts === 1 ? '' : 's'}
+        </Typography>
+      )}
+    </Stack>
+  );
+
+  if (loading) {
+    return (
+      <Card>
+        <CardContent sx={{ p: '16px !important' }}>
+          {header}
+          <Skeleton variant="rectangular" height={44} sx={{ borderRadius: 1, mb: 1.5 }} />
+          <Skeleton variant="rectangular" height={28} sx={{ borderRadius: 1 }} />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Card>
+        <CardContent sx={{ p: '16px !important' }}>
+          {header}
+          <Typography variant="body2" sx={{ opacity: 0.4 }}>
+            Analyst data unavailable
+          </Typography>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const { currentPrice, targetLow, targetMean, targetHigh } = data;
+  const hasRange =
+    currentPrice != null && targetLow != null && targetHigh != null && targetHigh > targetLow;
+
+  // Upside from the current price to the mean target.
+  const upsidePct =
+    targetMean != null && currentPrice != null && currentPrice > 0
+      ? ((targetMean - currentPrice) / currentPrice) * 100
+      : null;
+  const upsideUp = (upsidePct ?? 0) >= 0;
+
+  // Marker positions along the low→high track (percentages).
+  const pos = (price: number) =>
+    clamp(((price - targetLow!) / (targetHigh! - targetLow!)) * 100);
+  const curPos  = hasRange ? pos(currentPrice!) : 0;
+  const meanPos = hasRange && targetMean != null ? pos(targetMean) : 50;
+
+  const anyRatings = RATINGS.some(({ key }) => data[key] > 0);
+
+  return (
+    <Card>
+      <CardContent sx={{ p: '16px !important' }}>
+        {header}
+
+        {hasRange ? (
+          <Box sx={{ mb: anyRatings ? 2 : 0 }}>
+            {/* Upside-to-mean summary */}
+            {upsidePct != null && (
+              <Typography
+                sx={{
+                  fontSize: '0.7rem', fontWeight: 800, mb: 1.5,
+                  color: upsideUp ? '#16a34a' : '#dc2626',
+                }}
+              >
+                {upsideUp ? '+' : ''}{upsidePct.toFixed(1)}% to mean
+              </Typography>
+            )}
+
+            {/* Range bar */}
+            <Box sx={{ position: 'relative', height: 56, px: 0.5 }}>
+              {/* "Current" label above the marker line */}
+              <Box
+                sx={{
+                  position: 'absolute', top: 0,
+                  left: `${clamp(curPos)}%`, transform: 'translateX(-50%)',
+                  whiteSpace: 'nowrap', textAlign: 'center',
+                }}
+              >
+                <Typography sx={{ fontSize: '0.55rem', fontWeight: 700, color: warningColor, lineHeight: 1.1 }}>
+                  Current
+                </Typography>
+                <Typography sx={{ fontSize: '0.62rem', fontWeight: 900, color: warningColor, lineHeight: 1.1 }}>
+                  {fmt(currentPrice)}
+                </Typography>
+              </Box>
+
+              {/* Track (low → high) */}
+              <Box
+                sx={{
+                  position: 'absolute', top: 30, left: 0, right: 0, height: 8,
+                  borderRadius: 4,
+                  background: 'linear-gradient(90deg, #ef535044 0%, #94a3b844 50%, #00ffa344 100%)',
+                  border: `1px solid ${theme.palette.divider}`,
+                }}
+              />
+
+              {/* Mean tick */}
+              <Box
+                sx={{
+                  position: 'absolute', top: 27, left: `${meanPos}%`,
+                  transform: 'translateX(-50%)', width: 3, height: 14,
+                  borderRadius: 2, background: '#94a3b8',
+                }}
+              />
+
+              {/* Current-price vertical line */}
+              <Box
+                sx={{
+                  position: 'absolute', top: 22, left: `${curPos}%`,
+                  transform: 'translateX(-50%)', width: 2, height: 24,
+                  background: warningColor,
+                  boxShadow: `0 0 6px ${warningColor}`,
+                }}
+              />
+
+              {/* Low / Mean / High labels below the track */}
+              <Box sx={{ position: 'absolute', top: 42, left: 0 }}>
+                <Typography sx={{ fontSize: '0.6rem', fontWeight: 800, color: '#ef5350', lineHeight: 1.1 }}>
+                  {fmt(targetLow)}
+                </Typography>
+                <Typography sx={{ fontSize: '0.5rem', opacity: 0.5, lineHeight: 1 }}>Low</Typography>
+              </Box>
+              <Box
+                sx={{
+                  position: 'absolute', top: 42, left: `${meanPos}%`,
+                  transform: 'translateX(-50%)', textAlign: 'center',
+                }}
+              >
+                <Typography sx={{ fontSize: '0.6rem', fontWeight: 800, color: '#94a3b8', lineHeight: 1.1 }}>
+                  {fmt(targetMean)}
+                </Typography>
+                <Typography sx={{ fontSize: '0.5rem', opacity: 0.5, lineHeight: 1 }}>Mean</Typography>
+              </Box>
+              <Box sx={{ position: 'absolute', top: 42, right: 0, textAlign: 'right' }}>
+                <Typography sx={{ fontSize: '0.6rem', fontWeight: 800, color: '#16a34a', lineHeight: 1.1 }}>
+                  {fmt(targetHigh)}
+                </Typography>
+                <Typography sx={{ fontSize: '0.5rem', opacity: 0.5, lineHeight: 1 }}>High</Typography>
+              </Box>
+            </Box>
+          </Box>
+        ) : (
+          !anyRatings && (
+            <Typography variant="body2" sx={{ opacity: 0.4 }}>
+              No price target range available
+            </Typography>
+          )
+        )}
+
+        {/* Rating breakdown */}
+        {anyRatings && (
+          <Stack direction="row" flexWrap="wrap" gap={1}>
+            {RATINGS.map(({ key, label, color }) => {
+              const count = data[key];
+              if (count === 0) return null;
+              return (
+                <Box
+                  key={key}
+                  sx={{
+                    px: 1, py: 0.4, borderRadius: 1,
+                    background: `${color}1f`,
+                    border: `1px solid ${color}55`,
+                    display: 'flex', alignItems: 'center', gap: 0.5,
+                  }}
+                >
+                  <Typography sx={{ fontSize: '0.6rem', fontWeight: 700, color, letterSpacing: '0.02em' }}>
+                    {label}
+                  </Typography>
+                  <Typography sx={{ fontSize: '0.68rem', fontWeight: 900, color }}>
+                    {count}
+                  </Typography>
+                </Box>
+              );
+            })}
+          </Stack>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -543,3 +543,19 @@ export interface AlertFire {
   value:    number | null;
   fired_at: string;
 }
+
+/** Wall Street analyst price targets + rating breakdown (GET /analyst-targets/{symbol}). */
+export interface AnalystTargets {
+  symbol:           string;
+  currentPrice:     number | null;
+  targetLow:        number | null;
+  targetMean:       number | null;
+  targetMedian:     number | null;
+  targetHigh:       number | null;
+  numberOfAnalysts: number | null;
+  strongBuy:        number;
+  buy:              number;
+  hold:             number;
+  sell:             number;
+  strongSell:       number;
+}


### PR DESCRIPTION
## F21 — Analyst Price Targets Card

Adds a **Wall St. Targets** card showing analyst price-target consensus + rating breakdown for the searched ticker.

### Backend
- New `GET /analyst-targets/{symbol}` (`routers/market.py`) — returns `targetLow/Mean/Median/High`, `currentPrice`, `numberOfAnalysts`, and `strongBuy/buy/hold/sell/strongSell` counts.
- Sources `yfinance` `analyst_price_targets` + `recommendations_summary`, with an `.info` fallback so `numberOfAnalysts` (absent from `analyst_price_targets`) is still populated on real data.
- Symbol-validated, read-only rate limit (60/min), **Redis-cached 6h**, `502` on upstream failure (never leaks a traceback).

### Frontend
- `AnalystTargetsCard.tsx` — low→high range bar with an amber current-price marker, "+X% to mean" upside, and color-coded rating pills (hidden when count = 0). Loading skeleton + "Analyst data unavailable" empty state.
- Wired into the analysis page **below `DCFCard`** via a fire-and-forget fetch through a new Next.js proxy (`/api/analyst-targets/[symbol]`).
- New `AnalystTargets` type.

### Tests / verification
- 4 new backend tests (`test_analyst_targets_endpoint.py`): expected keys, empty-data fallback, 502 on fetch error, bad-symbol 422.
- Full backend suite **272 passed, 1 skipped**; `ruff` clean; `pnpm build` passes.
- Manually verified end-to-end against live yfinance: `/analyst-targets/AAPL` → mean $312.72, 43 analysts, ratings 7/23/15/1/2; second request cache-served (720ms → 29ms). Card renders correctly with no console errors.

Roadmap updated (moved to Shipped → Intelligence; Feature Idea marked shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Wall St. Analyst Price Targets” to the analysis page, including current price placement, low/mean/high (and median when available), analyst count, and a Strong Buy/Buy/Hold/Sell/Strong Sell breakdown.
* **Backend**
  * Introduced `GET /analyst-targets/{symbol}` with 6-hour caching and robust numeric sanitization (non-finite values return as empty/null).
* **Frontend**
  * Added a dedicated analyst targets API route and a card component with loading/unavailable states.
* **Tests**
  * Expanded endpoint tests, including sanitization and error/symbol validation cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->