### PR TITLE
feat(trade): label trade setups Long or Short

### DIFF
--- a/backend/routers/trade.py
+++ b/backend/routers/trade.py
@@ -105,6 +105,7 @@ class TradeSetupResponse(BaseModel):
     target_3: float
     risk_reward: str
     setup_type: str
+    direction: str          # "Long" | "Short" — trade side
     rationale: str
     risk_per_share: float
     risk_pct: float
@@ -209,6 +210,10 @@ async def trade_setup(request: Request, req: TradeSetupRequest, _user: str = Dep
         reward      = max(target_2 - entry_mid, 0.01)
         risk_reward = f"1:{reward / risk:.1f}"
 
+    # Trade side: a Bearish trend builds a short (stop above entry, targets
+    # below); anything else is a long. Mirrors the entry/stop/target geometry above.
+    direction = "Short" if req.trend == "Bearish" else "Long"
+
     # Setup type derived from trend + RSI
     rsi = req.rsi
     if req.trend == "Bullish" and rsi <= 40:
@@ -237,9 +242,9 @@ async def trade_setup(request: Request, req: TradeSetupRequest, _user: str = Dep
         user = (
             f"Symbol: {req.symbol} | Price: ${p:.2f} | RSI: {rsi:.1f} | "
             f"Trend: {req.trend} | Sentiment: {req.sentiment_label}\n"
-            f"Entry: ${entry_low:.2f}–${entry_high:.2f} | Stop: ${stop_loss:.2f} | "
-            f"Targets: ${target_1:.2f} / ${target_2:.2f} / ${target_3:.2f}\n"
-            f"Write one sentence explaining why this {setup_type} trade setup makes sense."
+            f"Side: {direction} | Entry: ${entry_low:.2f}–${entry_high:.2f} | "
+            f"Stop: ${stop_loss:.2f} | Targets: ${target_1:.2f} / ${target_2:.2f} / ${target_3:.2f}\n"
+            f"Write one sentence explaining why this {direction} {setup_type} trade setup makes sense."
         )
         raw = await analyst_jury_svc._call_groq("llama-3.3-70b-versatile", system, user)
         rationale = raw.strip()
@@ -263,6 +268,7 @@ async def trade_setup(request: Request, req: TradeSetupRequest, _user: str = Dep
         target_3=target_3,
         risk_reward=risk_reward,
         setup_type=setup_type,
+        direction=direction,
         rationale=rationale,
         risk_per_share=risk_ps,
         risk_pct=risk_pct_val,

--- a/backend/tests/test_routers.py
+++ b/backend/tests/test_routers.py
@@ -85,6 +85,7 @@ def test_trade_setup_bullish_oversold() -> None:
     assert resp.status_code == 200
     d = resp.json()
     assert d["setup_type"] == "Oversold Reversal"
+    assert d["direction"] == "Long"
     assert d["entry_low"] < d["entry_high"]
     assert d["stop_loss"] < d["entry_low"]
     assert d["target_1"] < d["target_2"] < d["target_3"]
@@ -111,6 +112,7 @@ def test_trade_setup_bearish_overbought() -> None:
     assert resp.status_code == 200
     d = resp.json()
     assert d["setup_type"] == "Overbought Fade"
+    assert d["direction"] == "Short"
     # Bearish: stop is above entry, targets descend
     assert d["stop_loss"] > d["entry_high"]
     assert d["target_1"] > d["target_2"]

--- a/frontend/components/TradeSetupCard.tsx
+++ b/frontend/components/TradeSetupCard.tsx
@@ -32,6 +32,18 @@ export default function TradeSetupCard({ setup, loading, isDark, primaryColor }:
             </Typography>
           </Stack>
           <Stack direction="row" spacing={1}>
+            {setup.direction && (
+              <Chip
+                label={setup.direction.toUpperCase()}
+                size="small"
+                sx={{
+                  fontSize: '0.65rem', fontWeight: 800, letterSpacing: '0.04em',
+                  background: `${setup.direction === 'Short' ? red : green}22`,
+                  color: setup.direction === 'Short' ? red : green,
+                  border: `1px solid ${setup.direction === 'Short' ? red : green}66`,
+                }}
+              />
+            )}
             <Chip
               label={setup.setup_type}
               size="small"

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -263,6 +263,7 @@ export interface TradeSetupResponse {
   target_3:                number;
   risk_reward:             string;
   setup_type:              string;
+  direction?:              'Long' | 'Short';   // trade side
   rationale:               string;
   risk_per_share:          number;
   risk_pct:                number;


### PR DESCRIPTION
## What

The Trade Setup card showed `setup_type` ("Range Consolidation", "Overbought Fade", …) and R:R, but never said **which side** the trade was. A setup with the stop *above* entry and targets *below* is clearly a short, yet nothing labeled it — you had to read the geometry (or the rationale) to tell.

This adds an explicit **LONG / SHORT** badge.

## Changes

- **Backend** (`routers/trade.py`): new `direction` field on `TradeSetupResponse`, derived from trend (`Bearish → Short`, else `Long`) — mirrors the existing entry/stop/target geometry. Also threaded into the Groq rationale prompt so the generated sentence stays coherent with the labeled side.
- **Frontend** (`TradeSetupCard.tsx`): a green **LONG** / red **SHORT** chip in the card header, next to the setup-type and R:R chips. `direction` added to the TS `TradeSetupResponse` type (optional, backward-compatible with any cached response).

## Verification

- `routers` tests assert `direction == "Long"` on the bullish path and `"Short"` on the bearish path (**37 pass**).
- `ruff check backend/` clean; `pnpm build` compiles.
- Note: the card itself is auth-gated (only fetched when signed in), so the badge was verified via the API contract + build rather than a local screenshot — it'll be visible on the signed-in preview.

## Out of scope (worth a follow-up?)

The **position-size %** ("1% rule") assumes cash equity. For leveraged products (futures/CFDs) the price levels (entry/stop/targets/R:R) transfer fine as a directional plan, but "% of portfolio" doesn't map to margin sizing. Could add an instrument-aware note later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)