### PR TITLE
feat(rotation): Sector Rotation relative-strength leaderboard (Feature 27)

### DIFF
--- a/.claude/FiForesight_Roadmap.md
+++ b/.claude/FiForesight_Roadmap.md
@@ -73,6 +73,7 @@ Documentation is part of the feature, not an afterthought. A feature PR is **not
 - URL-persistent analysis tab — `?symbol=` param, `router.replace` after predict, watchlist quick-launch (#228)
 - VWAP intraday overlay — dashed line + ±1σ bands on 1D/5D intervals (#228)
 - Dividend & Income card (Feature 26): `GET /dividends/{symbol}` (yfinance, Redis 6h) + `DividendIncomeCard` — forward yield, annual rate, payout ratio, 5-yr avg yield, ex-date, YoY growth; clean non-payer empty state.
+- Sector Rotation leaderboard (Feature 27): `GET /sectors/rotation` (11 GICS ETFs' relative strength vs SPY over 1M/3M/6M + RRG-lite quadrant, Redis 1h) + `/rotation` page (leaderboard table + quadrant scatter, click-to-analyze). Reuses the heatmap batch-download machinery.
 
 ### Navigation & Architecture
 - App Shell sidebar — collapsible, mobile bottom nav, `AppShellContext`, theme + auth in footer (#223)
@@ -193,6 +194,7 @@ Documentation is part of the feature, not an afterthought. A feature PR is **not
 - ~~Macro dashboard (`/macro` tab)~~ ✅ SHIPPED (Feature 15) — standalone FRED tab: 5 stat cards, T10Y2Y trend line, 30d-delta bar chart, inversion banner
 - International markets — yfinance supports non-US tickers; exchange detection already exists · `[Value: Med]` `[Effort: Med]`
 - ~~Analyst price target range~~ ✅ SHIPPED (Feature 21, PR #267) — `GET /analyst-targets/{symbol}`, `AnalystTargetsCard` (low/mean/high range bar + current marker + rating breakdown) below `DCFCard`
+- "Setups today" hint — scan the user's watchlist and flag which tickers have a *clean* (actionable) swing and/or day-trade setup, so users aren't hunting ticker-by-ticker. The coherence gate (PR #288/#289) correctly returns "no clean trade" on most choppy-day tickers (~3/10 actionable in a basket scan), so this surfaces the few that pass without loosening the gate. Likely a small badge/count in the Watchlist panel + an endpoint that fans out `/trade-setup` + `/day-trade-setup` per watchlist symbol (reuse Redis cache; one row each). · `[Value: High]` `[Effort: Med]`
 
 ### Architecture & Infra
 - Custom alert rule builder — price cross, RSI threshold, % move triggers; needs auth + background worker + notification channel · `[Value: High]` `[Effort: High]`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ FiForesight/
 │   │   ├── predict.py          # /health /debug /predict /sparklines /compare
 │   │   ├── simulation.py       # /simulation/suggest /simulation/performance /simulation/state
 │   │   ├── trade.py            # /trade-setup /chat
-│   │   ├── market.py           # /dcf /options /ipo/calendar /earnings/calendar /sectors/heatmap (F23) /briefing /orderbook /macro/snapshot /insider/{symbol} (F15) /screener (F24)
+│   │   ├── market.py           # /dcf /options /ipo/calendar /earnings/calendar /sectors/heatmap (F23) /sectors/rotation (F27) /briefing /orderbook /macro/snapshot /insider/{symbol} (F15) /screener (F24)
 │   │   ├── analytics.py        # /analytics/accuracy/{symbol} /analytics/sentiment/{symbol}
 │   │   ├── portfolio.py        # /portfolio/holdings (GET/POST/DELETE) /portfolio/summary (auth-gated)
 │   │   ├── alerts.py           # /alerts/rules (CRUD) /alerts/fires /alerts/subscribe /alerts/evaluate [cron] (Feature 9)

--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -790,6 +790,87 @@ async def get_sector_heatmap(request: Request) -> List[Dict[str, Any]]:
     return result
 
 
+@router.get("/sectors/rotation")
+@limiter.limit(lambda: Config.RATE_LIMIT_READONLY, key_func=get_remote_address)
+async def sector_rotation(request: Request) -> List[Dict[str, Any]]:
+    """Relative strength of each GICS sector ETF vs SPY over 1M/3M/6M.
+
+    Returns a list of {sector, etf, rs_1m, rs_3m, rs_6m, rs_momentum,
+    quadrant, ret_1m} sorted by rs_1m desc. rs_* = ETF % return − SPY %
+    return over that window. rs_momentum = rs_1m − rs_3m (positive = catching
+    up). quadrant ∈ {leading, weakening, lagging, improving} from sign of
+    rs_3m (level) × sign of rs_momentum. Redis-cached 1h; 502 on total
+    fetch failure (one missing ETF is skipped, not fatal). 60/min."""
+    CACHE_KEY = "sectors:rotation:f27"
+    cached = await cache_get(CACHE_KEY)
+    if cached:
+        return cached
+
+    tickers = list(SECTOR_ETF_MAP.values()) + ["SPY"]
+
+    def _closes(raw, etf):
+        """Close series for one ticker — handles grouped (multi-ticker) and
+        flat (single-ticker) column layouts, mirroring the heatmap helper."""
+        try:
+            return raw[etf]["Close"].dropna()
+        except KeyError:
+            return raw["Close"].dropna()
+
+    def _ret(closes, bars):
+        if len(closes) <= bars:
+            return None
+        return (closes.iloc[-1] / closes.iloc[-bars - 1] - 1) * 100
+
+    def _fetch() -> List[Dict[str, Any]]:
+        raw = yf.download(
+            " ".join(tickers), period="7mo", interval="1d",
+            auto_adjust=True, progress=False, group_by="ticker",
+        )
+        spy = _closes(raw, "SPY")
+        spy_1m, spy_3m, spy_6m = _ret(spy, 21), _ret(spy, 63), _ret(spy, 126)
+        rows: List[Dict[str, Any]] = []
+        for sector, etf in SECTOR_ETF_MAP.items():
+            try:
+                c = _closes(raw, etf)
+                if len(c) < 22:
+                    continue
+                r1, r3, r6 = _ret(c, 21), _ret(c, 63), _ret(c, 126)
+                rs_1m = round(r1 - spy_1m, 2) if r1 is not None and spy_1m is not None else None
+                rs_3m = round(r3 - spy_3m, 2) if r3 is not None and spy_3m is not None else None
+                rs_6m = round(r6 - spy_6m, 2) if r6 is not None and spy_6m is not None else None
+                momentum = round((rs_1m - rs_3m), 2) if rs_1m is not None and rs_3m is not None else None
+                level = rs_3m if rs_3m is not None else (rs_1m or 0)
+                mom = momentum if momentum is not None else 0
+                if level >= 0 and mom >= 0:
+                    quadrant = "leading"
+                elif level >= 0 and mom < 0:
+                    quadrant = "weakening"
+                elif level < 0 and mom >= 0:
+                    quadrant = "improving"
+                else:
+                    quadrant = "lagging"
+                rows.append({
+                    "sector": sector, "etf": etf, "rs_1m": rs_1m,
+                    "rs_3m": rs_3m, "rs_6m": rs_6m, "rs_momentum": momentum,
+                    "quadrant": quadrant,
+                    "ret_1m": round(r1, 2) if r1 is not None else None,
+                })
+            except Exception as e:
+                logger.warning(f"sector rotation {etf}: {e}")
+        rows.sort(key=lambda x: (x["rs_1m"] if x["rs_1m"] is not None else -999), reverse=True)
+        return rows
+
+    try:
+        result = await asyncio.wait_for(asyncio.to_thread(_fetch), timeout=15.0)
+    except Exception as e:
+        logger.error(f"sector rotation: {e}")
+        raise HTTPException(status_code=502, detail="Could not fetch rotation data")
+    if not result:
+        raise HTTPException(status_code=502, detail="Could not fetch rotation data")
+    await cache_set(CACHE_KEY, result, ttl_seconds=3600)
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Morning Briefing
 # ---------------------------------------------------------------------------

--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -861,7 +861,7 @@ async def sector_rotation(request: Request) -> List[Dict[str, Any]]:
         return rows
 
     try:
-        result = await asyncio.wait_for(asyncio.to_thread(_fetch), timeout=15.0)
+        result = await asyncio.wait_for(asyncio.to_thread(_fetch), timeout=12.0)
     except Exception as e:
         logger.error(f"sector rotation: {e}")
         raise HTTPException(status_code=502, detail="Could not fetch rotation data")

--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -808,7 +808,7 @@ async def sector_rotation(request: Request) -> List[Dict[str, Any]]:
 
     tickers = list(SECTOR_ETF_MAP.values()) + ["SPY"]
 
-    def _closes(raw, etf):
+    def _closes(raw: pd.DataFrame, etf: str) -> pd.Series:
         """Close series for one ticker — handles grouped (multi-ticker) and
         flat (single-ticker) column layouts, mirroring the heatmap helper."""
         try:
@@ -816,7 +816,7 @@ async def sector_rotation(request: Request) -> List[Dict[str, Any]]:
         except KeyError:
             return raw["Close"].dropna()
 
-    def _ret(closes, bars):
+    def _ret(closes: pd.Series, bars: int) -> Optional[float]:
         if len(closes) <= bars:
             return None
         return (closes.iloc[-1] / closes.iloc[-bars - 1] - 1) * 100

--- a/backend/tests/test_sector_rotation.py
+++ b/backend/tests/test_sector_rotation.py
@@ -1,0 +1,172 @@
+"""
+Sector rotation endpoint tests (F27) — GET /sectors/rotation.
+yf.download is mocked; no network required.
+"""
+from collections.abc import Generator
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from fastapi.responses import JSONResponse
+from slowapi.errors import RateLimitExceeded
+
+from backend.routers import market
+from backend.routers.market import SECTOR_ETF_MAP
+
+_FIELDS = ["Open", "High", "Low", "Close", "Volume"]
+_N = 140  # enough rows for the 126-bar (6M) lookback
+
+
+@pytest.fixture(autouse=True)
+def _no_cache() -> Generator[None, None, None]:
+    """Force the Redis cache inert so the endpoint's cache (sectors:rotation:f27)
+    can't leak between tests and skip the patched yf.download."""
+    with patch("redis_cache.get_redis", return_value=None):
+        yield
+
+
+def _build_app() -> TestClient:
+    app = FastAPI()
+    app.state.limiter = market.limiter
+
+    async def _handler(req: Request, exc: RateLimitExceeded) -> JSONResponse:
+        return JSONResponse(status_code=429, content={"detail": "rate limited"})
+
+    app.add_exception_handler(RateLimitExceeded, _handler)
+    app.include_router(market.router)
+    return TestClient(app)
+
+
+client = _build_app()
+
+
+def _ramp(total_return_pct: float) -> list[float]:
+    """A monotonic close series from 100 to 100*(1+total_return_pct/100) over _N bars."""
+    end = 100.0 * (1 + total_return_pct / 100.0)
+    return list(np.linspace(100.0, end, _N))
+
+
+def _frame(series_by_ticker: dict[str, list[float] | None], drop: str | None = None) -> pd.DataFrame:
+    """A grouped yfinance-style frame (MultiIndex [ticker, field]).
+
+    `series_by_ticker` maps ticker -> close list (or None for all-NaN).
+    `drop` omits that ticker's columns entirely (simulates a dropped batch member).
+    """
+    tickers = [t for t in series_by_ticker if t != drop]
+    cols = pd.MultiIndex.from_product([tickers, _FIELDS])
+    frame = pd.DataFrame(index=range(_N), columns=cols, dtype="float64")
+    for t in tickers:
+        closes = series_by_ticker[t]
+        vals = [np.nan] * _N if closes is None else closes
+        for field in _FIELDS:
+            frame[(t, field)] = vals
+    return frame
+
+
+def test_rotation_computes_relative_strength() -> None:
+    # SPY flat-ish; XLK strongly outperforms, XLE underperforms.
+    leader = SECTOR_ETF_MAP["Technology"]    # XLK
+    laggard = SECTOR_ETF_MAP["Energy"]       # XLE
+    series = {etf: _ramp(5.0) for etf in SECTOR_ETF_MAP.values()}
+    series["SPY"] = _ramp(5.0)
+    series[leader] = _ramp(25.0)
+    series[laggard] = _ramp(-10.0)
+
+    with patch("backend.routers.market.yf.download", return_value=_frame(series)):
+        resp = client.get("/sectors/rotation")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) == len(SECTOR_ETF_MAP)
+
+    by_etf = {r["etf"]: r for r in rows}
+    assert by_etf[leader]["rs_1m"] > 0
+    assert by_etf[laggard]["rs_1m"] < 0
+    # Sorted by rs_1m desc → strongest outperformer first, weakest last.
+    assert rows[0]["etf"] == leader
+    assert rows[-1]["etf"] == laggard
+    # SPY is the benchmark, never an output row.
+    assert all(r["etf"] != "SPY" for r in rows)
+
+
+def test_quadrant_classification() -> None:
+    rows = [
+        {"rs_3m": 5.0,  "rs_momentum": 2.0,  "quadrant": "leading"},
+        {"rs_3m": 5.0,  "rs_momentum": -2.0, "quadrant": "weakening"},
+        {"rs_3m": -5.0, "rs_momentum": 2.0,  "quadrant": "improving"},
+        {"rs_3m": -5.0, "rs_momentum": -2.0, "quadrant": "lagging"},
+    ]
+    for case in rows:
+        level, mom = case["rs_3m"], case["rs_momentum"]
+        if level >= 0 and mom >= 0:
+            q = "leading"
+        elif level >= 0 and mom < 0:
+            q = "weakening"
+        elif level < 0 and mom >= 0:
+            q = "improving"
+        else:
+            q = "lagging"
+        assert q == case["quadrant"]
+
+
+def test_quadrant_classification_endpoint() -> None:
+    """Drive each quadrant through the real endpoint by shaping rs_3m / rs_momentum.
+
+    SPY is a flat constant series (1M/3M/6M returns all 0), so for each ETF
+    rs_1m == its own 1M return and rs_3m == its own 3M return, and
+    rs_momentum == rs_1m − rs_3m. We pin the close at the 1M and 3M lookback
+    anchors (bars −22 and −64) with last close = 100 to hit exact returns.
+    """
+    series: dict[str, list[float] | None] = {}
+    # SPY flat over every window → RS == the ETF's own returns.
+    series["SPY"] = [100.0] * _N
+
+    def _shaped(r1: float, r3: float) -> list[float]:
+        s = [100.0] * _N
+        s[-1] = 100.0
+        s[-22] = 100.0 / (1 + r1 / 100.0)   # r1 = (last/anchor − 1)·100
+        s[-64] = 100.0 / (1 + r3 / 100.0)
+        return s
+
+    # leading: level>0, momentum>=0  (r1 >= r3 > 0)
+    series[SECTOR_ETF_MAP["Technology"]] = _shaped(8.0, 4.0)
+    # weakening: level>0, momentum<0  (0 < r1 < r3)
+    series[SECTOR_ETF_MAP["Healthcare"]] = _shaped(2.0, 6.0)
+    # improving: level<0, momentum>=0  (r3 < 0, r1 >= r3)
+    series[SECTOR_ETF_MAP["Energy"]] = _shaped(-2.0, -6.0)
+    # lagging: level<0, momentum<0  (r1 < r3 < 0)
+    series[SECTOR_ETF_MAP["Utilities"]] = _shaped(-8.0, -4.0)
+
+    # Remaining sectors get a flat series so they don't interfere.
+    for etf in SECTOR_ETF_MAP.values():
+        series.setdefault(etf, [100.0] * _N)
+
+    with patch("backend.routers.market.yf.download", return_value=_frame(series)):
+        resp = client.get("/sectors/rotation")
+    assert resp.status_code == 200
+    by_etf = {r["etf"]: r for r in resp.json()}
+    assert by_etf[SECTOR_ETF_MAP["Technology"]]["quadrant"] == "leading"
+    assert by_etf[SECTOR_ETF_MAP["Healthcare"]]["quadrant"] == "weakening"
+    assert by_etf[SECTOR_ETF_MAP["Energy"]]["quadrant"] == "improving"
+    assert by_etf[SECTOR_ETF_MAP["Utilities"]]["quadrant"] == "lagging"
+
+
+def test_missing_etf_skipped() -> None:
+    dropped = SECTOR_ETF_MAP["Industrials"]  # XLI omitted from the batch entirely
+    series = {etf: _ramp(5.0) for etf in SECTOR_ETF_MAP.values()}
+    series["SPY"] = _ramp(5.0)
+
+    with patch("backend.routers.market.yf.download", return_value=_frame(series, drop=dropped)):
+        resp = client.get("/sectors/rotation")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert all(r["etf"] != dropped for r in rows)
+    assert len(rows) == len(SECTOR_ETF_MAP) - 1
+
+
+def test_total_failure_502() -> None:
+    with patch("backend.routers.market.yf.download", side_effect=RuntimeError("boom")):
+        resp = client.get("/sectors/rotation")
+    assert resp.status_code == 502

--- a/backend/tests/test_sector_rotation.py
+++ b/backend/tests/test_sector_rotation.py
@@ -172,3 +172,18 @@ def test_total_failure_502() -> None:
     with patch("backend.routers.market.yf.download", side_effect=RuntimeError("boom")):
         resp = client.get("/sectors/rotation")
     assert resp.status_code == 502
+
+
+def test_empty_rows_502() -> None:
+    # Download succeeds structurally but every series is too short for the 1M
+    # lookback (len < 22), so no sector yields a row → empty result → 502.
+    tickers = list(SECTOR_ETF_MAP.values()) + ["SPY"]
+    cols = pd.MultiIndex.from_product([tickers, _FIELDS])
+    short = pd.DataFrame(index=range(10), columns=cols, dtype="float64")
+    for t in tickers:
+        for field in _FIELDS:
+            short[(t, field)] = list(np.linspace(100.0, 105.0, 10))
+
+    with patch("backend.routers.market.yf.download", return_value=short):
+        resp = client.get("/sectors/rotation")
+    assert resp.status_code == 502

--- a/backend/tests/test_sector_rotation.py
+++ b/backend/tests/test_sector_rotation.py
@@ -100,11 +100,13 @@ def test_quadrant_classification() -> None:
     ]
     for case in rows:
         level, mom = case["rs_3m"], case["rs_momentum"]
+        # Mirrors the endpoint's classification; the guards after the first branch
+        # are deliberately reduced (the static analyzer flags the implied ones).
         if level >= 0 and mom >= 0:
             q = "leading"
-        elif level >= 0 and mom < 0:
+        elif level >= 0:
             q = "weakening"
-        elif level < 0 and mom >= 0:
+        elif mom >= 0:
             q = "improving"
         else:
             q = "lagging"

--- a/frontend/app/(app)/layout.tsx
+++ b/frontend/app/(app)/layout.tsx
@@ -11,6 +11,7 @@ import {
   BrainCircuit, Home, Search, BarChart2, Calendar, Rocket, LineChart,
   Activity, Wallet, Bell, ChevronLeft, ChevronRight, Sun, Moon, LogIn, LogOut,
   Star, ChevronDown, ChevronUp, MoreHorizontal, Globe, Grid2X2, SlidersHorizontal,
+  RefreshCw,
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { AppShellProvider, useAppShell } from '../../contexts/AppShellContext';
@@ -38,6 +39,7 @@ const NAV_ITEMS: NavItem[] = [
   { label: 'IPO Tracker',  href: '/ipo',        icon: Rocket,    mobile: false },
   { label: 'Macro',        href: '/macro',      icon: Globe,     mobile: false },
   { label: 'Sectors',      href: '/sectors',    icon: Grid2X2,   mobile: false },
+  { label: 'Rotation',     href: '/rotation',   icon: RefreshCw, mobile: false },
   { label: 'Screener',     href: '/screener',   icon: SlidersHorizontal, mobile: false },
   { label: 'Watchlist',    href: '/watchlist',  icon: Star,      mobile: false },
   { label: 'Insights',     href: '/insights',   icon: Activity,  mobile: false },

--- a/frontend/app/(app)/rotation/page.tsx
+++ b/frontend/app/(app)/rotation/page.tsx
@@ -148,7 +148,16 @@ export default function SectorRotationPage() {
                           key={row.etf}
                           hover
                           onClick={() => handleSelect(row.etf)}
-                          sx={{ cursor: 'pointer' }}
+                          role="link"
+                          tabIndex={0}
+                          aria-label={`Analyze ${row.sector} (${row.etf})`}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSelect(row.etf); }
+                          }}
+                          sx={{
+                            cursor: 'pointer',
+                            '&:focus-visible': { outline: `2px solid ${primaryColor}`, outlineOffset: -2 },
+                          }}
                         >
                           <TableCell>
                             <Typography variant="body2" sx={{ fontWeight: 700 }}>{row.sector}</Typography>

--- a/frontend/app/(app)/rotation/page.tsx
+++ b/frontend/app/(app)/rotation/page.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  Alert, Box, Card, CardContent, Chip, Container, Skeleton, Stack, Table,
+  TableBody, TableCell, TableContainer, TableHead, TableRow, Typography,
+  useMediaQuery, useTheme,
+} from '@mui/material';
+import {
+  ScatterChart, Scatter, XAxis, YAxis, ZAxis, CartesianGrid,
+  ResponsiveContainer, Tooltip, ReferenceLine, LabelList, Cell,
+} from 'recharts';
+import { RefreshCw } from 'lucide-react';
+import { useAppShell } from '../../../contexts/AppShellContext';
+import type { SectorRotationRow } from '../../../types';
+
+type Quadrant = SectorRotationRow['quadrant'];
+
+const QUADRANT_LABEL: Record<Quadrant, string> = {
+  leading:   'Leading',
+  weakening: 'Weakening',
+  improving: 'Improving',
+  lagging:   'Lagging',
+};
+
+// Quadrant accents — leading=green, improving=blue, weakening=amber, lagging=red.
+function quadrantColor(q: Quadrant, isDark: boolean): string {
+  switch (q) {
+    case 'leading':   return isDark ? '#00ffa3' : '#16a34a';
+    case 'improving': return isDark ? '#38bdf8' : '#2563eb';
+    case 'weakening': return isDark ? '#fbbf24' : '#d97706';
+    case 'lagging':   return isDark ? '#ff5d73' : '#dc2626';
+  }
+}
+
+function rsColor(value: number | null, isDark: boolean): string {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return isDark ? '#94a3b8' : '#64748b';
+  }
+  if (value > 0) return isDark ? '#00ffa3' : '#16a34a';
+  if (value < 0) return isDark ? '#ff5d73' : '#dc2626';
+  return isDark ? '#94a3b8' : '#64748b';
+}
+
+function formatRs(value: number | null): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return '—';
+  return `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`;
+}
+
+export default function SectorRotationPage() {
+  const { isDark, primaryColor } = useAppShell();
+  const theme = useTheme();
+  const router = useRouter();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isTablet = useMediaQuery(theme.breakpoints.down('md'));
+
+  const [rows, setRows] = useState<SectorRotationRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const refresh = () => {
+      fetch('/api/sectors/rotation')
+        .then(r => {
+          if (!r.ok) throw new Error(`HTTP ${r.status}`);
+          return r.json();
+        })
+        .then((data: SectorRotationRow[]) => {
+          if (cancelled) return;
+          if (Array.isArray(data)) {
+            setRows(data);
+            setError(false);
+          } else {
+            setError(true);
+          }
+        })
+        .catch(() => { if (!cancelled) setError(true); })
+        .finally(() => { if (!cancelled) setLoading(false); });
+    };
+
+    refresh();
+    const interval = setInterval(refresh, 300_000); // 5 min
+    return () => { cancelled = true; clearInterval(interval); };
+  }, []);
+
+  // The analysis page auto-forecasts when ?symbol= changes — same convention the
+  // sector heatmap uses for click-to-analyze.
+  const handleSelect = (etf: string) => {
+    router.push(`/analysis?symbol=${encodeURIComponent(etf)}`);
+  };
+
+  const gridColor = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';
+  const axisColor = isDark ? '#94a3b8' : '#64748b';
+  const scatterHeight = isMobile ? 220 : isTablet ? 300 : 400;
+
+  // Only sectors with both a level (rs_3m) and a momentum reading can be plotted.
+  const scatterData = rows.filter(r => r.rs_3m !== null && r.rs_momentum !== null);
+
+  return (
+    <Container maxWidth="lg" disableGutters>
+      <Stack direction="row" alignItems="center" gap={1.5} sx={{ mb: 0.5 }}>
+        <RefreshCw size={26} color={primaryColor} />
+        <Typography variant="h5" sx={{ fontWeight: 800, letterSpacing: '-0.02em' }}>
+          Sector Rotation
+        </Typography>
+      </Stack>
+      <Typography color="text.secondary" sx={{ mb: 3 }}>
+        Relative strength of all 11 GICS sector ETFs vs the S&amp;P 500 (SPY) over 1M / 3M / 6M.
+        Leading sectors are outperforming and still improving; lagging ones are underperforming and
+        falling further behind. Click a sector to run a full forecast on its ETF.
+      </Typography>
+
+      {error && !loading && rows.length === 0 ? (
+        <Alert severity="warning">Sector rotation data unavailable</Alert>
+      ) : (
+        <Stack spacing={3}>
+          {/* ── Leaderboard ─────────────────────────────────────────────── */}
+          <Card>
+            <CardContent>
+              <Typography variant="overline" sx={{ opacity: 0.6 }}>
+                Relative-Strength Leaderboard
+              </Typography>
+              {loading ? (
+                <Stack spacing={1} sx={{ mt: 1 }}>
+                  {Array.from({ length: 6 }).map((_, i) => (
+                    <Skeleton key={i} variant="rounded" height={40} />
+                  ))}
+                </Stack>
+              ) : (
+                <TableContainer sx={{ overflowX: 'auto', mt: 1 }}>
+                  <Table size="small">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Sector (ETF)</TableCell>
+                        <TableCell align="right">RS 1M</TableCell>
+                        <TableCell align="right">RS 3M</TableCell>
+                        <TableCell align="right">RS 6M</TableCell>
+                        <TableCell align="right">Momentum</TableCell>
+                        <TableCell align="center">Quadrant</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {rows.map(row => (
+                        <TableRow
+                          key={row.etf}
+                          hover
+                          onClick={() => handleSelect(row.etf)}
+                          sx={{ cursor: 'pointer' }}
+                        >
+                          <TableCell>
+                            <Typography variant="body2" sx={{ fontWeight: 700 }}>{row.sector}</Typography>
+                            <Typography variant="caption" sx={{ opacity: 0.6 }}>{row.etf}</Typography>
+                          </TableCell>
+                          <TableCell align="right" sx={{ color: rsColor(row.rs_1m, isDark), fontWeight: 700 }}>
+                            {formatRs(row.rs_1m)}
+                          </TableCell>
+                          <TableCell align="right" sx={{ color: rsColor(row.rs_3m, isDark) }}>
+                            {formatRs(row.rs_3m)}
+                          </TableCell>
+                          <TableCell align="right" sx={{ color: rsColor(row.rs_6m, isDark) }}>
+                            {formatRs(row.rs_6m)}
+                          </TableCell>
+                          <TableCell align="right" sx={{ color: rsColor(row.rs_momentum, isDark) }}>
+                            {formatRs(row.rs_momentum)}
+                          </TableCell>
+                          <TableCell align="center">
+                            <Chip
+                              size="small"
+                              label={QUADRANT_LABEL[row.quadrant]}
+                              sx={{
+                                fontWeight: 700, height: 22,
+                                color: quadrantColor(row.quadrant, isDark),
+                                bgcolor: `${quadrantColor(row.quadrant, isDark)}1a`,
+                              }}
+                            />
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* ── Quadrant scatter (RRG-lite) ─────────────────────────────── */}
+          <Card>
+            <CardContent>
+              <Typography variant="overline" sx={{ opacity: 0.6 }}>
+                Rotation Quadrant · RS Level (3M) vs RS Momentum
+              </Typography>
+              {loading ? (
+                <Skeleton variant="rectangular" height={scatterHeight} sx={{ borderRadius: 2, mt: 1 }} />
+              ) : scatterData.length === 0 ? (
+                <Box sx={{ height: scatterHeight, display: 'flex', alignItems: 'center', justifyContent: 'center', opacity: 0.4 }}>
+                  <Typography variant="body2" sx={{ color: axisColor }}>Not enough history to plot</Typography>
+                </Box>
+              ) : (
+                <ResponsiveContainer width="100%" height={scatterHeight}>
+                  <ScatterChart margin={{ top: 20, right: 24, bottom: 16, left: 8 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke={gridColor} />
+                    <XAxis
+                      type="number" dataKey="rs_3m" name="RS Level (3M)"
+                      stroke={axisColor} tick={{ fontSize: 11 }}
+                      domain={['auto', 'auto']}
+                      label={{ value: 'RS Level (3M) %', position: 'insideBottom', offset: -8, fill: axisColor, fontSize: 11 }}
+                    />
+                    <YAxis
+                      type="number" dataKey="rs_momentum" name="RS Momentum"
+                      stroke={axisColor} tick={{ fontSize: 11 }}
+                      domain={['auto', 'auto']}
+                      label={{ value: 'Momentum', angle: -90, position: 'insideLeft', fill: axisColor, fontSize: 11 }}
+                    />
+                    <ZAxis range={[120, 120]} />
+                    <ReferenceLine x={0} stroke={axisColor} strokeDasharray="2 2" />
+                    <ReferenceLine y={0} stroke={axisColor} strokeDasharray="2 2" />
+                    <Tooltip
+                      cursor={{ strokeDasharray: '3 3' }}
+                      contentStyle={{ background: isDark ? '#0f172a' : '#fff', border: `1px solid ${gridColor}`, borderRadius: 8 }}
+                      formatter={(v: number, n: string) => [`${v >= 0 ? '+' : ''}${v.toFixed(2)}%`, n]}
+                      labelFormatter={() => ''}
+                    />
+                    <Scatter data={scatterData}>
+                      {scatterData.map(d => (
+                        <Cell key={d.etf} fill={quadrantColor(d.quadrant, isDark)} />
+                      ))}
+                      <LabelList dataKey="etf" position="top" style={{ fontSize: 11, fill: axisColor, fontWeight: 700 }} />
+                    </Scatter>
+                  </ScatterChart>
+                </ResponsiveContainer>
+              )}
+              <Stack direction="row" spacing={1} sx={{ mt: 1.5, flexWrap: 'wrap', gap: 0.5 }}>
+                {(['leading', 'improving', 'weakening', 'lagging'] as Quadrant[]).map(q => (
+                  <Chip
+                    key={q}
+                    size="small"
+                    label={QUADRANT_LABEL[q]}
+                    sx={{
+                      fontWeight: 700, height: 22,
+                      color: quadrantColor(q, isDark),
+                      bgcolor: `${quadrantColor(q, isDark)}1a`,
+                    }}
+                  />
+                ))}
+              </Stack>
+            </CardContent>
+          </Card>
+        </Stack>
+      )}
+    </Container>
+  );
+}

--- a/frontend/app/api/sectors/rotation/route.ts
+++ b/frontend/app/api/sectors/rotation/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
+export async function GET() {
+  try {
+    const res = await fetch(`${BACKEND_URL}/sectors/rotation`, {
+      next: { revalidate: 3600 },
+      signal: AbortSignal.timeout(25000),
+    });
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (err: unknown) {
+    console.error('[sectors/rotation] proxy error:', err);
+    return NextResponse.json({ error: 'Failed to load sector rotation data' }, { status: 502 });
+  }
+}

--- a/frontend/app/api/sectors/rotation/route.ts
+++ b/frontend/app/api/sectors/rotation/route.ts
@@ -3,7 +3,9 @@ const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
 export async function GET() {
   try {
     const res = await fetch(`${BACKEND_URL}/sectors/rotation`, {
-      next: { revalidate: 3600 },
+      // Backend already Redis-caches this 1h; keep the proxy window short so the
+      // backend TTL stays the freshness boundary (page also re-fetches every 5 min).
+      next: { revalidate: 300 },
       signal: AbortSignal.timeout(25000),
     });
     const data = await res.json();

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -214,6 +214,17 @@ export interface SectorRow {
   source?: string;   // data provider, e.g. "yfinance"
 }
 
+export interface SectorRotationRow {
+  sector: string;
+  etf: string;
+  rs_1m: number | null;
+  rs_3m: number | null;
+  rs_6m: number | null;
+  rs_momentum: number | null;
+  quadrant: 'leading' | 'weakening' | 'improving' | 'lagging';
+  ret_1m: number | null;
+}
+
 export interface DirectionForecast {
   /** "up" | "down" — predicted next-day direction. */
   direction:      'up' | 'down';


### PR DESCRIPTION
## Feature 27 — Sector Rotation leaderboard

Adds a `/rotation` view showing which GICS sectors are leading or lagging the S&P 500 by relative strength (RRG-lite).

### Backend
- **`GET /sectors/rotation`** (`backend/routers/market.py`) — reuses the existing heatmap batch-download machinery (`SECTOR_ETF_MAP` + grouped/flat close handling) over a 7-month window with **SPY as the benchmark**. Computes:
  - `rs_1m` / `rs_3m` / `rs_6m` = ETF % return − SPY % return at 21/63/126 trading-day lookbacks
  - `rs_momentum` = `rs_1m − rs_3m` (positive = catching up)
  - `quadrant` ∈ {leading, weakening, improving, lagging} from sign of level (`rs_3m`) × momentum
  - Sorted by `rs_1m` desc, Redis-cached 1h; one missing ETF is skipped (not fatal), total fetch failure → 502.

### Frontend
- `SectorRotationRow` type + `/api/sectors/rotation` proxy (clones the heatmap proxy).
- **`/rotation` page**: relative-strength leaderboard table (color-coded RS cells, quadrant chips, rows click through to `/analysis?symbol=ETF`) + a Recharts quadrant `ScatterChart` (`rs_3m` × `rs_momentum`, zero-crossing `ReferenceLine`s, responsive 220/300/400 heights).
- **"Rotation"** `NAV_ITEMS` entry (`RefreshCw` icon, `mobile: false` → More drawer) next to Sectors.

### Tests / Docs
- `backend/tests/test_sector_rotation.py` — 5 cases (RS computation + sort, quadrant logic, endpoint-driven quadrants, missing-ETF skip, 502). No network (yf.download mocked).
- Roadmap → Shipped (Data & UX); CLAUDE.md endpoint map updated. Also folded in the stashed "Setups today" backlog hint.

### Verification
- `python -m pytest backend/tests/ -q` → **350 passed, 1 skipped**
- `ruff check backend/` → clean
- `pnpm run lint` → no new warnings · `pnpm run build` → passes (`/rotation` prerendered ○)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Rotation** page to the app navigation.
  * Introduced a **sector rotation leaderboard** (RS 1M/3M/6M, momentum) plus a **Rotation Quadrant** chart.
  * Rotation data auto-refreshes every few minutes, with skeleton loading and an **“insufficient history to plot”** empty state.
* **Bug Fixes**
  * Improved user-facing behavior when rotation data fails to load, showing a clear error message instead of broken content (including upstream failure scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->