### PR TITLE
Day-trade setup: intraday VWAP-anchored Opening Range Breakout

### DIFF
--- a/backend/day_trade_service.py
+++ b/backend/day_trade_service.py
@@ -1,0 +1,253 @@
+"""Intraday day-trade setup — VWAP-anchored Opening Range Breakout (ORB).
+
+Strategy (deterministic):
+    • Uses a SINGLE 5-minute daily snapshot (yfinance period=1d interval=5m) —
+      no streaming, no per-minute engine. Same bars in → same setup out.
+    • Opening Range (OR) = high/low of the first 30 min (first 6 bars).
+    • VWAP = Σ(typical×vol)/Σ(vol), typical = (H+L+C)/3, cumulative on the session.
+    • BIAS GATE (the part that keeps it coherent): only take a trade when the
+      intraday VWAP position AGREES with the daily trend. If price is below VWAP
+      while the daily bias is up (or vice-versa) → "no clean intraday setup".
+      A Neutral daily trend falls back to pure VWAP momentum.
+    • Entry  = break of the OR edge in the bias direction.
+      Stop   = nearest of {VWAP, opposite OR edge} → defined risk.
+      Targets= 1R / 2R / measured-move (OR height).
+
+Day trades close intraday, so — unlike the swing setup — they avoid overnight
+CFD financing, which is surfaced in the CFD note.
+
+Every public entry point fails soft: a fetch failure or thin data returns an
+``available: False`` payload with a human ``message`` rather than raising.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# First 6 five-minute bars = the 09:30–10:00 ET opening range.
+_OPENING_RANGE_BARS = 6
+_CFD_LEVERAGE = 5.0   # typical EU retail major-stock CFD cap (broker-dependent)
+
+
+def _fetch_intraday_ohlcv(symbol: str) -> List[Dict]:
+    """One 5-min OHLCV snapshot for the latest session (RTH only).
+
+    Returns a list of ``{t, o, h, l, c, v}`` (ET-naive timestamps) or ``[]`` on
+    any failure / no data. Synchronous — call via ``asyncio.to_thread``.
+    Mirrors the pre/post-market strip used by the sparklines fetch.
+    """
+    import yfinance as _yf
+
+    try:
+        df = _yf.download(
+            symbol, period="1d", interval="5m",
+            progress=False, auto_adjust=True, timeout=10,
+        )
+        if df is None or df.empty:
+            return []
+
+        if hasattr(df.columns, "levels"):
+            df.columns = df.columns.get_level_values(0)
+
+        idx = df.index
+        if idx.tz is None:
+            idx = idx.tz_localize("UTC")
+        idx_et = idx.tz_convert("America/New_York")
+        mask = (
+            ((idx_et.hour == 9)  & (idx_et.minute >= 30)) |
+            ((idx_et.hour > 9)   & (idx_et.hour < 16))    |
+            ((idx_et.hour == 16) & (idx_et.minute == 0))
+        )
+        df = df[mask][:78]
+        if df.empty:
+            return []
+
+        def _col(name: str) -> str:
+            return name if name in df.columns else name.lower()
+
+        o_c, h_c, l_c = _col("Open"), _col("High"), _col("Low")
+        c_c, v_c      = _col("Close"), _col("Volume")
+        ts_et = df.index.tz_convert("America/New_York")
+
+        bars: List[Dict] = []
+        for i in range(len(df)):
+            try:
+                bars.append({
+                    "t": ts_et[i].strftime("%H:%M"),
+                    "o": float(df[o_c].iloc[i]),
+                    "h": float(df[h_c].iloc[i]),
+                    "l": float(df[l_c].iloc[i]),
+                    "c": float(df[c_c].iloc[i]),
+                    "v": float(df[v_c].iloc[i]) if v_c in df.columns else 0.0,
+                })
+            except Exception:
+                continue  # skip a malformed bar, keep the rest
+        # Drop any NaN-laden bars
+        bars = [b for b in bars if all(b[k] == b[k] for k in ("o", "h", "l", "c"))]
+        return bars
+    except Exception as exc:  # pragma: no cover - network/parse guard
+        logger.debug("[day-trade] _fetch_intraday_ohlcv(%s) error: %s", symbol, exc)
+        return []
+
+
+def compute_intraday_levels(bars: List[Dict]) -> Optional[Dict]:
+    """Pure: derive opening range, VWAP, session H/L and last from 5-min bars.
+
+    Returns ``None`` when there aren't enough bars to be meaningful.
+    """
+    if not bars:
+        return None
+
+    or_bars = bars[:_OPENING_RANGE_BARS]
+    or_complete = len(bars) >= _OPENING_RANGE_BARS
+    or_high = max(b["h"] for b in or_bars)
+    or_low  = min(b["l"] for b in or_bars)
+
+    # Cumulative VWAP over the whole session so far.
+    cum_pv = 0.0
+    cum_v  = 0.0
+    for b in bars:
+        typical = (b["h"] + b["l"] + b["c"]) / 3.0
+        vol     = b["v"] if b["v"] > 0 else 0.0
+        cum_pv += typical * vol
+        cum_v  += vol
+    last = bars[-1]["c"]
+    vwap = (cum_pv / cum_v) if cum_v > 0 else last  # fall back to last if no volume
+
+    return {
+        "or_high":       round(or_high, 2),
+        "or_low":        round(or_low, 2),
+        "vwap":          round(vwap, 2),
+        "session_high":  round(max(b["h"] for b in bars), 2),
+        "session_low":   round(min(b["l"] for b in bars), 2),
+        "last":          round(last, 2),
+        "n_bars":        len(bars),
+        "or_complete":   or_complete,
+    }
+
+
+def _cfd_block(direction: str) -> Dict:
+    side = "Buy" if direction == "Long" else "Sell"
+    margin = round(100.0 / _CFD_LEVERAGE, 1)
+    note = (
+        f"Place as a {side} CFD — same stop & targets. At {_CFD_LEVERAGE:.0f}:1, "
+        f"margin ≈ {margin:.0f}% of notional (size by the stop, not the margin). "
+        f"Closed intraday, so NO overnight financing — just spread. Flat by the close."
+    )
+    return {"cfd_side": side, "cfd_margin_pct": margin, "cfd_note": note}
+
+
+def build_orb_setup(levels: Optional[Dict], daily_trend: str) -> Dict:
+    """Pure strategy core — turn intraday levels + the daily bias into a setup.
+
+    ``daily_trend`` is the composite trend label ("Bullish"/"Bearish"/"Neutral").
+    Returns a fully-formed payload with a ``status`` describing what to do.
+    """
+    base = {
+        "available": False, "strategy": "Opening Range Breakout (VWAP-filtered)",
+        "direction": "Neutral", "status": "market_closed",
+        "message": "Intraday data unavailable — day-trade setups need US market-hours 5-min bars.",
+        "entry": None, "stop": None, "targets": None, "risk_reward": None,
+        "entry_trigger": None, "confirmation": None, "levels": None,
+        "cfd_side": None, "cfd_margin_pct": None, "cfd_note": None,
+    }
+    if not levels:
+        return base
+
+    base["levels"] = levels
+    if not levels["or_complete"]:
+        base.update(
+            status="forming",
+            message=(f"Opening range still forming ({levels['n_bars']} of "
+                     f"{_OPENING_RANGE_BARS} bars) — no trigger until the first 30 min completes."),
+        )
+        return base
+
+    last    = levels["last"]
+    vwap    = levels["vwap"]
+    or_high = levels["or_high"]
+    or_low  = levels["or_low"]
+    or_range = or_high - or_low
+    if or_range <= 0:
+        base.update(status="no_setup", message="Opening range is degenerate (no range) — skip.")
+        return base
+
+    vwap_bias = "up" if last >= vwap else "down"
+    daily_dir = {"Bullish": "up", "Bearish": "down"}.get(daily_trend, "flat")
+
+    # Coherence gate: intraday momentum must not fight the daily bias.
+    if daily_dir != "flat" and daily_dir != vwap_bias:
+        base.update(
+            status="conflict", direction="Neutral",
+            message=(f"No clean day trade: price is {'above' if vwap_bias == 'up' else 'below'} VWAP "
+                     f"(intraday {vwap_bias}) but the daily trend is {daily_trend.lower()}. "
+                     f"Wait for them to align."),
+        )
+        return base
+
+    bias = vwap_bias  # aligned, or daily neutral → pure VWAP momentum
+
+    if bias == "up":
+        direction = "Long"
+        entry = or_high
+        stop  = max(or_low, vwap)
+        if stop >= entry:
+            stop = or_low
+        risk  = max(entry - stop, 0.01)
+        targets = sorted([round(entry + risk, 2), round(entry + 2 * risk, 2),
+                          round(entry + or_range, 2)])
+        active = last >= or_high
+        edge   = "high"
+    else:
+        direction = "Short"
+        entry = or_low
+        stop  = min(or_high, vwap)
+        if stop <= entry:
+            stop = or_high
+        risk  = max(stop - entry, 0.01)
+        targets = sorted([round(entry - risk, 2), round(entry - 2 * risk, 2),
+                          round(entry - or_range, 2)], reverse=True)
+        active = last <= or_low
+        edge   = "low"
+
+    reward = abs(targets[1] - entry)  # T2 ≈ 2R by construction
+    rr = f"1:{reward / risk:.1f}"
+    confirmation = "active" if active else "pending"
+    trigger = (
+        "Breakout active — price has cleared the opening range; manage the open trade."
+        if active else
+        f"Enter on a 5-min close beyond the opening-range {edge} (${entry:.2f}); don't pre-empt it."
+    )
+
+    base.update(
+        available=True, status="ok", direction=direction,
+        entry=round(entry, 2), stop=round(stop, 2), targets=targets,
+        risk_reward=rr, confirmation=confirmation, entry_trigger=trigger,
+        message=(f"{direction} opening-range breakout, aligned with VWAP"
+                 + ("" if daily_dir == "flat" else f" and the {daily_trend.lower()} daily trend") + "."),
+        **_cfd_block(direction),
+    )
+    return base
+
+
+async def build_day_trade_setup(symbol: str, daily_trend: str) -> Dict:
+    """Fetch the intraday snapshot (off-thread) and build the ORB setup."""
+    import asyncio
+
+    try:
+        bars = await asyncio.wait_for(
+            asyncio.to_thread(_fetch_intraday_ohlcv, symbol), timeout=12
+        )
+    except Exception as exc:
+        logger.warning("[day-trade] intraday fetch failed for %s: %s", symbol, exc)
+        bars = []
+
+    levels = compute_intraday_levels(bars)
+    setup = build_orb_setup(levels, daily_trend)
+    logger.info(
+        "[day-trade] %s → status=%s direction=%s (bars=%d, trend=%s)",
+        symbol, setup["status"], setup["direction"], len(bars), daily_trend,
+    )
+    return setup

--- a/backend/routers/trade.py
+++ b/backend/routers/trade.py
@@ -12,6 +12,7 @@ from slowapi.util import get_remote_address
 
 from config import Config
 from dependencies import analyst_jury_svc, limiter, require_user, _user_rate_key
+from day_trade_service import build_day_trade_setup
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -432,6 +433,47 @@ async def trade_setup(request: Request, req: TradeSetupRequest, _user: str = Dep
         cfd_margin_pct=cfd_margin_pct,
         cfd_note=cfd_note,
     )
+
+
+# ---------------------------------------------------------------------------
+# Day-trade setup endpoint (intraday ORB + VWAP)
+# ---------------------------------------------------------------------------
+
+class DayTradeSetupRequest(BaseModel):
+    symbol: str
+    # Composite daily trend ("Bullish"/"Bearish"/"Neutral") — the bias the
+    # intraday setup must stay coherent with. Defaults to Neutral (pure VWAP).
+    daily_trend: str = "Neutral"
+
+    @field_validator("symbol")
+    @classmethod
+    def validate_symbol(cls, v: str) -> str:
+        s = (v or "").strip().upper()
+        if not _SYMBOL_RE.match(s):
+            raise ValueError("symbol must match [A-Za-z0-9.\\-:]{1,15}")
+        return s
+
+    @field_validator("daily_trend")
+    @classmethod
+    def validate_trend(cls, v: str) -> str:
+        if v not in ("Bullish", "Bearish", "Neutral"):
+            raise ValueError("daily_trend must be Bullish, Bearish, or Neutral")
+        return v
+
+
+@router.post("/day-trade-setup")
+@limiter.limit(lambda: Config.RATE_LIMIT_TRADE, key_func=_user_rate_key)
+async def day_trade_setup(
+    request: Request, req: DayTradeSetupRequest, _user: str = Depends(require_user)
+):
+    """Intraday VWAP-anchored Opening Range Breakout setup.
+
+    Fetches one 5-min snapshot (no streaming), computes the opening range + VWAP,
+    and returns a defined-risk ORB plan gated for coherence against the daily
+    trend. Always 200 with an ``available``/``status`` payload — a market-closed
+    or thin-data session degrades to a message, never a 500.
+    """
+    return await build_day_trade_setup(req.symbol, req.daily_trend)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_day_trade.py
+++ b/backend/tests/test_day_trade.py
@@ -1,0 +1,106 @@
+"""Day-trade setup — VWAP-anchored Opening Range Breakout (intraday ORB).
+
+Covers the pure strategy core (compute_intraday_levels + build_orb_setup): the
+opening-range/VWAP math and the coherence gate that keeps an intraday trade from
+fighting the daily bias.
+"""
+from backend.day_trade_service import compute_intraday_levels, build_orb_setup
+
+
+def _bar(op, hi, lo, cl, v=1000.0):
+    return {"t": "09:30", "o": op, "h": hi, "l": lo, "c": cl, "v": v}
+
+
+def _levels(or_high=102.0, or_low=98.0, vwap=100.0, last=103.0,
+            or_complete=True, n_bars=20):
+    return {
+        "or_high": or_high, "or_low": or_low, "vwap": vwap,
+        "session_high": max(or_high, last), "session_low": min(or_low, last),
+        "last": last, "n_bars": n_bars, "or_complete": or_complete,
+    }
+
+
+# ── compute_intraday_levels ───────────────────────────────────────────────────
+
+def test_levels_opening_range_is_first_six_bars():
+    bars = [
+        _bar(100, 105, 99, 104),   # 1
+        _bar(104, 106, 103, 105),  # 2
+        _bar(105, 105, 100, 101),  # 3
+        _bar(101, 103, 100, 102),  # 4
+        _bar(102, 104, 101, 103),  # 5
+        _bar(103, 104, 102, 103),  # 6  → OR = high 106, low 99
+        _bar(103, 110, 103, 109),  # 7  (after OR; pushes session high to 110)
+        _bar(109, 111, 108, 110),  # 8
+    ]
+    lv = compute_intraday_levels(bars)
+    assert lv is not None
+    assert lv["or_high"] == 106.0      # max high of first 6
+    assert lv["or_low"] == 99.0        # min low of first 6
+    assert lv["session_high"] == 111.0
+    assert lv["last"] == 110.0
+    assert lv["n_bars"] == 8 and lv["or_complete"] is True
+    assert lv["session_low"] <= lv["vwap"] <= lv["session_high"]
+
+
+def test_levels_none_on_empty():
+    assert compute_intraday_levels([]) is None
+
+
+def test_levels_or_incomplete_under_six_bars():
+    lv = compute_intraday_levels([_bar(100, 101, 99, 100) for _ in range(3)])
+    assert lv["or_complete"] is False and lv["n_bars"] == 3
+
+
+# ── build_orb_setup: states ───────────────────────────────────────────────────
+
+def test_orb_market_closed_when_no_levels():
+    s = build_orb_setup(None, "Bullish")
+    assert s["available"] is False and s["status"] == "market_closed"
+
+
+def test_orb_forming_before_range_completes():
+    s = build_orb_setup(_levels(or_complete=False, n_bars=3), "Bullish")
+    assert s["available"] is False and s["status"] == "forming"
+
+
+def test_orb_long_aligned_with_uptrend():
+    s = build_orb_setup(_levels(last=103.0), "Bullish")   # last>vwap, daily up
+    assert s["available"] is True and s["status"] == "ok"
+    assert s["direction"] == "Long"
+    assert s["entry"] == 102.0           # OR high
+    assert s["stop"] < s["entry"]        # defined risk below
+    assert s["targets"] == sorted(s["targets"])   # ascending for a long
+    assert s["risk_reward"].startswith("1:")
+    assert s["cfd_side"] == "Buy" and "NO overnight financing" in s["cfd_note"]
+
+
+def test_orb_short_aligned_with_downtrend():
+    s = build_orb_setup(_levels(last=97.0), "Bearish")    # last<vwap, daily down
+    assert s["direction"] == "Short"
+    assert s["entry"] == 98.0            # OR low
+    assert s["stop"] > s["entry"]        # stop above for a short
+    assert s["targets"] == sorted(s["targets"], reverse=True)
+    assert s["cfd_side"] == "Sell"
+
+
+def test_orb_conflict_when_intraday_fights_daily():
+    # Price above VWAP (intraday up) but the daily trend is bearish → no trade.
+    s = build_orb_setup(_levels(last=103.0), "Bearish")
+    assert s["available"] is False and s["status"] == "conflict"
+    assert s["direction"] == "Neutral"
+    assert "VWAP" in s["message"]
+
+
+def test_orb_neutral_daily_uses_pure_vwap_momentum():
+    up = build_orb_setup(_levels(last=103.0), "Neutral")
+    dn = build_orb_setup(_levels(last=97.0), "Neutral")
+    assert up["direction"] == "Long"
+    assert dn["direction"] == "Short"
+
+
+def test_orb_active_vs_pending_confirmation():
+    active  = build_orb_setup(_levels(last=103.0), "Bullish")   # last >= or_high
+    pending = build_orb_setup(_levels(last=101.0), "Bullish")   # above vwap, below or_high
+    assert active["confirmation"] == "active"
+    assert pending["confirmation"] == "pending"

--- a/frontend/app/(app)/analysis/page.tsx
+++ b/frontend/app/(app)/analysis/page.tsx
@@ -30,6 +30,7 @@ import PriceChartCard    from '../../../components/PriceChartCard';
 import FundamentalsPanel      from '../../../components/FundamentalsPanel';
 import PeerComparisonPanel    from '../../../components/PeerComparisonPanel';
 import TradeSetupCard         from '../../../components/TradeSetupCard';
+import DayTradeSetupCard      from '../../../components/DayTradeSetupCard';
 import SignalCoherencePanel    from '../../../components/SignalCoherencePanel';
 import OrderBookPanel    from '../../../components/OrderBookPanel';
 import StockChatPanel    from '../../../components/StockChatPanel';
@@ -42,7 +43,7 @@ import GapExplainerBanner    from '../../../components/GapExplainerBanner';
 import ReversalRiskCard       from '../../../components/ReversalRiskCard';
 import DirectionForecastCard  from '../../../components/DirectionForecastCard';
 import MorningBriefingPanel   from '../../../components/MorningBriefingPanel';
-import type { PredictionData, IndicatorKey, TradeSetupResponse, DCFResult, AnalystTargets } from '../../../types';
+import type { PredictionData, IndicatorKey, TradeSetupResponse, DayTradeSetup, DCFResult, AnalystTargets } from '../../../types';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -81,6 +82,8 @@ function AnalysisContent() {
   const [chartMode,        setChartMode]        = useState<'line' | 'candle'>('line');
   const [tradeSetup,       setTradeSetup]       = useState<TradeSetupResponse | null>(null);
   const [tradeSetupLoading, setTradeSetupLoading] = useState(false);
+  const [dayTradeSetup,    setDayTradeSetup]    = useState<DayTradeSetup | null>(null);
+  const [dayTradeLoading,  setDayTradeLoading]  = useState(false);
   const [dcfData,          setDcfData]          = useState<DCFResult | null>(null);
   const [analystTargets,   setAnalystTargets]   = useState<AnalystTargets | null>(null);
   const [analystTargetsLoading, setAnalystTargetsLoading] = useState(false);
@@ -121,6 +124,18 @@ function AnalysisContent() {
       .finally(() => setTradeSetupLoading(false));
   };
 
+  const fetchDayTradeSetup = (data: PredictionData) => {
+    setDayTradeSetup(null);
+    setDayTradeLoading(true);
+    axios.post('/api/day-trade-setup', {
+      symbol:      data.symbol,
+      daily_trend: data.prediction.trend,   // gate intraday coherence vs the daily bias
+    }, { headers: authHeaders })
+      .then(r  => setDayTradeSetup(r.data))
+      .catch(() => { /* non-fatal */ })
+      .finally(() => setDayTradeLoading(false));
+  };
+
   const handlePredict = async (overrideSymbol?: string) => {
     // Determine the full symbol (may carry an exchange suffix, e.g. "AAPL:NASDAQ").
     let fullSymbol: string;
@@ -141,6 +156,7 @@ function AnalysisContent() {
     setLoading(true);
     setError(null);
     setTradeSetup(null);
+    setDayTradeSetup(null);
     setDcfData(null);
     setAnalystTargets(null);
     setAnalystTargetsLoading(false);
@@ -153,8 +169,10 @@ function AnalysisContent() {
       router.replace(`/analysis?symbol=${encodeURIComponent(baseSymbol)}`, { scroll: false });
       if (user) {
         fetchTradeSetup(response.data);
+        fetchDayTradeSetup(response.data);
       } else {
         setTradeSetup(null);
+        setDayTradeSetup(null);
       }
       // Fire-and-forget DCF fetch (non-blocking)
       axios.get(`/api/dcf/${baseSymbol}`)
@@ -198,6 +216,9 @@ function AnalysisContent() {
   useEffect(() => {
     if (session?.access_token && prediction && !tradeSetup && !tradeSetupLoading) {
       fetchTradeSetup(prediction);
+    }
+    if (session?.access_token && prediction && !dayTradeSetup && !dayTradeLoading) {
+      fetchDayTradeSetup(prediction);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [session?.access_token, prediction]);
@@ -378,6 +399,16 @@ function AnalysisContent() {
                     title="Trade Setup"
                     message="Sign in to see entry zones, stop levels, and position sizing."
                     onSignIn={() => setAuthOpen(true)}
+                    isDark={isDark}
+                    primaryColor={primaryColor}
+                  />
+                )}
+
+                {/* ── Day-Trade Setup (intraday ORB+VWAP) ───────────── */}
+                {user && (
+                  <DayTradeSetupCard
+                    setup={dayTradeSetup}
+                    loading={dayTradeLoading}
                     isDark={isDark}
                     primaryColor={primaryColor}
                   />

--- a/frontend/app/api/day-trade-setup/route.ts
+++ b/frontend/app/api/day-trade-setup/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import axios from 'axios';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const auth = request.headers.get('authorization') || '';
+
+    const response = await axios.post(
+      `${BACKEND_URL}/day-trade-setup`,
+      body,
+      { headers: { ...(auth ? { Authorization: auth } : {}) } },
+    );
+    return NextResponse.json(response.data);
+  } catch (error: any) {
+    const status = error.response?.status || 500;
+    const detail = error.response?.data?.detail || 'Day-trade setup failed';
+    return NextResponse.json({ error: detail }, { status });
+  }
+}

--- a/frontend/components/DayTradeSetupCard.tsx
+++ b/frontend/components/DayTradeSetupCard.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { Box, Card, CardContent, Chip, Skeleton, Stack, Typography } from '@mui/material';
+import { AlertTriangle, Banknote, CheckCircle2, Clock, Shield, Target, Zap } from 'lucide-react';
+import type { DayTradeSetup } from '../types';
+
+interface Props {
+  setup:        DayTradeSetup | null;
+  loading:      boolean;
+  isDark:       boolean;
+  primaryColor: string;
+}
+
+/** A single intraday level cell (OR high/low, VWAP, last). Module-scoped so it's
+ *  a stable component, not re-created on every render. */
+function Level({ label, value, color }: { label: string; value: number; color?: string }) {
+  return (
+    <Box sx={{ textAlign: 'center', flex: 1 }}>
+      <Typography sx={{ fontSize: '0.55rem', opacity: 0.5, letterSpacing: '0.05em', fontWeight: 700 }}>
+        {label}
+      </Typography>
+      <Typography sx={{ fontSize: '0.72rem', fontWeight: 800, color: color ?? 'inherit' }}>
+        ${value.toFixed(2)}
+      </Typography>
+    </Box>
+  );
+}
+
+export default function DayTradeSetupCard({ setup, loading, isDark, primaryColor }: Props) {
+  const green = isDark ? '#00ffa3' : '#16a34a';
+  const red   = isDark ? '#ff0055' : '#dc2626';
+  const amber = isDark ? '#ffb020' : '#b45309';
+
+  if (loading) {
+    return <Skeleton variant="rectangular" height={140} sx={{ borderRadius: 2 }} />;
+  }
+  if (!setup) return null;
+
+  const dirColor = setup.direction === 'Short' ? red
+                 : setup.direction === 'Long'  ? green : amber;
+
+  // A "watch" state (not available) shows the reason; "ok" shows the full plan.
+  const watch = !setup.available;
+
+  return (
+    <Card sx={{ border: `1px solid ${dirColor}33` }}>
+      <CardContent sx={{ p: '16px !important' }}>
+        {/* Header */}
+        <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1.5 }}>
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <Zap size={16} color={primaryColor} />
+            <Typography variant="overline" sx={{ opacity: 0.5, lineHeight: 1 }}>
+              Day Trade · ORB
+            </Typography>
+          </Stack>
+          <Stack direction="row" spacing={1}>
+            {!watch && setup.direction !== 'Neutral' && (
+              <Chip
+                label={setup.direction.toUpperCase()}
+                size="small"
+                sx={{
+                  fontSize: '0.65rem', fontWeight: 800, letterSpacing: '0.04em',
+                  background: `${dirColor}22`, color: dirColor, border: `1px solid ${dirColor}66`,
+                }}
+              />
+            )}
+            {!watch && setup.risk_reward && (
+              <Chip
+                label={`R:R ${setup.risk_reward}`}
+                size="small"
+                sx={{
+                  fontSize: '0.65rem', fontWeight: 700,
+                  background: `${green}18`, color: green, border: `1px solid ${green}44`,
+                }}
+              />
+            )}
+          </Stack>
+        </Stack>
+
+        {/* Strategy line */}
+        <Typography sx={{ fontSize: '0.62rem', opacity: 0.45, mb: 1.25 }}>
+          {setup.strategy}
+        </Typography>
+
+        {watch ? (
+          /* Not actionable — explain why (closed / forming / conflict). */
+          <Box sx={{
+            display: 'flex', gap: 1, alignItems: 'flex-start',
+            p: 1.5, borderRadius: 2, border: `1px solid ${amber}55`, background: `${amber}12`,
+          }}>
+            <Box sx={{ mt: '1px', flexShrink: 0 }}><AlertTriangle size={15} color={amber} /></Box>
+            <Typography sx={{ fontSize: '0.78rem', lineHeight: 1.5, color: amber }}>
+              {setup.message}
+            </Typography>
+          </Box>
+        ) : (
+          <>
+            {/* Entry / Stop / Targets */}
+            <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr 1fr' }, gap: 1.5, mb: 1.5 }}>
+              <Box sx={{ p: 1.5, borderRadius: 2, border: `1px solid ${primaryColor}22`, background: `${primaryColor}08` }}>
+                <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 0.75 }}>
+                  <Target size={12} color={primaryColor} />
+                  <Typography sx={{ fontSize: '0.6rem', opacity: 0.5, letterSpacing: '0.07em', fontWeight: 700 }}>ENTRY</Typography>
+                </Stack>
+                <Typography sx={{ fontSize: '0.8rem', fontWeight: 800, color: primaryColor }}>
+                  ${setup.entry!.toFixed(2)}
+                </Typography>
+                <Typography sx={{ fontSize: '0.55rem', opacity: 0.6 }}>OR breakout</Typography>
+              </Box>
+              <Box sx={{ p: 1.5, borderRadius: 2, border: `1px solid ${red}22`, background: `${red}08` }}>
+                <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 0.75 }}>
+                  <Shield size={12} color={red} />
+                  <Typography sx={{ fontSize: '0.6rem', opacity: 0.5, letterSpacing: '0.07em', fontWeight: 700 }}>STOP</Typography>
+                </Stack>
+                <Typography sx={{ fontSize: '0.8rem', fontWeight: 800, color: red }}>
+                  ${setup.stop!.toFixed(2)}
+                </Typography>
+                <Typography sx={{ fontSize: '0.55rem', opacity: 0.6 }}>VWAP / OR edge</Typography>
+              </Box>
+              <Box sx={{ p: 1.5, borderRadius: 2, border: `1px solid ${green}22`, background: `${green}08` }}>
+                <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 0.75 }}>
+                  <Target size={12} color={green} />
+                  <Typography sx={{ fontSize: '0.6rem', opacity: 0.5, letterSpacing: '0.07em', fontWeight: 700 }}>TARGETS</Typography>
+                </Stack>
+                {(setup.targets ?? []).map((t, i) => (
+                  <Typography key={i} sx={{ fontSize: '0.7rem', fontWeight: i === 0 ? 800 : 600, color: green, opacity: 1 - i * 0.2 }}>
+                    T{i + 1} ${t.toFixed(2)}
+                  </Typography>
+                ))}
+              </Box>
+            </Box>
+
+            {/* Intraday levels */}
+            {setup.levels && (
+              <Stack direction="row" sx={{
+                px: 1, py: 1, mb: 1.5, borderRadius: 1.5,
+                background: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
+                border: '1px solid rgba(255,255,255,0.06)',
+              }}>
+                <Level label="OR HIGH" value={setup.levels.or_high} />
+                <Level label="VWAP" value={setup.levels.vwap} color={primaryColor} />
+                <Level label="OR LOW" value={setup.levels.or_low} />
+                <Level label="LAST" value={setup.levels.last} />
+              </Stack>
+            )}
+
+            {/* Entry trigger */}
+            {setup.entry_trigger && (() => {
+              const active = setup.confirmation === 'active';
+              const c = active ? green : amber;
+              const Icon = active ? CheckCircle2 : Clock;
+              return (
+                <Box sx={{
+                  display: 'flex', gap: 1, alignItems: 'flex-start',
+                  p: 1.25, mb: 1.5, borderRadius: 1.5, border: `1px solid ${c}44`, background: `${c}0f`,
+                }}>
+                  <Box sx={{ mt: '1px', flexShrink: 0 }}><Icon size={14} color={c} /></Box>
+                  <Box>
+                    <Typography sx={{ fontSize: '0.6rem', fontWeight: 800, letterSpacing: '0.05em', color: c, mb: 0.25 }}>
+                      {active ? 'BREAKOUT ACTIVE' : 'TRIGGER · PENDING'}
+                    </Typography>
+                    <Typography sx={{ fontSize: '0.72rem', opacity: 0.8, lineHeight: 1.45 }}>
+                      {setup.entry_trigger}
+                    </Typography>
+                  </Box>
+                </Box>
+              );
+            })()}
+
+            {/* CFD framing */}
+            {setup.cfd_note && (
+              <Box sx={{
+                display: 'flex', gap: 1, alignItems: 'flex-start',
+                p: 1.25, borderRadius: 1.5, border: `1px solid ${primaryColor}33`, background: `${primaryColor}0a`,
+              }}>
+                <Box sx={{ mt: '1px', flexShrink: 0 }}><Banknote size={14} color={primaryColor} /></Box>
+                <Box>
+                  <Typography sx={{ fontSize: '0.6rem', fontWeight: 800, letterSpacing: '0.05em', color: primaryColor, mb: 0.25 }}>
+                    CFD {setup.cfd_side ? `· ${setup.cfd_side.toUpperCase()}` : ''}
+                    {setup.cfd_margin_pct != null ? ` · ~${setup.cfd_margin_pct}% MARGIN` : ''}
+                  </Typography>
+                  <Typography sx={{ fontSize: '0.72rem', opacity: 0.75, lineHeight: 1.45 }}>
+                    {setup.cfd_note}
+                  </Typography>
+                </Box>
+              </Box>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -310,6 +310,35 @@ export interface TradeSetupResponse {
   cfd_note?:               string | null;
 }
 
+/** Intraday day-trade setup — VWAP-anchored Opening Range Breakout (ORB). */
+export interface DayTradeSetup {
+  available:      boolean;
+  strategy:       string;
+  /** ok | market_closed | forming | conflict | no_setup */
+  status:         string;
+  message:        string;
+  direction:      'Long' | 'Short' | 'Neutral';
+  entry:          number | null;
+  stop:           number | null;
+  targets:        number[] | null;
+  risk_reward:    string | null;
+  entry_trigger:  string | null;
+  confirmation:   'active' | 'pending' | null;
+  levels: {
+    or_high:      number;
+    or_low:       number;
+    vwap:         number;
+    session_high: number;
+    session_low:  number;
+    last:         number;
+    n_bars:       number;
+    or_complete:  boolean;
+  } | null;
+  cfd_side:       'Buy' | 'Sell' | null;
+  cfd_margin_pct: number | null;
+  cfd_note:       string | null;
+}
+
 export interface ChatMessage {
   role:    'user' | 'assistant';
   content: string;


### PR DESCRIPTION
Stacked on #288 (base = `fix/trade-signal-coherence`). Adds a **second, distinct setup** next to the swing setup so the analysis page now shows both:

- **Swing Setup · 5D** — Trend-Pullback + daily candle confirmation (from #288).
- **Day Trade · ORB** — intraday VWAP-anchored Opening Range Breakout (this PR).

## The workaround (no per-minute streaming)
Uses a **single 5-min snapshot** (`yfinance period=1d&interval=5m`, RTH only — the same call `/sparklines` already makes). From that one pull it derives the opening range (first 30 min), session VWAP, and session H/L, then builds a defined-risk plan. Generated on demand; the trader places it on their broker.

## Strategy (deterministic, coherence-gated)
- **Bias gate** (the part that makes it *work*): only take a trade when intraday VWAP position agrees with the daily composite trend. If they disagree → **"no clean day trade"**. A Neutral daily trend → pure VWAP momentum. This stops the intraday call from contradicting the daily thesis — the same anti-contradiction principle as #288, applied intraday.
- **Entry** = opening-range breakout · **Stop** = nearest of {VWAP, opposite OR edge} · **Targets** = 1R / 2R / measured-move.
- **States**: market_closed / forming / conflict / pending / active.
- **CFD note** highlights the day-trade edge: closed intraday → **no overnight financing**.

## Files
- `backend/day_trade_service.py` (fetch + pure `compute_intraday_levels` / `build_orb_setup`)
- `POST /day-trade-setup` (auth-gated; always 200 with an `available`/`status` payload)
- `frontend/components/DayTradeSetupCard.tsx` + proxy + type + analysis-page wiring (renders below the swing card)

## Verification
- `backend/tests/test_day_trade.py` (10 tests: OR/VWAP math + strategy core). **341 backend tests pass.** Ruff + frontend lint/build clean.
- Live: **GOOGL** (daily bearish, price above VWAP) and **NVDA** (daily bullish, below VWAP) correctly gated as *conflict / no clean day trade*; **AAPL** (daily neutral) → actionable **Short ORB**, R:R 1:2.0.

Note: both setup cards are auth-gated (like the existing swing card), so they render when signed in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)