### PR TITLE
fix(data): keep short-history bars so newly-listed tickers don't 404

### DIFF
--- a/backend/services.py
+++ b/backend/services.py
@@ -1255,12 +1255,17 @@ class DataCleaner:
             logger.warning("[CLEANER] DataFrame empty after NaN/zero drop — returning empty")
             return df
 
-        # 2. Remove outliers: Close values > 4σ from rolling 30-day median
+        # 2. Remove outliers: Close values > 4σ from rolling 30-day median.
+        #    Rows where the band can't be computed (fewer than min_periods in the
+        #    window → NaN bounds) are KEPT, not dropped: a NaN comparison is False,
+        #    so without this guard a short history (e.g. a just-listed ticker with
+        #    <5 bars) would mask out every row → empty df → spurious 404.
         rolling_med = df["Close"].rolling(30, min_periods=5, center=True).median()
         rolling_std = df["Close"].rolling(30, min_periods=5, center=True).std()
         upper = rolling_med + 4 * rolling_std
         lower = rolling_med - 4 * rolling_std
-        mask  = (df["Close"] >= lower) & (df["Close"] <= upper)
+        band_unknown = upper.isna() | lower.isna()
+        mask  = band_unknown | ((df["Close"] >= lower) & (df["Close"] <= upper))
         removed = int((~mask).sum())
         if removed:
             logger.debug(

--- a/backend/tests/test_data_cleaner.py
+++ b/backend/tests/test_data_cleaner.py
@@ -1,0 +1,48 @@
+"""
+Regression tests for DataCleaner.clean() — short-history handling.
+
+A just-listed ticker (e.g. SPCX/SpaceX) can have only a couple of OHLCV bars.
+The 4σ outlier step uses rolling(min_periods=5); with <5 bars the rolling band
+is NaN, and a NaN comparison is False, so without a guard every row gets masked
+out → empty df → /predict spuriously 404s. These tests lock the fix in.
+"""
+import pandas as pd
+
+from backend.services import DataCleaner
+
+
+def _ohlcv(closes, start="2026-06-12"):
+    idx = pd.bdate_range(start=start, periods=len(closes), tz="UTC")
+    return pd.DataFrame(
+        {
+            "Open": closes,
+            "High": [c * 1.01 for c in closes],
+            "Low": [c * 0.99 for c in closes],
+            "Close": closes,
+            "Volume": [1_000_000] * len(closes),
+        },
+        index=idx,
+    )
+
+
+class TestDataCleanerShortHistory:
+    def test_two_bar_history_not_emptied(self):
+        # The SPCX case: 2 bars must survive cleaning (was → empty → 404).
+        df = _ohlcv([160.95, 192.50])
+        out = DataCleaner.clean(df)
+        assert not out.empty
+        assert len(out) >= 2
+
+    def test_four_bar_history_not_emptied(self):
+        # Anything below min_periods=5 previously wiped out.
+        df = _ohlcv([10.0, 11.0, 10.5, 12.0])
+        out = DataCleaner.clean(df)
+        assert not out.empty
+
+    def test_long_history_still_filters_outlier(self):
+        # Guard must not disable outlier removal for normal-length series.
+        closes = [100.0 + (i % 3) for i in range(60)]
+        closes[30] = 100_000.0  # blatant >4σ spike
+        out = DataCleaner.clean(_ohlcv(closes))
+        assert out["Close"].max() < 1_000.0  # the spike was removed
+        assert not out.empty


### PR DESCRIPTION
## Problem

Querying a freshly-listed ticker (e.g. **SPCX** / SpaceX, which began trading 2026-06-12 with only ~2 daily bars) returned **HTTP 404** from `/predict` — the app showed "Analysis failed."

## Root cause

`DataCleaner.clean()`'s 4σ outlier step computes a rolling band with `rolling(30, min_periods=5)`. When a ticker has **fewer than 5 bars**, every rolling window falls short of `min_periods`, so the rolling median/std are `NaN` → the `upper`/`lower` bounds are `NaN`. The keep-mask `(Close >= NaN) & (Close <= NaN)` is **all-False** (NaN comparisons are False), so **every row is dropped** → empty df → `/predict` raises `404 No usable data after cleaning`.

Confirmed via logs:
```
[YFINANCE] fetch_history — 2 rows for SPCX | 2026-06-12 → 2026-06-15
[STEP-1] DataCleaner returned empty df for SPCX — returning 404
```

## Fix

Keep rows whose outlier band can't be computed (NaN bounds), applying the 4σ filter only where it's actually defined:

```python
band_unknown = upper.isna() | lower.isna()
mask = band_unknown | ((df["Close"] >= lower) & (df["Close"] <= upper))
```

Outlier removal on normal-length series is unchanged (bands are defined there). The downstream ensemble already degrades gracefully below 20 bars (volatility-only low-confidence estimate), so short-history tickers now return a usable 200 instead of 404.

## Verification
- **Before:** `POST /predict {data: SPCX}` → 404.
- **After:** → **200**, price $192.50, 3 bars, 5-day forecast (low-confidence fallback). Renders in the app (chart + cards, no console errors); AAPL and other full-history tickers unaffected.
- New `backend/tests/test_data_cleaner.py`: 2-bar & 4-bar histories survive cleaning; a 60-bar series with a blatant >4σ spike still has the spike removed.
- Full backend suite: **276 passed, 1 skipped**; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)