### PR TITLE
Trade-setup coherence: real trend, forecast-aware gating, swing candle confirmation, fat-tailed MC + CFD framing

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -731,12 +731,16 @@ def detect_candle_patterns(
                         "description": "Long upper wick, small body — sellers rejected higher prices."}
 
         # ── Inside Bar (consolidation; direction neutral) ──
-        if h2 < h1 and l2 > l1:
+        # Require a real range on the last bar: a synthetic/flat live bar
+        # (h2 == l2, appended when the current day has no real bar yet) sits
+        # inside the prior range and would otherwise trip a false "Inside Bar".
+        if rng2 > 0 and h2 < h1 and l2 > l1:
             return {"pattern": "Inside Bar", "direction": "neutral",
                     "description": "Range contained within the prior bar — consolidation; breakout pending."}
 
         return None
-    except Exception:
+    except Exception as exc:
+        logger.debug("[CANDLE] detect_candle_patterns failed: %s", exc, exc_info=True)
         return None
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -616,6 +616,130 @@ def calculate_model_stats(prices: List[float]) -> Dict:
     return stats
 
 
+def classify_trend(
+    price: float,
+    sma50: Optional[float],
+    sma200: Optional[float],
+    trend_slope: Optional[float],
+    macd: Optional[float],
+    macd_signal: Optional[float],
+    rsi: Optional[float],
+) -> str:
+    """Composite short/medium-term trend label — "Bullish" | "Bearish" | "Neutral".
+
+    Replaces the old single-oscillator heuristic (``"Bullish" if rsi > 50``),
+    which mislabelled stocks (e.g. a name in a long-term uptrend reading
+    "Bearish" purely because RSI dipped below 50) and was the *sole* input to the
+    trade-setup direction. Here we average four independent structural/momentum
+    votes, each in {-1, +1}:
+
+      • price vs SMA50      — above = uptrend
+      • SMA50 vs SMA200     — golden/death cross context
+      • 20-day price slope  — sign of the recent drift
+      • MACD vs signal      — momentum confirmation
+
+    Each vote is skipped when its input is missing (so a <200-bar name still gets
+    a read from whatever is available). RSI is only a light tiebreaker inside the
+    neutral band — it never overrides structure. When no structural input exists
+    at all we fall back to the legacy RSI rule so the label is never empty.
+    """
+    score = 0.0
+    votes = 0
+    if sma50 is not None and price > 0:
+        score += 1 if price >= sma50 else -1
+        votes += 1
+    if sma50 is not None and sma200 is not None:
+        score += 1 if sma50 >= sma200 else -1
+        votes += 1
+    if trend_slope is not None and trend_slope != 0:
+        score += 1 if trend_slope > 0 else -1
+        votes += 1
+    if macd is not None and macd_signal is not None:
+        score += 1 if macd >= macd_signal else -1
+        votes += 1
+
+    if votes == 0:
+        # No structural signal available — keep the legacy behaviour as a floor.
+        return "Bullish" if (rsi if rsi is not None else 50) > 50 else "Bearish"
+
+    norm = score / votes          # -1 (all bearish) .. +1 (all bullish)
+    if norm >= 0.5:
+        return "Bullish"
+    if norm <= -0.5:
+        return "Bearish"
+    # Mixed structure — let RSI break the tie only when it is clearly stretched,
+    # otherwise call it honestly Neutral rather than forcing a side.
+    if rsi is not None:
+        if rsi >= 60:
+            return "Bullish"
+        if rsi <= 40:
+            return "Bearish"
+    return "Neutral"
+
+
+def detect_candle_patterns(
+    opens: List[float],
+    highs: List[float],
+    lows: List[float],
+    closes: List[float],
+) -> Optional[Dict]:
+    """Detect a confirmed candlestick pattern on the most recent daily bar.
+
+    Returns the single most significant pattern printed at the **last** bar — the
+    candle that would confirm/trigger a swing entry — or ``None``. Deterministic,
+    pure, and defensive: any length mismatch, missing value, or insufficient
+    history returns ``None`` so a bad bar never aborts ``/predict``.
+
+    Priority (strongest first): engulfing → hammer/shooting-star → inside bar.
+    Each result carries a ``direction`` (bullish / bearish / neutral) used to
+    decide whether it confirms a long or a short.
+    """
+    n = len(closes)
+    if n < 2 or not (len(opens) == len(highs) == len(lows) == n):
+        return None
+    try:
+        o1, h1, l1, c1 = opens[-2], highs[-2], lows[-2], closes[-2]   # prior bar
+        o2, h2, l2, c2 = opens[-1], highs[-1], lows[-1], closes[-1]   # last bar
+        if any(v is None for v in (o1, h1, l1, c1, o2, h2, l2, c2)):
+            return None
+
+        body2  = abs(c2 - o2)
+        rng2   = h2 - l2
+        upper2 = h2 - max(o2, c2)
+        lower2 = min(o2, c2) - l2
+
+        prev_bear = c1 < o1
+        prev_bull = c1 > o1
+        last_bull = c2 > o2
+        last_bear = c2 < o2
+
+        # ── Engulfing (strongest reversal signal) ──
+        if prev_bear and last_bull and o2 <= c1 and c2 >= o1 and body2 > 0:
+            return {"pattern": "Bullish Engulfing", "direction": "bullish",
+                    "description": "Last candle's body engulfs the prior down candle — bullish reversal."}
+        if prev_bull and last_bear and o2 >= c1 and c2 <= o1 and body2 > 0:
+            return {"pattern": "Bearish Engulfing", "direction": "bearish",
+                    "description": "Last candle's body engulfs the prior up candle — bearish reversal."}
+
+        # ── Hammer / Shooting Star (single-bar long-wick rejection) ──
+        if rng2 > 0 and body2 > 0:
+            if lower2 >= 2 * body2 and upper2 <= body2:
+                return {"pattern": "Hammer", "direction": "bullish",
+                        "description": "Long lower wick, small body — buyers rejected lower prices."}
+            if upper2 >= 2 * body2 and lower2 <= body2:
+                return {"pattern": "Shooting Star", "direction": "bearish",
+                        "description": "Long upper wick, small body — sellers rejected higher prices."}
+
+        # ── Inside Bar (consolidation; direction neutral) ──
+        if h2 < h1 and l2 > l1:
+            return {"pattern": "Inside Bar", "direction": "neutral",
+                    "description": "Range contained within the prior bar — consolidation; breakout pending."}
+
+        return None
+    except Exception:
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Per-model forecast helpers
 # ---------------------------------------------------------------------------
@@ -953,17 +1077,24 @@ def run_monte_carlo(
     closes: List[float],
     steps: int = 5,
     n_sims: int = 1000,
+    method: str = "bootstrap",
 ) -> Optional[Dict]:
     """
-    Geometric Brownian Motion Monte Carlo price path simulation.
+    Monte Carlo price-path simulation — fat-tailed by default.
 
-    Daily log-returns are simulated as:
+    ``method="bootstrap"`` (default): each simulated daily move is drawn (with
+    replacement) from THIS stock's *actual* historical daily log-returns. This
+    preserves the empirical fat tails and skew that a Normal/GBM model flattens,
+    so P10 / VaR-95 reflect the kind of moves the stock has really made rather
+    than an idealised bell curve that underestimates crashes.
+
+    ``method="normal"``: classic Geometric Brownian Motion fallback —
         Δlog(S_t) = (μ - σ²/2) + σ·Z_t,  Z_t ~ N(0,1)
-    and accumulated with np.cumsum to form each GBM path (Δt = 1 trading day).
+    used automatically when history is too short to bootstrap (<5 returns).
 
-    μ and σ are estimated from daily log-returns of closes.
-    Uses np.random.default_rng(seed=42) for reproducibility.
-    Returns None gracefully when fewer than 10 price points are available.
+    Paths are accumulated with np.cumsum (Δt = 1 trading day). μ and σ are
+    estimated from daily log-returns. Uses np.random.default_rng(seed=42) for
+    reproducibility. Returns None gracefully when <10 price points are available.
     """
     if len(closes) < 10:
         logger.warning(
@@ -978,15 +1109,24 @@ def run_monte_carlo(
         S0          = float(arr[-1])
 
         rng = np.random.default_rng(seed=42)
-        Z   = rng.standard_normal((n_sims, steps))
 
-        # GBM via cumulative log-returns (Δt = 1 trading day).
-        # Each column is an independent daily increment; np.cumsum builds
-        # temporally consistent Brownian-motion trajectories.
-        drift            = mu - 0.5 * sigma ** 2
-        step_log_returns = drift + sigma * Z          # per-step Δ log price
-        log_paths        = np.cumsum(step_log_returns, axis=1)
-        paths            = S0 * np.exp(log_paths)     # shape (n_sims, steps)
+        use_bootstrap = method == "bootstrap" and len(log_returns) >= 5
+        if use_bootstrap:
+            # Fat-tailed: resample the stock's real daily log-returns. Captures
+            # empirical tails + skew (a single −15% day in history can recur in a
+            # path), unlike the symmetric Normal which never produces moves it
+            # wasn't told to.
+            idx              = rng.integers(0, len(log_returns), size=(n_sims, steps))
+            step_log_returns = log_returns[idx]       # per-step Δ log price
+        else:
+            # Normal GBM fallback (thin-tailed). Δt = 1 trading day; np.cumsum
+            # builds temporally consistent Brownian-motion trajectories.
+            Z                = rng.standard_normal((n_sims, steps))
+            drift            = mu - 0.5 * sigma ** 2
+            step_log_returns = drift + sigma * Z
+
+        log_paths = np.cumsum(step_log_returns, axis=1)
+        paths     = S0 * np.exp(log_paths)            # shape (n_sims, steps)
 
         final     = paths[:, -1]
         p10       = float(np.percentile(final, 10))
@@ -1016,7 +1156,8 @@ def run_monte_carlo(
             })
 
         logger.info(
-            f"[MC] ✓ n_sims={n_sims}, steps={steps} | "
+            f"[MC] ✓ method={'bootstrap' if use_bootstrap else 'normal'}, "
+            f"n_sims={n_sims}, steps={steps} | "
             f"S0=${S0:.2f} → p10=${p10:.2f}, p50=${p50:.2f}, p90=${p90:.2f} | "
             f"prob_gain={prob_gain:.1f}%, VaR95=${var_95:.2f}"
         )

--- a/backend/routers/predict.py
+++ b/backend/routers/predict.py
@@ -21,7 +21,8 @@ from models import (
     calculate_macd, calculate_bollinger_bands, calculate_sma_series,
     calculate_ema_series, calculate_support_resistance,
     calculate_atr, calculate_stochastic, calculate_adx, calculate_obv,
-    detect_divergences, calculate_fibonacci_levels,
+    detect_divergences, calculate_fibonacci_levels, classify_trend,
+    detect_candle_patterns,
     _skill_to_weights,
 )
 from services import DataCleaner, ANALYST_PERSONAS
@@ -1414,6 +1415,9 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
     # Fibonacci retracement levels (Feature 25) — swing high/low over the chart
     # window. None when insufficient data; the frontend handles null gracefully.
     fibonacci = await asyncio.to_thread(calculate_fibonacci_levels, highs, lows)
+    # Candlestick pattern on the latest daily bar — the entry-trigger candle that
+    # confirms a swing setup. None when no pattern printed; never aborts /predict.
+    candle_pattern = await asyncio.to_thread(detect_candle_patterns, opens, highs, lows, closes)
     logger.info(
         "[STEP-4b#] ✓ Advanced signals — ATR-14=%s | Stoch %%K=%s %%D=%s | "
         "ADX=%s | OBV=%s pts | divergences=%s",
@@ -1877,6 +1881,24 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
     )
     logger.info(f"[REQUEST] ════════════════ /predict ← {symbol} complete ════════════════")
 
+    # ── Composite trend label ────────────────────────────────────────────────
+    # Replaces the old single-oscillator heuristic (`rsi > 50`). Blends price
+    # structure (SMA50/200) + 20-day slope + MACD so the header badge and the
+    # trade-setup direction reflect the actual trend, not just where RSI sits.
+    def _last_valid(seq):
+        return next((v for v in reversed(seq) if v is not None), None)
+
+    trend_label = classify_trend(
+        price        = live_price,
+        sma50        = _last_valid(sma50),
+        sma200       = _last_valid(sma200),
+        trend_slope  = forecast.get("stats", {}).get("trend_slope"),
+        macd         = _last_valid(macd_data["macd"]),
+        macd_signal  = _last_valid(macd_data["signal"]),
+        rsi          = rsi,
+    )
+    logger.info(f"[TREND] {symbol} composite trend → {trend_label} (RSI={rsi:.1f})")
+
     return PredictionResponse(
         symbol       = symbol,
         currentPrice = f"{live_price:.2f}",
@@ -1884,7 +1906,7 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
         prediction   = {
             "highRange": f"{forecast['high']:.2f}",
             "lowRange":  f"{forecast['low']:.2f}",
-            "trend":     "Bullish" if rsi > 50 else "Bearish",
+            "trend":     trend_label,
         },
         analystNote  = note,
         confidence   = forecast["conf"],
@@ -1910,6 +1932,7 @@ async def _predict_inner(payload: PredictRequest) -> PredictionResponse:
             "fibonacci":   fibonacci,
             "rf_feature_importance": forecast.get("rf_feature_importance", []),
             "earnings_surprise":     earnings_surprise,
+            "candle_pattern":        candle_pattern,
         },
         lastUpdated  = now.isoformat(),
         juryAnalysts  = jury,

--- a/backend/routers/trade.py
+++ b/backend/routers/trade.py
@@ -1,4 +1,5 @@
 # backend/routers/trade.py
+import asyncio
 import json
 import logging
 import re
@@ -392,7 +393,13 @@ async def trade_setup(request: Request, req: TradeSetupRequest, _user: str = Dep
                 f"Stop: ${stop_loss:.2f} | Targets: ${target_1:.2f} / ${target_2:.2f} / ${target_3:.2f}\n"
                 f"Write one sentence explaining why this {direction} {setup_type} trade setup makes sense."
             )
-            raw = await analyst_jury_svc._call_groq("llama-3.3-70b-versatile", system, user)
+            # Bound the external call (the httpx client allows up to 35s) so a
+            # slow Groq response can't hang the request — falls back to the
+            # template rationale below on timeout, same as any other failure.
+            raw = await asyncio.wait_for(
+                analyst_jury_svc._call_groq("llama-3.3-70b-versatile", system, user),
+                timeout=12.0,
+            )
             rationale = raw.strip()
         except Exception as exc:
             logger.warning("[TRADE-SETUP] Groq rationale failed: %s", exc)

--- a/backend/routers/trade.py
+++ b/backend/routers/trade.py
@@ -19,6 +19,13 @@ logger = logging.getLogger(__name__)
 # Regex matching the same safe-symbol set used by /jury/reanalyze and services.py
 _SYMBOL_RE = re.compile(r"^[A-Za-z0-9.\-:]{1,15}$")
 
+# Candlestick patterns recognised by models.detect_candle_patterns. The pattern
+# name arrives client→server, so we only echo it back into the trigger text when
+# it's one of these known values (never trust arbitrary strings).
+_KNOWN_PATTERNS = {
+    "Bullish Engulfing", "Bearish Engulfing", "Hammer", "Shooting Star", "Inside Bar",
+}
+
 # Strip newlines + ASCII control characters from context interpolation values
 _CTRL_RE = re.compile(r"[\x00-\x1f\x7f]")
 
@@ -50,6 +57,17 @@ class TradeSetupRequest(BaseModel):
     # compatibility — falls back to the support/resistance % stop when absent.
     atr_14: Optional[float] = None
     conservative: bool = False
+    # 5-day ensemble forecast central path endpoint (forecastDays[-1].predicted).
+    # When supplied, the setup is checked for coherence with the model: a short
+    # whose targets sit below a price the forecast projects HIGHER (or a long
+    # below a falling forecast) is flagged non-actionable instead of being shown
+    # as a tradeable edge. Optional for backward compatibility.
+    forecast_close: Optional[float] = None
+    # Latest daily candlestick pattern (from /predict indicators.candle_pattern).
+    # Turns the entry into a real trigger — "wait for X at $level" — and marks the
+    # setup confirmed when a matching reversal candle has already printed.
+    candle_pattern: Optional[str] = None
+    candle_pattern_dir: Optional[str] = None   # "bullish" | "bearish" | "neutral"
 
     @field_validator("symbol")
     @classmethod
@@ -66,6 +84,20 @@ class TradeSetupRequest(BaseModel):
     def validate_atr(cls, v: Optional[float]) -> Optional[float]:
         if v is not None and v < 0:
             raise ValueError("atr_14 must be non-negative")
+        return v
+
+    @field_validator("forecast_close")
+    @classmethod
+    def validate_forecast_close(cls, v: Optional[float]) -> Optional[float]:
+        if v is not None and v <= 0:
+            raise ValueError("forecast_close must be > 0")
+        return v
+
+    @field_validator("candle_pattern_dir")
+    @classmethod
+    def validate_candle_dir(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and v not in ("bullish", "bearish", "neutral"):
+            raise ValueError("candle_pattern_dir must be bullish, bearish, or neutral")
         return v
 
     @field_validator("current_price")
@@ -105,13 +137,28 @@ class TradeSetupResponse(BaseModel):
     target_3: float
     risk_reward: str
     setup_type: str
-    direction: str          # "Long" | "Short" — trade side
+    direction: str          # "Long" | "Short" | "Neutral" — trade side ("Neutral" = no clean setup)
     rationale: str
     risk_per_share: float
     risk_pct: float
     suggested_position_pct: float
     atr_14: Optional[float] = None
     atr_multiplier: Optional[float] = None
+    # Coherence gate: False when the setup contradicts the 5-day forecast, the
+    # trend is mixed, or reward < risk. The frontend mutes/hides the levels and
+    # surfaces `conflict_note` instead of presenting a misleading "edge".
+    actionable: bool = True
+    conflict_note: Optional[str] = None
+    # Swing entry trigger derived from the latest daily candle (Option A):
+    # entry_trigger = what to wait for; confirmation = "confirmed" | "pending".
+    entry_trigger: Optional[str] = None
+    confirmation: Optional[str] = None
+    # CFD-ready framing — the same setup expressed for a CFD broker (e.g. T212):
+    # which side to open, the margin a typical retail leverage implies, and the
+    # financing/spread caveats that erode a leveraged multi-day hold.
+    cfd_side: Optional[str] = None        # "Buy" | "Sell"
+    cfd_margin_pct: Optional[float] = None
+    cfd_note: Optional[str] = None
 
 
 @router.post("/trade-setup", response_model=TradeSetupResponse)
@@ -229,35 +276,137 @@ async def trade_setup(request: Request, req: TradeSetupRequest, _user: str = Dep
     else:
         setup_type = "Range Consolidation"
 
-    # Rationale via Groq (~80 tokens)
+    # ── Coherence gate (forecast-aware) ───────────────────────────────────────
+    # The trend chose the geometry above, but presenting a short whose targets
+    # sit below a price the 5-day model expects to RISE — or any setup that risks
+    # more than it can win — is exactly the contradiction users call out. Resolve
+    # it honestly: flag the setup non-actionable rather than dressing up a bad
+    # trade with entry/stop/target levels.
+    trend_dir = {"Bullish": "up", "Bearish": "down"}.get(req.trend, "flat")
+
+    forecast_dir = "flat"
+    if req.forecast_close is not None and req.forecast_close > 0:
+        if req.forecast_close > p * 1.01:        # >1% above spot over 5 days
+            forecast_dir = "up"
+        elif req.forecast_close < p * 0.99:
+            forecast_dir = "down"
+
+    rr_ratio = reward / risk          # both floored at 0.01 in the branches above
+    conflict = (
+        (trend_dir == "up"   and forecast_dir == "down") or
+        (trend_dir == "down" and forecast_dir == "up")
+    )
+
+    actionable    = True
+    conflict_note: Optional[str] = None
+    if trend_dir == "flat":
+        actionable    = False
+        direction     = "Neutral"
+        setup_type    = "No Clean Setup"
+        conflict_note = (
+            "Trend is mixed — no directional edge right now. Treat the entry zone as a "
+            "watch range, not a trade."
+        )
+    elif conflict:
+        actionable    = False
+        direction     = "Neutral"
+        setup_type    = "Conflicting Signals"
+        fdir = "higher" if forecast_dir == "up" else "lower"
+        conflict_note = (
+            f"Signals disagree: the {req.trend.lower()} trend favours a {trend_dir} move, "
+            f"but the 5-day forecast projects {fdir}. No clean trade — wait for them to align."
+        )
+    elif rr_ratio < 1.0:
+        actionable    = False
+        setup_type    = "Unfavorable R:R"
+        conflict_note = (
+            f"Risk outweighs reward at current levels (R:R {risk_reward}) — not a "
+            f"high-quality {direction.lower()} setup."
+        )
+
+    # ── Swing entry trigger (Option A — candle confirmation) ──────────────────
+    # A setup is a *plan*: wait for price to reach the entry zone AND for a
+    # confirming reversal candle, then enter. We surface that trigger explicitly
+    # instead of implying "enter now". `confirmation` is "confirmed" when a daily
+    # candle matching the side has already printed, else "pending".
+    entry_trigger: Optional[str] = None
+    confirmation: Optional[str]  = None
+    if actionable:
+        want_dir = "bullish" if direction == "Long" else "bearish"
+        pattern_ok = (
+            req.candle_pattern in _KNOWN_PATTERNS
+            and req.candle_pattern_dir == want_dir
+        )
+        if pattern_ok:
+            confirmation  = "confirmed"
+            entry_trigger = (
+                f"{req.candle_pattern} printed at the entry zone "
+                f"(${entry_low:.2f}–${entry_high:.2f}) — trigger active."
+            )
+        else:
+            confirmation  = "pending"
+            candles = "engulfing / hammer" if want_dir == "bullish" else "engulfing / shooting star"
+            entry_trigger = (
+                f"Wait for a {want_dir} reversal candle ({candles}) in the entry zone "
+                f"(${entry_low:.2f}–${entry_high:.2f}) before entering — don't chase."
+            )
+
+    # ── CFD-ready framing ─────────────────────────────────────────────────────
+    # The setup is instrument-agnostic; this expresses it for a CFD broker. KEY
+    # point: leverage only changes the *margin* posted — the risk is still the
+    # stop distance, so the 1%-rule size above is unchanged. We surface the side,
+    # the implied margin at a typical retail leverage, and the carrying costs that
+    # quietly erode a leveraged multi-day hold (financing per night + spread).
+    cfd_side: Optional[str]        = None
+    cfd_margin_pct: Optional[float] = None
+    cfd_note: Optional[str]        = None
+    if actionable:
+        cfd_leverage   = 5.0   # typical EU retail major-stock CFD cap (broker-dependent)
+        cfd_side       = "Buy" if direction == "Long" else "Sell"
+        cfd_margin_pct = round(100.0 / cfd_leverage, 1)
+        cfd_note = (
+            f"Place as a {cfd_side} CFD — same stop & targets. At {cfd_leverage:.0f}:1, "
+            f"margin ≈ {cfd_margin_pct:.0f}% of notional, but size by the stop (risk is "
+            f"unchanged). Budget spread + overnight financing (~4–5 nights on a 5-day "
+            f"swing); check your broker's rate."
+        )
+
+    # Rationale: a generated sentence for a real setup; the plain conflict note
+    # otherwise (also skips the Groq call when there's no edge to explain).
     rationale = (
         f"{setup_type} setup with RSI at {rsi:.0f} and a {req.trend.lower()} trend; "
         f"entry zone ${entry_low:.2f}–${entry_high:.2f} targets ${target_2:.2f}."
     )
-    try:
-        system = (
-            "You are a trading analyst. "
-            "Respond in exactly one plain-text sentence — no markdown, no bullet points."
-        )
-        user = (
-            f"Symbol: {req.symbol} | Price: ${p:.2f} | RSI: {rsi:.1f} | "
-            f"Trend: {req.trend} | Sentiment: {req.sentiment_label}\n"
-            f"Side: {direction} | Entry: ${entry_low:.2f}–${entry_high:.2f} | "
-            f"Stop: ${stop_loss:.2f} | Targets: ${target_1:.2f} / ${target_2:.2f} / ${target_3:.2f}\n"
-            f"Write one sentence explaining why this {direction} {setup_type} trade setup makes sense."
-        )
-        raw = await analyst_jury_svc._call_groq("llama-3.3-70b-versatile", system, user)
-        rationale = raw.strip()
-    except Exception as exc:
-        logger.warning("[TRADE-SETUP] Groq rationale failed: %s", exc)
+    if not actionable:
+        rationale = conflict_note or rationale
+    else:
+        try:
+            system = (
+                "You are a trading analyst. "
+                "Respond in exactly one plain-text sentence — no markdown, no bullet points."
+            )
+            user = (
+                f"Symbol: {req.symbol} | Price: ${p:.2f} | RSI: {rsi:.1f} | "
+                f"Trend: {req.trend} | Sentiment: {req.sentiment_label}\n"
+                f"Side: {direction} | Entry: ${entry_low:.2f}–${entry_high:.2f} | "
+                f"Stop: ${stop_loss:.2f} | Targets: ${target_1:.2f} / ${target_2:.2f} / ${target_3:.2f}\n"
+                f"Write one sentence explaining why this {direction} {setup_type} trade setup makes sense."
+            )
+            raw = await analyst_jury_svc._call_groq("llama-3.3-70b-versatile", system, user)
+            rationale = raw.strip()
+        except Exception as exc:
+            logger.warning("[TRADE-SETUP] Groq rationale failed: %s", exc)
 
     # Position sizing — 1% portfolio-risk rule.
     # 1.0 / risk_pct_decimal already yields position_pct (e.g. 5% risk → 20% position).
-    # Cap at 50% so a very tight stop doesn't suggest an outsized allocation.
+    # Cap at 50% so a very tight stop doesn't suggest an outsized allocation. A
+    # non-actionable setup suggests 0% — we don't size a trade we're not endorsing.
     entry_mid_final = (entry_low + entry_high) / 2
     risk_ps  = round(max(abs(entry_mid_final - stop_loss), 0.01), 4)
     risk_pct_val = round(risk_ps / entry_mid_final * 100, 2)
-    suggested_pct = round(min(1.0 / (risk_pct_val / 100), 50.0), 1)
+    suggested_pct = (
+        round(min(1.0 / (risk_pct_val / 100), 50.0), 1) if actionable else 0.0
+    )
 
     return TradeSetupResponse(
         entry_low=entry_low,
@@ -275,6 +424,13 @@ async def trade_setup(request: Request, req: TradeSetupRequest, _user: str = Dep
         suggested_position_pct=suggested_pct,
         atr_14=round(req.atr_14, 4) if use_atr else None,
         atr_multiplier=atr_multiplier,
+        actionable=actionable,
+        conflict_note=conflict_note,
+        entry_trigger=entry_trigger,
+        confirmation=confirmation,
+        cfd_side=cfd_side,
+        cfd_margin_pct=cfd_margin_pct,
+        cfd_note=cfd_note,
     )
 
 

--- a/backend/tests/test_advanced_signals.py
+++ b/backend/tests/test_advanced_signals.py
@@ -9,7 +9,8 @@ import pytest
 from backend.models import (
     MODELS_AVAILABLE,
     calculate_atr, calculate_stochastic, calculate_adx, calculate_obv,
-    detect_divergences, run_ensemble_forecast,
+    detect_divergences, run_ensemble_forecast, classify_trend,
+    detect_candle_patterns,
 )
 
 
@@ -206,3 +207,120 @@ def test_fetch_earnings_surprise_graceful_on_raise(monkeypatch):
     monkeypatch.setattr(services, "yf", type("YF", (), {"Ticker": staticmethod(_boom)}))
     monkeypatch.setattr(services, "YFINANCE_AVAILABLE", True)
     assert svc.fetch_earnings_surprise("AAPL") == []
+
+
+# == classify_trend (composite trend label) =================================
+
+def test_classify_trend_all_bullish():
+    """Price > SMA50 > SMA200, positive slope, MACD > signal → Bullish."""
+    assert classify_trend(
+        price=110.0, sma50=105.0, sma200=100.0,
+        trend_slope=0.5, macd=1.2, macd_signal=0.8, rsi=58.0,
+    ) == "Bullish"
+
+
+def test_classify_trend_all_bearish():
+    assert classify_trend(
+        price=90.0, sma50=95.0, sma200=100.0,
+        trend_slope=-0.5, macd=0.4, macd_signal=0.9, rsi=42.0,
+    ) == "Bearish"
+
+
+def test_classify_trend_mixed_is_neutral():
+    """Long-term up (price>SMA200, SMA50>SMA200) but short-term down (slope<0,
+    MACD<signal) and a mid RSI → honestly Neutral, not forced to a side."""
+    label = classify_trend(
+        price=101.0, sma50=100.0, sma200=98.0,
+        trend_slope=-0.3, macd=0.2, macd_signal=0.5, rsi=50.0,
+    )
+    assert label == "Neutral"
+
+
+def test_classify_trend_mixed_rsi_breaks_tie_when_stretched():
+    """Same mixed structure, but a stretched RSI tips the neutral band."""
+    assert classify_trend(
+        price=101.0, sma50=100.0, sma200=98.0,
+        trend_slope=-0.3, macd=0.2, macd_signal=0.5, rsi=65.0,
+    ) == "Bullish"
+    assert classify_trend(
+        price=101.0, sma50=100.0, sma200=98.0,
+        trend_slope=-0.3, macd=0.2, macd_signal=0.5, rsi=35.0,
+    ) == "Bearish"
+
+
+def test_classify_trend_no_structure_falls_back_to_rsi():
+    """With no SMAs/slope/MACD, the legacy RSI>50 rule is the floor (never empty)."""
+    assert classify_trend(
+        price=100.0, sma50=None, sma200=None,
+        trend_slope=None, macd=None, macd_signal=None, rsi=55.0,
+    ) == "Bullish"
+    assert classify_trend(
+        price=100.0, sma50=None, sma200=None,
+        trend_slope=None, macd=None, macd_signal=None, rsi=45.0,
+    ) == "Bearish"
+
+
+# == detect_candle_patterns (daily candle confirmation) =====================
+
+def test_candle_bullish_engulfing():
+    # prior bearish (100→96), last bullish body engulfs it (95→102)
+    op = [100.0, 95.0]
+    hi = [101.0, 103.0]
+    lo = [95.0, 94.0]
+    cl = [96.0, 102.0]
+    out = detect_candle_patterns(op, hi, lo, cl)
+    assert out and out["pattern"] == "Bullish Engulfing" and out["direction"] == "bullish"
+
+
+def test_candle_bearish_engulfing():
+    # prior bullish (100→104), last bearish body engulfs it (105→99)
+    op = [100.0, 105.0]
+    hi = [105.0, 106.0]
+    lo = [99.0, 98.0]
+    cl = [104.0, 99.0]
+    out = detect_candle_patterns(op, hi, lo, cl)
+    assert out and out["pattern"] == "Bearish Engulfing" and out["direction"] == "bearish"
+
+
+def test_candle_hammer():
+    # last bar: small body near top, long lower wick (lower >= 2x body)
+    op = [100.0, 100.0]
+    hi = [101.0, 101.5]
+    lo = [98.0, 96.0]
+    cl = [99.0, 101.0]
+    out = detect_candle_patterns(op, hi, lo, cl)
+    assert out and out["pattern"] == "Hammer" and out["direction"] == "bullish"
+
+
+def test_candle_shooting_star():
+    # last bar: small body near bottom, long upper wick (upper >= 2x body).
+    # prior bar bearish so the engulfing checks don't fire first.
+    op = [105.0, 101.0]
+    hi = [106.0, 106.0]
+    lo = [99.0, 99.5]
+    cl = [100.0, 100.0]
+    out = detect_candle_patterns(op, hi, lo, cl)
+    assert out and out["pattern"] == "Shooting Star" and out["direction"] == "bearish"
+
+
+def test_candle_inside_bar():
+    # last range contained in prior; not engulfing/hammer/star → Inside Bar (neutral)
+    op = [100.0, 98.0]
+    hi = [110.0, 105.0]
+    lo = [90.0, 95.0]
+    cl = [108.0, 102.0]
+    out = detect_candle_patterns(op, hi, lo, cl)
+    assert out and out["pattern"] == "Inside Bar" and out["direction"] == "neutral"
+
+
+def test_candle_none_when_no_pattern():
+    op = [100.0, 100.5]
+    hi = [110.0, 110.5]
+    lo = [90.0, 90.2]
+    cl = [100.2, 100.4]
+    assert detect_candle_patterns(op, hi, lo, cl) is None
+
+
+def test_candle_insufficient_or_mismatched_returns_none():
+    assert detect_candle_patterns([100.0], [101.0], [99.0], [100.0]) is None
+    assert detect_candle_patterns([100.0, 101.0], [101.0], [99.0], [100.0, 101.0]) is None

--- a/backend/tests/test_monte_carlo.py
+++ b/backend/tests/test_monte_carlo.py
@@ -70,3 +70,29 @@ def test_monte_carlo_determinism():
     assert r1["p50"] == r2["p50"]
     assert r1["p10"] == r2["p10"]
     assert r1["p90"] == r2["p90"]
+
+
+def _skewed_crash_history():
+    """Strongly negatively-skewed history: many tiny ups, rare large crashes."""
+    closes = [100.0]
+    for i in range(120):
+        closes.append(closes[-1] * (0.85 if i % 30 == 0 else 1.002))
+    return closes
+
+
+def test_monte_carlo_bootstrap_is_default_and_fatter_downside():
+    """Bootstrap (default) should carry the real crash tail — a heavier downside
+    than the symmetric Normal GBM on the same negatively-skewed history."""
+    closes = _skewed_crash_history()
+    boot = run_monte_carlo(closes, steps=5, n_sims=4000)                     # default
+    norm = run_monte_carlo(closes, steps=5, n_sims=4000, method="normal")
+    assert boot["p10"] <= norm["p10"]      # heavier left tail
+    assert boot["var_95"] >= 0
+
+
+def test_monte_carlo_falls_back_to_normal_on_short_history():
+    """With <5 returns, bootstrap isn't viable → Normal path still produces output."""
+    result = run_monte_carlo([100.0, 101.0, 99.0, 102.0, 100.5, 101.5,
+                              103.0, 102.0, 104.0, 103.5, 105.0], steps=5, n_sims=200)
+    assert result is not None
+    assert result["p10"] <= result["p50"] <= result["p90"]

--- a/backend/tests/test_monte_carlo.py
+++ b/backend/tests/test_monte_carlo.py
@@ -90,9 +90,11 @@ def test_monte_carlo_bootstrap_is_default_and_fatter_downside():
     assert boot["var_95"] >= 0
 
 
-def test_monte_carlo_falls_back_to_normal_on_short_history():
-    """With <5 returns, bootstrap isn't viable → Normal path still produces output."""
+def test_monte_carlo_normal_method_produces_output():
+    """method="normal" forces the Normal GBM path (the bootstrap fallback) and
+    must still return ordered percentile output."""
     result = run_monte_carlo([100.0, 101.0, 99.0, 102.0, 100.5, 101.5,
-                              103.0, 102.0, 104.0, 103.5, 105.0], steps=5, n_sims=200)
+                              103.0, 102.0, 104.0, 103.5, 105.0],
+                             steps=5, n_sims=200, method="normal")
     assert result is not None
     assert result["p10"] <= result["p50"] <= result["p90"]

--- a/backend/tests/test_routers.py
+++ b/backend/tests/test_routers.py
@@ -5,6 +5,7 @@ All external calls are mocked; no network required.
 from typing import Any, Dict, List, Tuple
 from unittest.mock import patch, AsyncMock, MagicMock
 import importlib as _il
+import warnings
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -60,8 +61,10 @@ def _reset_rate_limiter():
     """
     try:
         limiter.reset()
-    except Exception:
-        pass
+    except Exception as exc:
+        # Best-effort: if the storage backend can't be reset, tests still proceed
+        # (they'll just share the limit window) — surface it so it's not silent.
+        warnings.warn(f"limiter.reset() failed: {exc}", RuntimeWarning, stacklevel=2)
     yield
 
 

--- a/backend/tests/test_routers.py
+++ b/backend/tests/test_routers.py
@@ -5,6 +5,7 @@ All external calls are mocked; no network required.
 from typing import Any, Dict, List, Tuple
 from unittest.mock import patch, AsyncMock, MagicMock
 import importlib as _il
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from fastapi.responses import JSONResponse
@@ -47,6 +48,21 @@ _test_app.include_router(market.router)
 _test_app.dependency_overrides[require_user] = lambda: "test-user-uuid"
 
 client = TestClient(_test_app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter():
+    """Reset the shared in-memory limiter before each test.
+
+    The suite fires many /trade-setup + /market calls in well under a minute;
+    without this they accumulate against the per-IP limit and later tests get a
+    spurious 429. (Dedicated rate-limit behaviour is covered in test_security.py.)
+    """
+    try:
+        limiter.reset()
+    except Exception:
+        pass
+    yield
 
 
 # ---------------------------------------------------------------------------
@@ -231,6 +247,201 @@ def test_trade_setup_invalid_rsi() -> None:
 def test_trade_setup_high_below_low() -> None:
     resp = client.post("/trade-setup", json=_trade_payload(high_range=130.0, low_range=140.0))
     assert resp.status_code == 422
+
+
+# ── Coherence gate: forecast-aware, honesty-gated setups ──────────────────────
+
+def test_trade_setup_conflict_short_vs_rising_forecast() -> None:
+    """The GOOGL case: a bearish trend would build a short, but the 5-day forecast
+    projects HIGHER — the setup must be flagged non-actionable, not a fake short."""
+    payload = _trade_payload(
+        rsi=35.0, trend="Bearish", current_price=150.0,
+        high_range=160.0, low_range=140.0,
+        forecast_close=156.0,   # +4% over 5 days → forecast up, contradicts short
+    )
+    with patch("backend.routers.trade.analyst_jury_svc", _mock_jury()):
+        resp = client.post("/trade-setup", json=payload)
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["actionable"] is False
+    assert d["direction"] == "Neutral"
+    assert d["setup_type"] == "Conflicting Signals"
+    assert d["conflict_note"]
+    assert d["suggested_position_pct"] == 0.0
+
+
+def test_trade_setup_conflict_long_vs_falling_forecast() -> None:
+    payload = _trade_payload(
+        rsi=55.0, trend="Bullish", current_price=150.0,
+        high_range=160.0, low_range=140.0,
+        forecast_close=144.0,   # −4% → forecast down, contradicts long
+    )
+    with patch("backend.routers.trade.analyst_jury_svc", _mock_jury()):
+        resp = client.post("/trade-setup", json=payload)
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["actionable"] is False
+    assert d["direction"] == "Neutral"
+    assert d["setup_type"] == "Conflicting Signals"
+
+
+def test_trade_setup_aligned_forecast_is_actionable() -> None:
+    """Bullish trend + rising forecast agree → a real, actionable long."""
+    payload = _trade_payload(
+        rsi=55.0, trend="Bullish", current_price=150.0,
+        high_range=165.0, low_range=140.0,
+        forecast_close=158.0,   # +5% → forecast up, agrees with long
+    )
+    with patch("backend.routers.trade.analyst_jury_svc", _mock_jury()):
+        resp = client.post("/trade-setup", json=payload)
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["actionable"] is True
+    assert d["direction"] == "Long"
+    assert d["suggested_position_pct"] > 0
+
+
+def test_trade_setup_neutral_trend_no_clean_setup() -> None:
+    """A mixed (Neutral) trend yields an honest 'No Clean Setup', not a forced long."""
+    with patch("backend.routers.trade.analyst_jury_svc", _mock_jury()):
+        resp = client.post("/trade-setup", json=_trade_payload(rsi=50.0, trend="Neutral"))
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["actionable"] is False
+    assert d["direction"] == "Neutral"
+    assert d["setup_type"] == "No Clean Setup"
+    assert d["suggested_position_pct"] == 0.0
+
+
+def test_trade_setup_unfavorable_rr_flagged() -> None:
+    """A setup whose reward is smaller than its risk is flagged, not presented as an edge."""
+    payload = _trade_payload(
+        rsi=50.0, trend="Bearish", current_price=150.0,
+        high_range=152.0, low_range=149.0,   # tiny downside reward
+        atr_14=10.0,                         # huge ATR → wide stop = large risk
+    )
+    with patch("backend.routers.trade.analyst_jury_svc", _mock_jury()):
+        resp = client.post("/trade-setup", json=payload)
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["actionable"] is False
+    assert d["setup_type"] == "Unfavorable R:R"
+    assert d["suggested_position_pct"] == 0.0
+
+
+def test_trade_setup_no_forecast_is_backward_compatible() -> None:
+    """Without forecast_close, behaviour is unchanged (no spurious conflict)."""
+    payload = _trade_payload(rsi=32.0, trend="Bearish", high_range=180.0, low_range=135.0)
+    with patch("backend.routers.trade.analyst_jury_svc", _mock_jury()):
+        resp = client.post("/trade-setup", json=payload)
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["direction"] == "Short"
+    assert d["setup_type"] == "Breakdown Play"
+    assert d["actionable"] is True
+
+
+# ── Swing entry trigger: daily candle confirmation ────────────────────────────
+
+def test_trade_setup_entry_confirmed_by_matching_candle() -> None:
+    """An actionable long with a bullish candle already printed → confirmed trigger."""
+    payload = _trade_payload(
+        rsi=55.0, trend="Bullish", current_price=150.0,
+        high_range=165.0, low_range=140.0, forecast_close=158.0,
+        candle_pattern="Bullish Engulfing", candle_pattern_dir="bullish",
+    )
+    with patch("backend.routers.trade.analyst_jury_svc", _mock_jury()):
+        resp = client.post("/trade-setup", json=payload)
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["actionable"] is True
+    assert d["confirmation"] == "confirmed"
+    assert "Bullish Engulfing" in d["entry_trigger"]
+
+
+def test_trade_setup_entry_pending_without_candle() -> None:
+    """Actionable long, no candle → pending trigger ('wait for ...')."""
+    payload = _trade_payload(
+        rsi=55.0, trend="Bullish", current_price=150.0,
+        high_range=165.0, low_range=140.0, forecast_close=158.0,
+    )
+    with patch("backend.routers.trade.analyst_jury_svc", _mock_jury()):
+        resp = client.post("/trade-setup", json=payload)
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["confirmation"] == "pending"
+    assert "Wait for" in d["entry_trigger"]
+
+
+def test_trade_setup_entry_pending_when_candle_dir_mismatches() -> None:
+    """A bearish candle does not confirm a long → still pending."""
+    payload = _trade_payload(
+        rsi=55.0, trend="Bullish", current_price=150.0,
+        high_range=165.0, low_range=140.0, forecast_close=158.0,
+        candle_pattern="Shooting Star", candle_pattern_dir="bearish",
+    )
+    with patch("backend.routers.trade.analyst_jury_svc", _mock_jury()):
+        resp = client.post("/trade-setup", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["confirmation"] == "pending"
+
+
+def test_trade_setup_no_trigger_when_not_actionable() -> None:
+    """A conflicted (non-actionable) setup carries no entry trigger."""
+    payload = _trade_payload(
+        rsi=35.0, trend="Bearish", current_price=150.0,
+        high_range=160.0, low_range=140.0, forecast_close=156.0,
+        candle_pattern="Bullish Engulfing", candle_pattern_dir="bullish",
+    )
+    with patch("backend.routers.trade.analyst_jury_svc", _mock_jury()):
+        resp = client.post("/trade-setup", json=payload)
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["actionable"] is False
+    assert d["confirmation"] is None
+    assert d["entry_trigger"] is None
+
+
+def test_trade_setup_invalid_candle_dir_rejected() -> None:
+    resp = client.post("/trade-setup", json=_trade_payload(candle_pattern_dir="sideways"))
+    assert resp.status_code == 422
+
+
+# ── CFD-ready framing ─────────────────────────────────────────────────────────
+
+def test_trade_setup_cfd_framing_on_actionable_long() -> None:
+    payload = _trade_payload(
+        rsi=55.0, trend="Bullish", current_price=150.0,
+        high_range=165.0, low_range=140.0, forecast_close=158.0,
+    )
+    with patch("backend.routers.trade.analyst_jury_svc", _mock_jury()):
+        resp = client.post("/trade-setup", json=payload)
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["cfd_side"] == "Buy"
+    assert d["cfd_margin_pct"] == 20.0          # 5:1 leverage → 20% margin
+    assert "CFD" in d["cfd_note"] and "financing" in d["cfd_note"]
+
+
+def test_trade_setup_cfd_side_sell_on_short() -> None:
+    payload = _trade_payload(
+        rsi=32.0, trend="Bearish", current_price=150.0,
+        high_range=180.0, low_range=135.0,   # aligned short (no forecast_close)
+    )
+    with patch("backend.routers.trade.analyst_jury_svc", _mock_jury()):
+        resp = client.post("/trade-setup", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["cfd_side"] == "Sell"
+
+
+def test_trade_setup_no_cfd_framing_when_not_actionable() -> None:
+    payload = _trade_payload(rsi=50.0, trend="Neutral")
+    with patch("backend.routers.trade.analyst_jury_svc", _mock_jury()):
+        resp = client.post("/trade-setup", json=payload)
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["cfd_side"] is None
+    assert d["cfd_note"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/app/(app)/analysis/page.tsx
+++ b/frontend/app/(app)/analysis/page.tsx
@@ -30,6 +30,7 @@ import PriceChartCard    from '../../../components/PriceChartCard';
 import FundamentalsPanel      from '../../../components/FundamentalsPanel';
 import PeerComparisonPanel    from '../../../components/PeerComparisonPanel';
 import TradeSetupCard         from '../../../components/TradeSetupCard';
+import SignalCoherencePanel    from '../../../components/SignalCoherencePanel';
 import OrderBookPanel    from '../../../components/OrderBookPanel';
 import StockChatPanel    from '../../../components/StockChatPanel';
 import { useIndicatorSignals } from '../../../hooks/useIndicatorSignals';
@@ -108,6 +109,12 @@ function AnalysisContent() {
       sentiment_label: data.sentiment?.label ?? 'Neutral',
       var_95:          data.monteCarlo?.var_95 ?? null,
       atr_14:          data.indicators?.atr_14 ?? null,
+      // 5-day forecast central path endpoint — lets the backend flag a setup that
+      // contradicts the model (e.g. a short below a rising forecast).
+      forecast_close:  data.forecastDays?.[data.forecastDays.length - 1]?.predicted ?? null,
+      // Latest daily candle — turns the entry into a confirmation trigger.
+      candle_pattern:     data.indicators?.candle_pattern?.pattern   ?? null,
+      candle_pattern_dir: data.indicators?.candle_pattern?.direction ?? null,
     }, { headers: authHeaders })
       .then(r  => setTradeSetup(r.data))
       .catch(() => { /* non-fatal */ })
@@ -315,6 +322,13 @@ function AnalysisContent() {
                   sector={prediction.metrics?.sector}
                   onSelectTicker={(etf) => handlePredict(etf)}
                   isDark={isDark}
+                />
+
+                {/* ── Signal Coherence — one honest net read across the cards ── */}
+                <SignalCoherencePanel
+                  prediction={prediction}
+                  isDark={isDark}
+                  primaryColor={primaryColor}
                 />
 
                 {/* Price chart card */}

--- a/frontend/components/MonteCarloFanChart.tsx
+++ b/frontend/components/MonteCarloFanChart.tsx
@@ -216,7 +216,7 @@ export default function MonteCarloFanChart({ monteCarlo, currentPrice, symbol, r
               { icon: '🐂🐻', term: 'Bull / Bear case', desc: 'The best 10% of outcomes (Bull) and the worst 10% (Bear). 80% of all simulated paths fall between these two lines — that\'s your likely range.' },
               { icon: '⚠️', term: 'VaR 95 (Risk gauge)', desc: 'Stands for "Value at Risk." If you held this stock for 5 days, this is the most you\'d expect to lose in 95 out of 100 scenarios. Lower = safer.' },
               { icon: '🏔️', term: '3D Surface', desc: 'A 3D view where mountain peaks show the most likely price for each day. Taller peak = higher chance of landing there. Open it from the "3D Surface" button.' },
-              { icon: '🎲', term: 'How it works', desc: 'The simulation uses the stock\'s real historical data (daily returns and volatility) to generate 1,000 realistic random price paths — like rolling the dice 1,000 times.' },
+              { icon: '🎲', term: 'How it works', desc: 'The simulation resamples the stock\'s own real daily moves (with replacement) to build 1,000 price paths — like reshuffling its actual history 1,000 times. Using real moves keeps the fat tails (big rare drops) a plain bell-curve model would miss.' },
             ].map(({ icon, term, desc }) => (
               <Box key={term} sx={{ display: 'flex', gap: 0.5, alignItems: 'flex-start' }}>
                 <Typography sx={{ fontSize: 11, lineHeight: 1.2, flexShrink: 0 }}>{icon}</Typography>

--- a/frontend/components/PriceChartCard.tsx
+++ b/frontend/components/PriceChartCard.tsx
@@ -181,7 +181,8 @@ export default function PriceChartCard({
             <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 0.5 }}>
               <Chip
                 label={`${prediction.prediction.trend} Trend`}
-                color={prediction.prediction.trend === 'Bullish' ? 'success' : 'error'}
+                color={prediction.prediction.trend === 'Bullish' ? 'success'
+                  : prediction.prediction.trend === 'Bearish' ? 'error' : 'default'}
                 size="small"
                 sx={{ fontWeight: 900, fontSize: '0.7rem' }}
               />

--- a/frontend/components/SignalCoherencePanel.tsx
+++ b/frontend/components/SignalCoherencePanel.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import { Box, Card, CardContent, Stack, Typography } from '@mui/material';
+import { Scale, TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import type { PredictionData } from '../types';
+
+interface Props {
+  prediction:   PredictionData | null;
+  isDark:       boolean;
+  primaryColor: string;
+}
+
+type Dir = 'bull' | 'bear' | 'neutral';
+
+interface Signal {
+  label:   string;
+  dir:     Dir;
+  read:    string;   // short human value, e.g. "Bullish", "+2.5%", "Down"
+  horizon: string;   // what time frame this signal speaks to
+}
+
+// Mirror of the jury rating→score map (AnalystJuryPanel) so the jury contributes
+// one net direction here too.
+const RATING_SCORE: Record<string, number> = {
+  'Strong Buy': 2, 'Low Risk': 2, 'Buy': 1, 'Accumulate': 1,
+  'Hold': 0, 'Medium Risk': 0,
+  'Distribute': -1, 'Sell': -1, 'High Risk': -1, 'Strong Sell': -2,
+};
+
+/** Collect the directional/timing signals the app already produces. Value signals
+ *  (DCF, analyst price targets) are deliberately excluded — they answer a
+ *  different, longer-horizon question and are noted in the explainer instead. */
+function buildSignals(p: PredictionData): Signal[] {
+  const out: Signal[] = [];
+  const price = parseFloat(p.currentPrice);
+
+  // 1. Short-term trend (price structure + momentum)
+  const t = p.prediction.trend;
+  out.push({
+    label: 'Trend', read: t, horizon: 'short-term',
+    dir: t === 'Bullish' ? 'bull' : t === 'Bearish' ? 'bear' : 'neutral',
+  });
+
+  // 2. 5-day ensemble forecast (central path endpoint vs spot)
+  const fc = p.forecastDays?.[p.forecastDays.length - 1]?.predicted;
+  if (fc != null && price > 0) {
+    const chg = (fc - price) / price;
+    out.push({
+      label: '5-Day Model',
+      read: `${chg >= 0 ? '+' : ''}${(chg * 100).toFixed(1)}%`,
+      horizon: '5-day',
+      dir: chg > 0.01 ? 'bull' : chg < -0.01 ? 'bear' : 'neutral',
+    });
+  }
+
+  // 3. Market regime (HMM state)
+  const rg = p.regime?.regime;
+  if (rg && rg !== 'unknown') {
+    out.push({
+      label: 'Regime',
+      read: rg.replace(/_/g, ' '),
+      horizon: 'multi-week',
+      dir: rg === 'trending_up' ? 'bull' : rg === 'trending_down' ? 'bear' : 'neutral',
+    });
+  }
+
+  // 4. Next-day RF classifier
+  const df = p.directionForecast;
+  if (df) {
+    out.push({
+      label: 'Next-Day',
+      read: df.direction === 'up' ? 'Up' : 'Down',
+      horizon: 'next-day',
+      dir: df.direction === 'up' ? 'bull' : 'bear',
+    });
+  }
+
+  // 5. Analyst jury (only when verdicts are present — it runs on demand)
+  const jury = p.juryAnalysts ?? [];
+  if (jury.length > 0) {
+    const mean = jury.reduce((s, a) => s + (RATING_SCORE[a.rating] ?? 0), 0) / jury.length;
+    out.push({
+      label: 'Jury',
+      read: mean > 0.3 ? 'Bullish' : mean < -0.3 ? 'Bearish' : 'Hold',
+      horizon: 'discretionary',
+      dir: mean > 0.3 ? 'bull' : mean < -0.3 ? 'bear' : 'neutral',
+    });
+  }
+
+  // 6. News sentiment (VADER)
+  const sl = p.sentiment?.label;
+  if (sl) {
+    out.push({
+      label: 'Sentiment',
+      read: sl,
+      horizon: 'news now',
+      dir: sl === 'Bullish' ? 'bull' : sl === 'Bearish' ? 'bear' : 'neutral',
+    });
+  }
+
+  return out;
+}
+
+export default function SignalCoherencePanel({ prediction, isDark, primaryColor }: Props) {
+  if (!prediction) return null;
+
+  const green = isDark ? '#00ffa3' : '#16a34a';
+  const red   = isDark ? '#ff0055' : '#dc2626';
+  const amber = isDark ? '#ffb020' : '#b45309';
+  const grey  = isDark ? '#64748b' : '#94a3b8';
+
+  const signals = buildSignals(prediction);
+  const bull = signals.filter(s => s.dir === 'bull').length;
+  const bear = signals.filter(s => s.dir === 'bear').length;
+  const neut = signals.filter(s => s.dir === 'neutral').length;
+  const total = signals.length || 1;
+  const decisive = bull + bear;
+  const conflict = bull > 0 && bear > 0;
+  const coherence = decisive > 0 ? Math.max(bull, bear) / decisive : 0;
+  const majorityBull = bull >= bear;
+
+  // Headline verdict — honest about disagreement, which is the whole point.
+  let verdict: string;
+  let vColor: string;
+  let VIcon: typeof TrendingUp;
+  if (decisive === 0) {
+    verdict = 'Neutral · Range-bound';
+    vColor = grey; VIcon = Minus;
+  } else if (!conflict) {
+    verdict = majorityBull ? 'Aligned · Bullish' : 'Aligned · Bearish';
+    vColor = majorityBull ? green : red;
+    VIcon  = majorityBull ? TrendingUp : TrendingDown;
+  } else if (coherence >= 0.67) {
+    verdict = majorityBull ? 'Leaning Bullish · some disagreement'
+                           : 'Leaning Bearish · some disagreement';
+    vColor = amber;
+    VIcon  = majorityBull ? TrendingUp : TrendingDown;
+  } else {
+    verdict = 'Mixed · Low Conviction';
+    vColor = amber; VIcon = Minus;
+  }
+
+  const dirColor = (d: Dir) => d === 'bull' ? green : d === 'bear' ? red : grey;
+  const DirIcon  = (d: Dir) => d === 'bull' ? TrendingUp : d === 'bear' ? TrendingDown : Minus;
+
+  const explainer = conflict
+    ? 'These signals measure different horizons, so they can — and here do — point different ways. Short-term momentum and the next-day model often diverge from the 5-day forecast, the market regime, and long-term value (DCF, analyst targets). Weight them by your own time frame rather than trading every box at once.'
+    : 'Most directional signals agree here. They still cover different horizons (next-day → multi-week) and exclude long-term value (DCF, analyst targets) — treat this as a timing read, not a full thesis.';
+
+  return (
+    <Card sx={{ border: `1px solid ${vColor}44` }}>
+      <CardContent sx={{ p: '16px !important' }}>
+        {/* Header */}
+        <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1.5 }}>
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <Scale size={16} color={primaryColor} />
+            <Typography variant="overline" sx={{ opacity: 0.5, lineHeight: 1 }}>
+              Signal Coherence
+            </Typography>
+          </Stack>
+          <Stack direction="row" alignItems="center" spacing={0.75}
+                 sx={{ px: 1, py: 0.5, borderRadius: 1.5, background: `${vColor}18`, border: `1px solid ${vColor}55` }}>
+            <VIcon size={14} color={vColor} />
+            <Typography sx={{ fontSize: '0.72rem', fontWeight: 800, color: vColor, letterSpacing: '0.02em' }}>
+              {verdict}
+            </Typography>
+          </Stack>
+        </Stack>
+
+        {/* Conviction meter — bull / neutral / bear proportions */}
+        <Box sx={{ display: 'flex', height: 6, borderRadius: 3, overflow: 'hidden', mb: 1.5 }}>
+          {bull > 0 && <Box sx={{ flex: bull, background: green }} />}
+          {neut > 0 && <Box sx={{ flex: neut, background: grey, opacity: 0.4 }} />}
+          {bear > 0 && <Box sx={{ flex: bear, background: red }} />}
+        </Box>
+        <Stack direction="row" justifyContent="space-between" sx={{ mb: 1.5 }}>
+          <Typography sx={{ fontSize: '0.62rem', color: green, fontWeight: 700 }}>
+            {bull} bullish
+          </Typography>
+          <Typography sx={{ fontSize: '0.62rem', color: grey, fontWeight: 700 }}>
+            {neut} neutral · {signals.length} signals
+          </Typography>
+          <Typography sx={{ fontSize: '0.62rem', color: red, fontWeight: 700 }}>
+            {bear} bearish
+          </Typography>
+        </Stack>
+
+        {/* Per-signal chips */}
+        <Box sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: 'repeat(2, 1fr)', sm: 'repeat(3, 1fr)' },
+          gap: 1, mb: 1.5,
+        }}>
+          {signals.map((s) => {
+            const c = dirColor(s.dir);
+            const Icon = DirIcon(s.dir);
+            return (
+              <Box key={s.label} sx={{
+                p: 1, borderRadius: 1.5, border: `1px solid ${c}33`, background: `${c}0d`,
+              }}>
+                <Stack direction="row" alignItems="center" justifyContent="space-between">
+                  <Typography sx={{ fontSize: '0.6rem', opacity: 0.55, fontWeight: 700, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
+                    {s.label}
+                  </Typography>
+                  <Icon size={12} color={c} />
+                </Stack>
+                <Typography sx={{ fontSize: '0.78rem', fontWeight: 800, color: c, lineHeight: 1.2, textTransform: 'capitalize' }}>
+                  {s.read}
+                </Typography>
+                <Typography sx={{ fontSize: '0.55rem', opacity: 0.4 }}>
+                  {s.horizon}
+                </Typography>
+              </Box>
+            );
+          })}
+        </Box>
+
+        {/* Explainer */}
+        <Typography sx={{ fontSize: '0.72rem', opacity: 0.65, lineHeight: 1.5 }}>
+          {explainer}
+        </Typography>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/SignalCoherencePanel.tsx
+++ b/frontend/components/SignalCoherencePanel.tsx
@@ -113,7 +113,6 @@ export default function SignalCoherencePanel({ prediction, isDark, primaryColor 
   const bull = signals.filter(s => s.dir === 'bull').length;
   const bear = signals.filter(s => s.dir === 'bear').length;
   const neut = signals.filter(s => s.dir === 'neutral').length;
-  const total = signals.length || 1;
   const decisive = bull + bear;
   const conflict = bull > 0 && bear > 0;
   const coherence = decisive > 0 ? Math.max(bull, bear) / decisive : 0;

--- a/frontend/components/TradeSetupCard.tsx
+++ b/frontend/components/TradeSetupCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Box, Card, CardContent, Chip, Skeleton, Stack, Typography } from '@mui/material';
-import { Shield, Target, TrendingUp } from 'lucide-react';
+import { AlertTriangle, Banknote, CheckCircle2, Clock, Shield, Target, TrendingUp } from 'lucide-react';
 import type { TradeSetupResponse } from '../types';
 
 interface Props {
@@ -14,11 +14,19 @@ interface Props {
 export default function TradeSetupCard({ setup, loading, isDark, primaryColor }: Props) {
   const green = isDark ? '#00ffa3' : '#16a34a';
   const red   = isDark ? '#ff0055' : '#dc2626';
+  const amber = isDark ? '#ffb020' : '#b45309';
 
   if (loading) {
     return <Skeleton variant="rectangular" height={140} sx={{ borderRadius: 2 }} />;
   }
   if (!setup) return null;
+
+  // Coherence gate (Feature: signal coherence). `actionable === false` means the
+  // setup contradicts the 5-day forecast, the trend is mixed, or reward < risk —
+  // we surface the reason instead of presenting misleading entry/stop/targets.
+  const actionable = setup.actionable !== false;
+  const dirColor   = setup.direction === 'Short' ? red
+                   : setup.direction === 'Long'  ? green : amber;
 
   return (
     <Card>
@@ -28,19 +36,18 @@ export default function TradeSetupCard({ setup, loading, isDark, primaryColor }:
           <Stack direction="row" alignItems="center" spacing={1}>
             <Target size={16} color={primaryColor} />
             <Typography variant="overline" sx={{ opacity: 0.5, lineHeight: 1 }}>
-              Trade Setup
+              Swing Setup · 5D
             </Typography>
           </Stack>
           <Stack direction="row" spacing={1}>
             {setup.direction && (
               <Chip
-                label={setup.direction.toUpperCase()}
+                label={setup.direction === 'Neutral' ? 'NO TRADE' : setup.direction.toUpperCase()}
                 size="small"
                 sx={{
                   fontSize: '0.65rem', fontWeight: 800, letterSpacing: '0.04em',
-                  background: `${setup.direction === 'Short' ? red : green}22`,
-                  color: setup.direction === 'Short' ? red : green,
-                  border: `1px solid ${setup.direction === 'Short' ? red : green}66`,
+                  background: `${dirColor}22`, color: dirColor,
+                  border: `1px solid ${dirColor}66`,
                 }}
               />
             )}
@@ -53,87 +60,167 @@ export default function TradeSetupCard({ setup, loading, isDark, primaryColor }:
                 border: `1px solid ${primaryColor}44`,
               }}
             />
-            <Chip
-              label={`R:R ${setup.risk_reward}`}
-              size="small"
-              sx={{
-                fontSize: '0.65rem', fontWeight: 700,
-                background: `${green}18`, color: green,
-                border: `1px solid ${green}44`,
-              }}
-            />
+            {actionable && (
+              <Chip
+                label={`R:R ${setup.risk_reward}`}
+                size="small"
+                sx={{
+                  fontSize: '0.65rem', fontWeight: 700,
+                  background: `${green}18`, color: green,
+                  border: `1px solid ${green}44`,
+                }}
+              />
+            )}
           </Stack>
         </Stack>
 
-        {/* 3-column grid */}
-        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr 1fr' }, gap: 1.5, mb: 1.5 }}>
-
-          {/* Entry zone */}
-          <Box sx={{ p: 1.5, borderRadius: 2, border: `1px solid ${primaryColor}22`, background: `${primaryColor}08` }}>
-            <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 0.75 }}>
-              <TrendingUp size={12} color={primaryColor} />
-              <Typography sx={{ fontSize: '0.6rem', opacity: 0.5, letterSpacing: '0.07em', fontWeight: 700 }}>ENTRY</Typography>
-            </Stack>
-            <Typography sx={{ fontSize: '0.8rem', fontWeight: 800, color: primaryColor }}>
-              ${setup.entry_low.toFixed(2)}
-            </Typography>
-            <Typography sx={{ fontSize: '0.7rem', color: primaryColor, opacity: 0.7 }}>
-              – ${setup.entry_high.toFixed(2)}
-            </Typography>
-          </Box>
-
-          {/* Stop loss */}
-          <Box sx={{ p: 1.5, borderRadius: 2, border: `1px solid ${red}22`, background: `${red}08` }}>
-            <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 0.75 }}>
-              <Shield size={12} color={red} />
-              <Typography sx={{ fontSize: '0.6rem', opacity: 0.5, letterSpacing: '0.07em', fontWeight: 700 }}>STOP</Typography>
-            </Stack>
-            <Typography sx={{ fontSize: '0.8rem', fontWeight: 800, color: red }}>
-              ${setup.stop_loss.toFixed(2)}
-            </Typography>
-            {setup.atr_14 != null && setup.atr_multiplier != null && (
-              <Typography sx={{ fontSize: '0.55rem', color: red, opacity: 0.65, mt: 0.25, lineHeight: 1.3 }}>
-                ATR-14: {setup.atr_14.toFixed(2)} · entry {setup.stop_loss <= (setup.entry_low + setup.entry_high) / 2 ? '−' : '+'} {setup.atr_multiplier.toFixed(1)}×ATR
+        {/* ── Non-actionable: explain the conflict instead of faking a trade ── */}
+        {!actionable ? (
+          <>
+            <Box sx={{
+              display: 'flex', gap: 1, alignItems: 'flex-start',
+              p: 1.5, mb: 1.5, borderRadius: 2,
+              border: `1px solid ${amber}55`, background: `${amber}12`,
+            }}>
+              <Box sx={{ mt: '1px', flexShrink: 0 }}><AlertTriangle size={15} color={amber} /></Box>
+              <Typography sx={{ fontSize: '0.78rem', lineHeight: 1.5, color: amber }}>
+                {setup.conflict_note ?? 'No clean setup at current levels.'}
               </Typography>
+            </Box>
+            {/* Reference levels only — clearly not a recommendation. */}
+            <Box sx={{
+              display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap', gap: 1,
+              px: 1.25, py: 1, borderRadius: 1.5,
+              background: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
+              border: '1px solid rgba(255,255,255,0.06)', opacity: 0.75,
+            }}>
+              <Typography sx={{ fontSize: '0.65rem', opacity: 0.7, fontFamily: 'monospace' }}>
+                Watch range ${setup.entry_low.toFixed(2)}–${setup.entry_high.toFixed(2)}
+              </Typography>
+              <Typography sx={{ fontSize: '0.6rem', opacity: 0.45, letterSpacing: '0.05em', fontWeight: 700 }}>
+                REFERENCE ONLY · NO POSITION
+              </Typography>
+            </Box>
+          </>
+        ) : (
+          <>
+            {/* 3-column grid */}
+            <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr 1fr' }, gap: 1.5, mb: 1.5 }}>
+
+              {/* Entry zone */}
+              <Box sx={{ p: 1.5, borderRadius: 2, border: `1px solid ${primaryColor}22`, background: `${primaryColor}08` }}>
+                <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 0.75 }}>
+                  <TrendingUp size={12} color={primaryColor} />
+                  <Typography sx={{ fontSize: '0.6rem', opacity: 0.5, letterSpacing: '0.07em', fontWeight: 700 }}>ENTRY</Typography>
+                </Stack>
+                <Typography sx={{ fontSize: '0.8rem', fontWeight: 800, color: primaryColor }}>
+                  ${setup.entry_low.toFixed(2)}
+                </Typography>
+                <Typography sx={{ fontSize: '0.7rem', color: primaryColor, opacity: 0.7 }}>
+                  – ${setup.entry_high.toFixed(2)}
+                </Typography>
+              </Box>
+
+              {/* Stop loss */}
+              <Box sx={{ p: 1.5, borderRadius: 2, border: `1px solid ${red}22`, background: `${red}08` }}>
+                <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 0.75 }}>
+                  <Shield size={12} color={red} />
+                  <Typography sx={{ fontSize: '0.6rem', opacity: 0.5, letterSpacing: '0.07em', fontWeight: 700 }}>STOP</Typography>
+                </Stack>
+                <Typography sx={{ fontSize: '0.8rem', fontWeight: 800, color: red }}>
+                  ${setup.stop_loss.toFixed(2)}
+                </Typography>
+                {setup.atr_14 != null && setup.atr_multiplier != null && (
+                  <Typography sx={{ fontSize: '0.55rem', color: red, opacity: 0.65, mt: 0.25, lineHeight: 1.3 }}>
+                    ATR-14: {setup.atr_14.toFixed(2)} · entry {setup.stop_loss <= (setup.entry_low + setup.entry_high) / 2 ? '−' : '+'} {setup.atr_multiplier.toFixed(1)}×ATR
+                  </Typography>
+                )}
+              </Box>
+
+              {/* Targets */}
+              <Box sx={{ p: 1.5, borderRadius: 2, border: `1px solid ${green}22`, background: `${green}08` }}>
+                <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 0.75 }}>
+                  <Target size={12} color={green} />
+                  <Typography sx={{ fontSize: '0.6rem', opacity: 0.5, letterSpacing: '0.07em', fontWeight: 700 }}>TARGETS</Typography>
+                </Stack>
+                <Typography sx={{ fontSize: '0.75rem', fontWeight: 800, color: green }}>T1 ${setup.target_1.toFixed(2)}</Typography>
+                <Typography sx={{ fontSize: '0.7rem', color: green, opacity: 0.8 }}>T2 ${setup.target_2.toFixed(2)}</Typography>
+                <Typography sx={{ fontSize: '0.65rem', color: green, opacity: 0.6 }}>T3 ${setup.target_3.toFixed(2)}</Typography>
+              </Box>
+            </Box>
+
+            {/* Position sizing */}
+            <Box sx={{
+              display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+              px: 1.25, py: 0.75, mb: 1.5, borderRadius: 1.5,
+              background: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
+              border: '1px solid rgba(255,255,255,0.06)',
+            }}>
+              <Typography sx={{ fontSize: '0.65rem', opacity: 0.5, letterSpacing: '0.06em', fontWeight: 700 }}>
+                POSITION SIZE
+              </Typography>
+              <Stack direction="row" spacing={2} alignItems="center">
+                <Typography sx={{ fontSize: '0.72rem', fontWeight: 800, color: primaryColor }}>
+                  {setup.suggested_position_pct.toFixed(1)}% of portfolio
+                </Typography>
+                <Typography sx={{ fontSize: '0.6rem', opacity: 0.4, fontFamily: 'monospace' }}>
+                  {setup.risk_pct.toFixed(1)}% risk/share · 1% rule
+                </Typography>
+              </Stack>
+            </Box>
+
+            {/* Entry trigger — a setup is a plan: wait for the candle, don't chase. */}
+            {setup.entry_trigger && (() => {
+              const confirmed = setup.confirmation === 'confirmed';
+              const c = confirmed ? green : amber;
+              const Icon = confirmed ? CheckCircle2 : Clock;
+              return (
+                <Box sx={{
+                  display: 'flex', gap: 1, alignItems: 'flex-start',
+                  p: 1.25, mb: 1.5, borderRadius: 1.5,
+                  border: `1px solid ${c}44`, background: `${c}0f`,
+                }}>
+                  <Box sx={{ mt: '1px', flexShrink: 0 }}><Icon size={14} color={c} /></Box>
+                  <Box>
+                    <Typography sx={{ fontSize: '0.6rem', fontWeight: 800, letterSpacing: '0.05em', color: c, mb: 0.25 }}>
+                      {confirmed ? 'ENTRY CONFIRMED' : 'ENTRY TRIGGER · PENDING'}
+                    </Typography>
+                    <Typography sx={{ fontSize: '0.72rem', opacity: 0.8, lineHeight: 1.45 }}>
+                      {setup.entry_trigger}
+                    </Typography>
+                  </Box>
+                </Box>
+              );
+            })()}
+
+            {/* CFD-ready framing — same setup expressed for a CFD broker. */}
+            {setup.cfd_note && (
+              <Box sx={{
+                display: 'flex', gap: 1, alignItems: 'flex-start',
+                p: 1.25, mb: 1.5, borderRadius: 1.5,
+                border: `1px solid ${primaryColor}33`, background: `${primaryColor}0a`,
+              }}>
+                <Box sx={{ mt: '1px', flexShrink: 0 }}><Banknote size={14} color={primaryColor} /></Box>
+                <Box>
+                  <Typography sx={{ fontSize: '0.6rem', fontWeight: 800, letterSpacing: '0.05em', color: primaryColor, mb: 0.25 }}>
+                    CFD {setup.cfd_side ? `· ${setup.cfd_side.toUpperCase()}` : ''}
+                    {setup.cfd_margin_pct != null ? ` · ~${setup.cfd_margin_pct}% MARGIN` : ''}
+                  </Typography>
+                  <Typography sx={{ fontSize: '0.72rem', opacity: 0.75, lineHeight: 1.45 }}>
+                    {setup.cfd_note}
+                  </Typography>
+                </Box>
+              </Box>
             )}
-          </Box>
+          </>
+        )}
 
-          {/* Targets */}
-          <Box sx={{ p: 1.5, borderRadius: 2, border: `1px solid ${green}22`, background: `${green}08` }}>
-            <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 0.75 }}>
-              <Target size={12} color={green} />
-              <Typography sx={{ fontSize: '0.6rem', opacity: 0.5, letterSpacing: '0.07em', fontWeight: 700 }}>TARGETS</Typography>
-            </Stack>
-            <Typography sx={{ fontSize: '0.75rem', fontWeight: 800, color: green }}>T1 ${setup.target_1.toFixed(2)}</Typography>
-            <Typography sx={{ fontSize: '0.7rem', color: green, opacity: 0.8 }}>T2 ${setup.target_2.toFixed(2)}</Typography>
-            <Typography sx={{ fontSize: '0.65rem', color: green, opacity: 0.6 }}>T3 ${setup.target_3.toFixed(2)}</Typography>
-          </Box>
-        </Box>
-
-        {/* Position sizing */}
-        <Box sx={{
-          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-          px: 1.25, py: 0.75, mb: 1.5, borderRadius: 1.5,
-          background: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
-          border: '1px solid rgba(255,255,255,0.06)',
-        }}>
-          <Typography sx={{ fontSize: '0.65rem', opacity: 0.5, letterSpacing: '0.06em', fontWeight: 700 }}>
-            POSITION SIZE
+        {/* Rationale (actionable setups only — the note is shown above otherwise) */}
+        {actionable && (
+          <Typography sx={{ fontSize: '0.78rem', opacity: 0.7, lineHeight: 1.5 }}>
+            {setup.rationale}
           </Typography>
-          <Stack direction="row" spacing={2} alignItems="center">
-            <Typography sx={{ fontSize: '0.72rem', fontWeight: 800, color: primaryColor }}>
-              {setup.suggested_position_pct.toFixed(1)}% of portfolio
-            </Typography>
-            <Typography sx={{ fontSize: '0.6rem', opacity: 0.4, fontFamily: 'monospace' }}>
-              {setup.risk_pct.toFixed(1)}% risk/share · 1% rule
-            </Typography>
-          </Stack>
-        </Box>
-
-        {/* Rationale */}
-        <Typography sx={{ fontSize: '0.78rem', opacity: 0.7, lineHeight: 1.5 }}>
-          {setup.rationale}
-        </Typography>
+        )}
       </CardContent>
     </Card>
   );

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -100,7 +100,7 @@ export interface PredictionData {
   prediction: {
     highRange: string;
     lowRange:  string;
-    trend:     'Bullish' | 'Bearish';
+    trend:     'Bullish' | 'Bearish' | 'Neutral';
   };
   analystNote:  string;
   confidence:   string;
@@ -144,6 +144,7 @@ export interface PredictionData {
     fibonacci?:   FibonacciLevels | null;
     rf_feature_importance?: FeatureImportance[];
     earnings_surprise?:     EarningsSurprise[];
+    candle_pattern?:        CandlePattern | null;
   };
   juryAnalysts?: AnalystJuror[];
   modelWeights?: { prophet: number; sarima: number; rf: number };
@@ -267,6 +268,13 @@ export interface EarningsSurprise {
   surprise_pct: number | null;
 }
 
+/** Latest daily candlestick pattern (entry-trigger candle for a swing setup). */
+export interface CandlePattern {
+  pattern:     string;                              // e.g. "Bullish Engulfing"
+  direction:   'bullish' | 'bearish' | 'neutral';
+  description: string;
+}
+
 // Sub-panel indicators toggleable on the price chart (persisted in localStorage).
 export type SubPanelKey = 'stoch' | 'adx' | 'obv';
 
@@ -281,13 +289,25 @@ export interface TradeSetupResponse {
   target_3:                number;
   risk_reward:             string;
   setup_type:              string;
-  direction?:              'Long' | 'Short';   // trade side
+  direction?:              'Long' | 'Short' | 'Neutral';   // trade side ('Neutral' = no clean setup)
   rationale:               string;
   risk_per_share:          number;
   risk_pct:                number;
   suggested_position_pct:  number;
   atr_14?:                 number | null;
   atr_multiplier?:         number | null;
+  /** False when the setup contradicts the forecast, the trend is mixed, or reward < risk. */
+  actionable?:             boolean;
+  /** One-line explanation shown in place of the levels when not actionable. */
+  conflict_note?:          string | null;
+  /** Swing entry trigger — what to wait for at the entry zone (candle confirmation). */
+  entry_trigger?:          string | null;
+  /** "confirmed" once a matching daily candle has printed, else "pending". */
+  confirmation?:           'confirmed' | 'pending' | null;
+  /** CFD-ready framing — same setup expressed for a CFD broker. */
+  cfd_side?:               'Buy' | 'Sell' | null;
+  cfd_margin_pct?:         number | null;
+  cfd_note?:               string | null;
 }
 
 export interface ChatMessage {


### PR DESCRIPTION
## Why
The app could contradict itself: GOOGL showed a **SHORT** trade setup (R:R 1:0.4) while the **5-day forecast projected higher** and the per-day forecast was green. Acting on the cards as shown could lose money. Root cause: the `trend` field was literally `RSI > 50` and was the *sole* driver of trade direction, never reconciled with the forecast.

## What changed

**Root-cause fix**
- `models.classify_trend` — real composite trend (price vs SMA50/SMA200 + 20-day slope + MACD), can be **Neutral**. Replaces `RSI>50`, which drove both the header badge and the trade direction.
- **Forecast-aware, honesty-gated `/trade-setup`** — takes the 5-day forecast; when the trend contradicts it → **Conflicting Signals**, mixed trend → **No Clean Setup**, reward<risk → **Unfavorable R:R**. Non-actionable setups show the reason + 0% size instead of a misleading trade.
- **`SignalCoherencePanel`** (top of analysis page) — one net read across trend / 5-day model / regime / next-day RF / jury / sentiment, each tagged by horizon, with an explainer of why they diverge.

**Swing setup — daily candle confirmation (Option A)**
- `detect_candle_patterns` (engulfing / hammer / shooting-star / inside-bar on the latest daily bar), surfaced in `/predict` `indicators.candle_pattern`.
- Entry is now a real **trigger**: *"wait for a bullish reversal candle near $X"* (pending) vs *"Bullish Engulfing printed — trigger active"* (confirmed). Card reframed as **Swing Setup · 5D**.

**Fat-tailed Monte Carlo**
- `run_monte_carlo` now defaults to **historical bootstrap** (resamples the stock's actual daily returns), preserving real fat tails + skew that Normal GBM flattens; Normal fallback kept for short history. "How it works" text updated.

**CFD-ready framing**
- `/trade-setup` returns `cfd_side` / `cfd_margin_pct` / `cfd_note` so an actionable setup is directly placeable on a CFD broker (leverage→margin, risk unchanged, financing + spread caveats). Rendered on the card.

## Tests / verification
- +30 backend tests (composite trend, conflict/RR gating, candle detection + confirmation, bootstrap MC, CFD framing). **331 passed, 1 skipped**.
- `ruff` clean; frontend `lint` (0 errors) + `build` clean.
- Verified live against `/predict` + `/trade-setup`: GOOGL conflict → `Neutral / Conflicting Signals / actionable:false`; coherence panel renders "Leaning Bearish · some disagreement"; MC bootstrap + CFD fields confirmed.

## Notes
- One PR by request (covers what would otherwise be several feature PRs).
- Follow-up discussed: a dedicated **intraday CFD setup** via a single 5m daily snapshot (no per-minute streaming) — not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Signal Coherence” panel summarizing multi-horizon alignment, decisiveness, and conflict signals.
  * Added candlestick pattern insights and forecast-aware “swing setup” details, including entry confirmation/pending and CFD framing.
  * Monte Carlo now defaults to a bootstrap mode for more realistic fat-tail behavior.
* **Bug Fixes**
  * Trade setups now more clearly label conflicting or unfavorable setups as non-actionable, with reference-only guidance and zero position sizing.
  * Trend labels now support a neutral state instead of forcing bullish/bearish output.
  * Improved robustness for limited or skewed historical simulation inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->