### PR TITLE
fix(insider): populate Form 4 shares/price/type via XML enrichment

### DIFF
--- a/backend/services.py
+++ b/backend/services.py
@@ -1775,9 +1775,15 @@ class InsiderService:
 
     Uses the EDGAR full-text search index (``efts.sec.gov``) to find recent
     Form 4 filings for a symbol over the last 30 days, mapping each hit onto a
-    compact ``{filer, type, shares, price, date, sec_link}`` shape. The
-    full-text index carries filing metadata reliably (filer names, date, link);
-    transaction code/shares/price are surfaced when present, else ``None``.
+    compact ``{filer, type, shares, price, date, sec_link}`` shape.
+
+    The FTS index carries only filing *metadata* (filer, date, link) — the
+    transaction code/shares/price live in each filing's Form 4 *XML*. So each
+    filing is enriched in a second pass that fetches and parses its ownership
+    XML (``_enrich_rows`` → ``_parse_form4``), pulling the most-material
+    transaction's code/shares/price and the reporting owner's name. A filing
+    whose XML is missing/holdings-only keeps its metadata-only fallback
+    (type ``"Filing"``, shares/price ``None``) so the card still renders.
 
     Redis-cached 6h per symbol. Returns ``[]`` on any failure (never raises).
     """
@@ -1801,15 +1807,19 @@ class InsiderService:
         return "Filing"
 
     @staticmethod
-    def _sec_link(hit: dict, src: dict) -> str:
-        """Best-effort link to the filing on sec.gov from the FTS hit."""
-        _id = hit.get("_id") or ""
-        ciks = src.get("ciks") or []
-        cik = str(ciks[0]).lstrip("0") if ciks else ""
-        if _id and ":" in _id and cik:
-            accession, _, filename = _id.partition(":")
-            acc_nodash = accession.replace("-", "")
-            return f"https://www.sec.gov/Archives/edgar/data/{cik}/{acc_nodash}/{filename}"
+    def _issuer_cik(accession: str) -> str:
+        """The Form 4 filer-of-record CIK = the leading 10 digits of the accession
+        number (the issuer files on the insider's behalf). Used for the archive
+        path. Returns the un-padded CIK, or "" if the accession is malformed."""
+        head = (accession or "").split("-")[0]
+        return head.lstrip("0") if head.isdigit() else ""
+
+    @classmethod
+    def _sec_link(cls, accession: str, cik: str) -> str:
+        """Canonical human-readable filing-index page on sec.gov."""
+        acc_nodash = (accession or "").replace("-", "")
+        if cik and acc_nodash and accession:
+            return f"https://www.sec.gov/Archives/edgar/data/{cik}/{acc_nodash}/{accession}-index.htm"
         if cik:
             return f"https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&CIK={cik}&type=4"
         return "https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&type=4"
@@ -1822,24 +1832,127 @@ class InsiderService:
         except (TypeError, ValueError):
             return None
 
-    def _map_hit(self, hit: dict) -> Optional[dict]:
-        src = hit.get("_source") or {}
-        names = src.get("display_names") or []
-        # display_names is typically ["Issuer (CIK ...)", "Reporting Owner (CIK ...)"];
-        # the reporting owner (the insider) is the filer we want.
-        filer = ""
+    @classmethod
+    def _owner_from_names(cls, display_names: list, ciks: list, issuer_cik: str) -> str:
+        """Pick the reporting owner from the FTS display_names.
+
+        EDGAR lists ``display_names`` as ``[reporting owner, issuer]`` but the
+        order isn't guaranteed, so identify the owner as the first entry whose
+        CIK differs from the issuer's (the filer-of-record). Falls back to the
+        first name, then "Unknown".
+        """
+        names = display_names or []
+        try:
+            for nm, ck in zip(names, ciks or []):
+                if str(ck).lstrip("0") != str(issuer_cik):
+                    return str(nm).split(" (")[0].strip()
+        except Exception:
+            pass
         if names:
-            filer = str(names[-1]).split(" (")[0].strip()
-        shares = self._to_float(src.get("shares") or src.get("transaction_shares"))
-        price = self._to_float(src.get("price") or src.get("transaction_price"))
+            return str(names[0]).split(" (")[0].strip()
+        return "Unknown"
+
+    @classmethod
+    def _parse_form4(cls, content: bytes) -> dict:
+        """Parse a Form 4 ownership XML → the single most-material transaction.
+
+        Returns ``{owner, type, shares, price}`` (each ``None`` when absent).
+        Picks the transaction with the largest absolute share count across both
+        the non-derivative and derivative tables. Never raises — bad/partial XML
+        degrades to all-``None``.
+        """
+        out: dict = {"owner": None, "type": None, "shares": None, "price": None}
+        try:
+            root = ET.fromstring(content)
+        except Exception:
+            return out
+        owner = (root.findtext(".//reportingOwner/reportingOwnerId/rptOwnerName") or "").strip()
+        out["owner"] = owner or None
+        best = None  # (abs_shares, code, shares, price)
+        for tag in (".//nonDerivativeTransaction", ".//derivativeTransaction"):
+            for t in root.findall(tag):
+                code = t.findtext(".//transactionCoding/transactionCode")
+                shares = cls._to_float(t.findtext(".//transactionAmounts/transactionShares/value"))
+                price = cls._to_float(t.findtext(".//transactionAmounts/transactionPricePerShare/value"))
+                if shares is None:
+                    continue
+                if best is None or abs(shares) > best[0]:
+                    best = (abs(shares), code, shares, price)
+        if best is not None:
+            _, code, shares, price = best
+            out["type"] = cls._map_type(code)
+            out["shares"] = int(shares)
+            out["price"] = round(price, 2) if price is not None else None
+        return out
+
+    def _base_row(self, hit: dict) -> Optional[dict]:
+        """Metadata-only row from an FTS hit (the guaranteed fallback).
+
+        Carries private ``_accession``/``_filename``/``_cik`` keys consumed by the
+        XML-enrichment pass; these are stripped before the row is returned.
+        """
+        src = hit.get("_source") or {}
+        _id = hit.get("_id") or ""
+        accession, _, filename = _id.partition(":")
+        cik = self._issuer_cik(accession)
+        filer = self._owner_from_names(src.get("display_names"), src.get("ciks"), cik)
         return {
             "filer":    filer or "Unknown",
-            "type":     self._map_type(src.get("transaction_code") or src.get("type")),
-            "shares":   int(shares) if shares is not None else None,
-            "price":    round(price, 2) if price is not None else None,
+            "type":     "Filing",
+            "shares":   None,
+            "price":    None,
             "date":     str(src.get("file_date") or src.get("date") or "")[:10],
-            "sec_link": self._sec_link(hit, src),
+            "sec_link": self._sec_link(accession, cik),
+            "_accession": accession,
+            "_filename":  filename,
+            "_cik":       cik,
         }
+
+    _ARCHIVE_BASE = "https://www.sec.gov/Archives/edgar/data"
+    # Overall wall-clock cap on the XML-enrichment pass. Kept well inside the 12s
+    # _safe_fetch envelope /predict wraps this call in, so a slow SEC degrades to
+    # metadata-only rows rather than dropping the whole card.
+    _ENRICH_BUDGET = 7.0
+
+    async def _enrich_rows(self, client: "httpx.AsyncClient", rows: List[dict]) -> None:
+        """Fetch + parse each row's Form 4 XML to fill in type/shares/price/filer.
+
+        Concurrent (semaphore-bounded) with a per-fetch timeout and an overall
+        budget, so a slow/unreachable SEC can't blow the /predict deadline — rows
+        that don't enrich in time simply keep their metadata-only fallback.
+        """
+        sem = asyncio.Semaphore(5)
+
+        async def _one(row: dict) -> None:
+            accession, filename, cik = row["_accession"], row["_filename"], row["_cik"]
+            if not (accession and filename.endswith(".xml") and cik):
+                return
+            url = f"{self._ARCHIVE_BASE}/{cik}/{accession.replace('-', '')}/{filename}"
+            async with sem:
+                try:
+                    r = await asyncio.wait_for(client.get(url), timeout=6.0)
+                    if r.status_code != 200:
+                        return
+                    parsed = self._parse_form4(r.content)
+                except Exception as exc:
+                    logger.debug("[INSIDER] enrich %s failed: %s", filename, exc)
+                    return
+            if parsed.get("owner"):
+                row["filer"] = parsed["owner"]
+            if parsed.get("type"):
+                row["type"] = parsed["type"]
+            if parsed.get("shares") is not None:
+                row["shares"] = parsed["shares"]
+            if parsed.get("price") is not None:
+                row["price"] = parsed["price"]
+
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*(_one(r) for r in rows)), timeout=self._ENRICH_BUDGET
+            )
+        except asyncio.TimeoutError:
+            logger.warning("[INSIDER] XML enrichment exceeded %.0fs — returning partial",
+                           self._ENRICH_BUDGET)
 
     async def get_insider_transactions(self, symbol: str) -> List[dict]:
         from redis_cache import cache_get, cache_set
@@ -1866,21 +1979,33 @@ class InsiderService:
                 )
                 resp.raise_for_status()
                 raw = resp.json()
-            hits = ((raw or {}).get("hits", {}) or {}).get("hits", []) or []
-            result: List[dict] = []
-            for hit in hits[:10]:
-                try:
-                    mapped = self._map_hit(hit)
-                    if mapped:
-                        result.append(mapped)
-                except Exception as exc:
-                    logger.debug("[INSIDER] hit map error: %s", exc)
-                    continue
-            logger.info("[INSIDER] ✓ %s — %d Form 4 filings", sym, len(result))
+                hits = ((raw or {}).get("hits", {}) or {}).get("hits", []) or []
+                rows: List[dict] = []
+                for hit in hits[:10]:
+                    try:
+                        base = self._base_row(hit)
+                        if base:
+                            rows.append(base)
+                    except Exception as exc:
+                        logger.debug("[INSIDER] hit map error: %s", exc)
+                        continue
+                # Enrich each filing with the transaction details from its Form 4
+                # XML (the FTS index carries metadata only — no shares/price/code).
+                if rows:
+                    await self._enrich_rows(client, rows)
+
+            # Strip the private enrichment keys before returning/caching.
+            for row in rows:
+                for k in ("_accession", "_filename", "_cik"):
+                    row.pop(k, None)
+
+            enriched = sum(1 for r in rows if r["shares"] is not None)
+            logger.info("[INSIDER] ✓ %s — %d Form 4 filings (%d with txn detail)",
+                        sym, len(rows), enriched)
             # Cache real results 6h; an empty list briefly (1h) so a transient
             # failure self-heals rather than sticking for the full window.
-            await cache_set(cache_key, result, ttl_seconds=self._CACHE_TTL if result else 3600)
-            return result
+            await cache_set(cache_key, rows, ttl_seconds=self._CACHE_TTL if rows else 3600)
+            return rows
         except Exception as exc:
             logger.warning("[INSIDER] fetch failed for %s: %s — returning []", sym, exc)
             return []

--- a/backend/services.py
+++ b/backend/services.py
@@ -1846,8 +1846,9 @@ class InsiderService:
             for nm, ck in zip(names, ciks or []):
                 if str(ck).lstrip("0") != str(issuer_cik):
                     return str(nm).split(" (")[0].strip()
-        except Exception:
-            pass
+        except Exception as exc:
+            # Malformed display_names/ciks — fall through to the positional fallback.
+            logger.debug("[INSIDER] owner inference failed: %s", exc)
         if names:
             return str(names[0]).split(" (")[0].strip()
         return "Unknown"

--- a/backend/tests/test_alternative_data.py
+++ b/backend/tests/test_alternative_data.py
@@ -125,28 +125,98 @@ class TestFREDService:
 # InsiderService
 # ---------------------------------------------------------------------------
 
+# A minimal but realistic Form 4 ownership XML (issuer files for the insider).
+_FORM4_XML = b"""<?xml version="1.0"?>
+<ownershipDocument>
+  <reportingOwner>
+    <reportingOwnerId><rptOwnerName>John Smith</rptOwnerName></reportingOwnerId>
+  </reportingOwner>
+  <nonDerivativeTable>
+    <nonDerivativeTransaction>
+      <transactionCoding><transactionCode>P</transactionCode></transactionCoding>
+      <transactionAmounts>
+        <transactionShares><value>5000</value></transactionShares>
+        <transactionPricePerShare><value>132.00</value></transactionPricePerShare>
+        <transactionAcquiredDisposedCode><value>A</value></transactionAcquiredDisposedCode>
+      </transactionAmounts>
+    </nonDerivativeTransaction>
+  </nonDerivativeTable>
+</ownershipDocument>"""
+
+
 class TestInsiderService:
     def setup_method(self):
         self.svc = InsiderService()
 
     def _hit(self, **src: Any) -> dict:
+        # Real EDGAR FTS shape: display_names = [reporting owner, issuer], with an
+        # aligned ciks array; the accession prefix is the issuer's CIK (0000320193).
         base = {
-            "display_names": ["Apple Inc. (CIK 0000320193)", "John Smith (CIK 0001234567)"],
+            "display_names": ["John Smith (CIK 0007654321)", "Apple Inc. (CIK 0000320193)"],
+            "ciks": ["0007654321", "0000320193"],
             "file_date": "2026-05-01",
-            "ciks": ["0001234567"],
-            "transaction_code": "P",
-            "shares": 5000,
-            "price": 132.0,
         }
         base.update(src)
-        return {"_id": "0001234567-26-000001:wf-form4.xml", "_source": base}
+        return {"_id": "0000320193-26-000001:wf-form4.xml", "_source": base}
 
-    def test_maps_filing(self):
-        resp = MagicMock()
-        resp.raise_for_status = MagicMock()
-        resp.json.return_value = {"hits": {"hits": [self._hit()]}}
+    def _routed_get(self, fts_hits: list, xml_bytes: bytes = _FORM4_XML, xml_status: int = 200):
+        """AsyncMock .get that routes FTS-search vs Form 4 XML requests by URL."""
+        fts = MagicMock()
+        fts.raise_for_status = MagicMock()
+        fts.json.return_value = {"hits": {"hits": fts_hits}}
+
+        def _get(url, **kwargs):
+            if str(url).endswith(".xml"):
+                xml = MagicMock()
+                xml.status_code = xml_status
+                xml.content = xml_bytes
+                return xml
+            return fts
+
+        return AsyncMock(side_effect=_get)
+
+    # ── Pure XML parser ────────────────────────────────────────────────────
+    def test_parse_form4_extracts_txn(self):
+        out = self.svc._parse_form4(_FORM4_XML)
+        assert out["owner"] == "John Smith"
+        assert out["type"] == "Purchase"
+        assert out["shares"] == 5000
+        assert out["price"] == 132.0
+
+    def test_parse_form4_picks_largest_txn(self):
+        xml = b"""<ownershipDocument><nonDerivativeTable>
+          <nonDerivativeTransaction>
+            <transactionCoding><transactionCode>M</transactionCode></transactionCoding>
+            <transactionAmounts><transactionShares><value>100</value></transactionShares>
+              <transactionPricePerShare><value>10</value></transactionPricePerShare></transactionAmounts>
+          </nonDerivativeTransaction>
+          <nonDerivativeTransaction>
+            <transactionCoding><transactionCode>S</transactionCode></transactionCoding>
+            <transactionAmounts><transactionShares><value>900</value></transactionShares>
+              <transactionPricePerShare><value>50</value></transactionPricePerShare></transactionAmounts>
+          </nonDerivativeTransaction>
+        </nonDerivativeTable></ownershipDocument>"""
+        out = self.svc._parse_form4(xml)
+        assert out["type"] == "Sale"
+        assert out["shares"] == 900
+        assert out["price"] == 50.0
+
+    def test_parse_form4_bad_xml(self):
+        out = self.svc._parse_form4(b"not xml <<<")
+        assert out == {"owner": None, "type": None, "shares": None, "price": None}
+
+    def test_owner_from_names_skips_issuer(self):
+        # issuer CIK 320193 → the owner is the other entry
+        owner = self.svc._owner_from_names(
+            ["John Smith (CIK 0007654321)", "Apple Inc. (CIK 0000320193)"],
+            ["0007654321", "0000320193"], "320193",
+        )
+        assert owner == "John Smith"
+
+    # ── Full path with enrichment ──────────────────────────────────────────
+    def test_enriches_filing_from_xml(self):
         with patch("backend.services.httpx.AsyncClient",
-                   return_value=_async_client(AsyncMock(return_value=resp))):
+                   return_value=_async_client(self._routed_get([self._hit()]))):
             result = run(self.svc.get_insider_transactions("AAPL"))
         assert len(result) == 1
         f = result[0]
@@ -156,6 +226,20 @@ class TestInsiderService:
         assert f["price"] == 132.0
         assert f["date"] == "2026-05-01"
         assert f["sec_link"].startswith("https://www.sec.gov/")
+        # private enrichment keys must not leak into the response
+        assert not any(k.startswith("_") for k in f)
+
+    def test_metadata_only_when_xml_unavailable(self):
+        # XML 404 → row keeps its metadata-only fallback, still renders.
+        with patch("backend.services.httpx.AsyncClient",
+                   return_value=_async_client(self._routed_get([self._hit()], xml_status=404))):
+            result = run(self.svc.get_insider_transactions("AAPL"))
+        assert len(result) == 1
+        f = result[0]
+        assert f["filer"] == "John Smith"   # from display_names (issuer skipped)
+        assert f["type"] == "Filing"
+        assert f["shares"] is None
+        assert f["price"] is None
 
     def test_type_code_mapping(self):
         assert self.svc._map_type("P") == "Purchase"
@@ -167,11 +251,8 @@ class TestInsiderService:
 
     def test_caps_to_10_filings(self):
         hits = [self._hit() for _ in range(15)]
-        resp = MagicMock()
-        resp.raise_for_status = MagicMock()
-        resp.json.return_value = {"hits": {"hits": hits}}
         with patch("backend.services.httpx.AsyncClient",
-                   return_value=_async_client(AsyncMock(return_value=resp))):
+                   return_value=_async_client(self._routed_get(hits))):
             result = run(self.svc.get_insider_transactions("AAPL"))
         assert len(result) == 10
 
@@ -182,11 +263,8 @@ class TestInsiderService:
         assert result == []
 
     def test_empty_hits_returns_empty(self):
-        resp = MagicMock()
-        resp.raise_for_status = MagicMock()
-        resp.json.return_value = {"hits": {"hits": []}}
         with patch("backend.services.httpx.AsyncClient",
-                   return_value=_async_client(AsyncMock(return_value=resp))):
+                   return_value=_async_client(self._routed_get([]))):
             result = run(self.svc.get_insider_transactions("CRYPTO"))
         assert result == []
 


### PR DESCRIPTION
﻿## Problem

The **Insider Transactions** card (Feature 15) rendered every row as type **"Filing"** with **"—"** for Shares and Price, and showed the **issuer company name** as the Filer instead of the actual insider.



## Root cause

`InsiderService` only queried the EDGAR full-text search index (`efts.sec.gov`), which carries **filing metadata only** (filer, date, link). The transaction **code / shares / price live in each filing's Form 4 XML**, which was never fetched — so `src.get("shares")`/`price`/`transaction_code` were always `None` and `type` fell back to `"Filing"`. Separately, `display_names` is `[reporting owner, issuer]`, but the code read `[-1]` (the issuer), so the Filer column showed the company.

## Fix

`InsiderService` now enriches each FTS hit by fetching + parsing its **Form 4 ownership XML**:

- **`_parse_form4`** — pulls the most-material transaction's `transactionCode` / `transactionShares` / `transactionPricePerShare` (across non-derivative + derivative tables) and the `reportingOwnerId/rptOwnerName`. Never raises — bad/partial XML degrades to all-`None`.
- **`_enrich_rows`** — concurrent (semaphore 5), per-fetch **6s** timeout, **7s** overall budget, kept well inside the **12s `_safe_fetch`** envelope `/predict` wraps this call in. A filing whose XML is missing or holdings-only keeps its **metadata-only fallback** (type `"Filing"`, shares/price `None`) so the card still renders.
- **`_owner_from_names`** — Filer = reporting owner, identified by skipping the entry whose CIK matches the issuer (the accession-prefix CIK), so it's order-independent. The XML's owner name overrides it when available.
- **`_sec_link`** — now the canonical `{accession}-index.htm` filing page (human-readable) instead of the raw XML.

**Response shape is unchanged** (`{filer, type, shares, price, date, sec_link}`) — no frontend change needed.

## Verification

- Live local run (`LRCX`, cache-bypassed): real insider names, red **Sale** chips, **shares** (7,659 / 8,233 / 6,592), **prices** ($309.60 / $371.17 / $347.86). No console errors.
- `ruff check backend/` clean; **285 backend tests pass** (+5 new), 1 hmmlearn skip.
- Tests rewritten to the **real EDGAR FTS shape** ( `[owner, issuer]` + aligned CIKs) and a sample **Form 4 XML**, covering: XML parse, largest-transaction selection, bad XML, owner-vs-issuer disambiguation, full enrichment path, and the metadata-only fallback when the XML is unavailable.

## Notes for reviewer

- Adds up to N (≤10) extra SEC XML GETs per uncached symbol; bounded as above and **Redis-cached 6h** per symbol, so steady-state cost is unchanged.
- Rows that remain "Filing" / "—" are genuine holdings-only or derivative-only Form 4s with no priced transaction — correct, graceful behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

