### PR TITLE
feat(backtester): rule-based strategy backtester (Feature 28)

### DIFF
--- a/.claude/FiForesight_Roadmap.md
+++ b/.claude/FiForesight_Roadmap.md
@@ -34,6 +34,7 @@ Documentation is part of the feature, not an afterthought. A feature PR is **not
 - Walk-forward backtester — rolling 252-day train → 5-day predict, per-model MAE + directional accuracy (#222)
 - Advanced Technical Signals (Feature 14): ATR-14 volatility-adaptive trade stops (2.0×/2.5×, 8% cap), RSI/MACD divergence detection (scipy `find_peaks`, injected into jury context + prompts), earnings surprise history (last 4Q), RF feature importance (top-5), and Stochastic/ADX/OBV sub-panels (`SignalPanels`, localStorage-persisted). New helpers in `models.py`; `indicators` payload extended; 19 new backend tests. (#260)
 - Fibonacci Retracement overlay (Feature 25): swing-high/low auto-detection → 7 retracement levels in the /predict indicators payload + toggleable dashed overlay on PriceChartCard. New `calculate_fibonacci_levels` helper in models.py.
+- Rule-Based Strategy Backtester (Feature 28): `POST /backtest` + `/backtest` page — curated long-only strategies (SMA cross / RSI reversion / MACD cross / Bollinger bounce) simulated over a yfinance window, equity curve vs buy-&-hold + win rate / max drawdown / Sharpe / CAGR. On-demand (no cron), `backtester_service.py` (reuses `models.py` indicator helpers), Redis 1h. Out-of-scope v1: shorting, leverage, costs, position sizing.
 
 ### Intelligence
 - 3-model LLM Analyst Jury (Llama 4 Scout, Llama 3.3 70B, GPT-OSS 20B) via Groq + LangGraph

--- a/backend/backtester_service.py
+++ b/backend/backtester_service.py
@@ -1,0 +1,138 @@
+# backend/backtester_service.py
+"""Rule-based strategy backtester (F28) — on-demand, long-only, single-position.
+
+Curated strategy set only; pure pandas simulation over a yfinance history window.
+No cron, no leverage, no costs (documented out-of-scope v1).
+
+Indicator math is reused from ``models.py`` (calculate_sma_series / calculate_rsi_series /
+calculate_macd / calculate_bollinger_bands) — not reimplemented here.
+"""
+import asyncio
+import logging
+
+import numpy as np
+import pandas as pd
+import yfinance as yf
+
+from models import (
+    calculate_bollinger_bands,
+    calculate_macd,
+    calculate_rsi_series,
+    calculate_sma_series,
+)
+
+logger = logging.getLogger(__name__)
+
+STRATEGIES = {"sma_cross", "rsi_reversion", "macd_cross", "bollinger_bounce"}
+_PERIOD_MAP = {"1y": "1y", "2y": "2y", "5y": "5y"}
+
+
+def _signals(df: pd.DataFrame, strategy: str, params: dict) -> pd.Series:
+    """Return a boolean 'in position' Series aligned to df.index.
+
+    Indicator series come from the shared ``models.py`` helpers (List[float] in,
+    list-with-None out); we map those into a per-bar long/flat boolean.
+    """
+    closes = df["Close"].tolist()
+    idx = df.index
+
+    if strategy == "sma_cross":
+        fast = calculate_sma_series(closes, int(params.get("fast", 20)))
+        slow = calculate_sma_series(closes, int(params.get("slow", 50)))
+        pos = [f is not None and s is not None and f > s for f, s in zip(fast, slow)]
+        return pd.Series(pos, index=idx)
+
+    if strategy == "rsi_reversion":
+        rsi = calculate_rsi_series(closes, 14)
+        lo = float(params.get("oversold", 30))
+        hi = float(params.get("overbought", 70))
+        pos, holding = [], False
+        for v in rsi:
+            if v is not None:
+                if not holding and v <= lo:
+                    holding = True
+                elif holding and v >= hi:
+                    holding = False
+            pos.append(holding)
+        return pd.Series(pos, index=idx)
+
+    if strategy == "macd_cross":
+        m = calculate_macd(closes)
+        macd, signal = m["macd"], m["signal"]
+        pos = [a is not None and b is not None and a > b for a, b in zip(macd, signal)]
+        return pd.Series(pos, index=idx)
+
+    if strategy == "bollinger_bounce":
+        bb = calculate_bollinger_bands(closes, 20, 2.0)
+        lower, mid = bb["lower"], bb["middle"]
+        pos, holding = [], False
+        for c, lo, m in zip(closes, lower, mid):
+            if not holding and lo is not None and c <= lo:
+                holding = True
+            elif holding and m is not None and c >= m:
+                holding = False
+            pos.append(holding)
+        return pd.Series(pos, index=idx)
+
+    raise ValueError(f"unknown strategy {strategy}")
+
+
+def _run(df: pd.DataFrame, in_pos: pd.Series) -> dict:
+    close = df["Close"]
+    # enter/exit on the NEXT bar (shift the position) to avoid lookahead bias
+    held = in_pos.shift(1).fillna(False)
+    ret = close.pct_change().fillna(0)
+    strat_ret = ret.where(held, 0.0)
+    equity = (1 + strat_ret).cumprod()
+    bh = (1 + ret).cumprod()
+    # trades = transitions flat->held (entry) and held->flat (exit)
+    entries = held & ~held.shift(1).fillna(False)
+    exits = ~held & held.shift(1).fillna(False)
+    trade_returns, in_trade, entry_px = [], False, None
+    for i, c in enumerate(close):
+        if entries.iloc[i]:
+            in_trade, entry_px = True, c
+        elif exits.iloc[i] and in_trade and entry_px:
+            trade_returns.append(c / entry_px - 1)
+            in_trade = False
+    wins = sum(1 for r in trade_returns if r > 0)
+    n = len(trade_returns)
+    roll_max = equity.cummax()
+    drawdown = equity / roll_max - 1
+    years = max((df.index[-1] - df.index[0]).days / 365.25, 0.01)
+    cagr = equity.iloc[-1] ** (1 / years) - 1
+    sharpe = (strat_ret.mean() / strat_ret.std() * np.sqrt(252)) if strat_ret.std() else 0.0
+    curve = [
+        {
+            "date": d.strftime("%Y-%m-%d"),
+            "strategy": round(float(e), 4),
+            "buyHold": round(float(b), 4),
+        }
+        for d, e, b in zip(df.index, equity, bh)
+    ]
+    return {
+        "totalReturnPct": round(float(equity.iloc[-1] - 1) * 100, 2),
+        "buyHoldReturnPct": round(float(bh.iloc[-1] - 1) * 100, 2),
+        "cagrPct": round(float(cagr) * 100, 2),
+        "winRatePct": round(wins / n * 100, 1) if n else None,
+        "numTrades": n,
+        "maxDrawdownPct": round(float(drawdown.min()) * 100, 2),
+        "sharpe": round(float(sharpe), 2),
+        "equityCurve": curve,
+    }
+
+
+async def run_backtest(symbol: str, strategy: str, params: dict, period: str) -> dict:
+    """Fetch the window and simulate the curated strategy (bounded 20s)."""
+    if strategy not in STRATEGIES:
+        raise ValueError("unknown strategy")
+    per = _PERIOD_MAP.get(period, "2y")
+
+    def _work():
+        df = yf.Ticker(symbol).history(period=per, auto_adjust=True)
+        if df is None or len(df) < 60:
+            raise ValueError("insufficient history")
+        in_pos = _signals(df, strategy, params)
+        return _run(df, in_pos)
+
+    return await asyncio.wait_for(asyncio.to_thread(_work), timeout=20.0)

--- a/backend/backtester_service.py
+++ b/backend/backtester_service.py
@@ -88,13 +88,20 @@ def _run(df: pd.DataFrame, in_pos: pd.Series) -> dict:
     # trades = transitions flat->held (entry) and held->flat (exit)
     entries = held & ~held.shift(1).fillna(False)
     exits = ~held & held.shift(1).fillna(False)
+    # Trade P&L uses the SAME shifted interval as strat_ret: a position held over
+    # bars [e, x-1] earns close[x-1]/close[e-1]-1, so entry/exit prices reference
+    # the prior bar's close. Keeps the trades table coherent with the equity curve.
     trade_returns, in_trade, entry_px = [], False, None
-    for i, c in enumerate(close):
+    for i in range(len(close)):
         if entries.iloc[i]:
-            in_trade, entry_px = True, c
-        elif exits.iloc[i] and in_trade and entry_px:
-            trade_returns.append(c / entry_px - 1)
+            in_trade = True
+            entry_px = close.iloc[i - 1] if i > 0 else close.iloc[i]
+        elif exits.iloc[i] and in_trade and entry_px is not None:
+            exit_px = close.iloc[i - 1] if i > 0 else close.iloc[i]
+            trade_returns.append(exit_px / entry_px - 1)
             in_trade = False
+    if in_trade and entry_px is not None:  # close any position still open on the last bar
+        trade_returns.append(close.iloc[-1] / entry_px - 1)
     wins = sum(1 for r in trade_returns if r > 0)
     n = len(trade_returns)
     roll_max = equity.cummax()
@@ -123,16 +130,25 @@ def _run(df: pd.DataFrame, in_pos: pd.Series) -> dict:
 
 
 async def run_backtest(symbol: str, strategy: str, params: dict, period: str) -> dict:
-    """Fetch the window and simulate the curated strategy (bounded 20s)."""
+    """Fetch the window and simulate the curated strategy (bounded 12s)."""
     if strategy not in STRATEGIES:
         raise ValueError("unknown strategy")
     per = _PERIOD_MAP.get(period, "2y")
 
-    def _work():
+    def _work() -> dict:
         df = yf.Ticker(symbol).history(period=per, auto_adjust=True)
         if df is None or len(df) < 60:
             raise ValueError("insufficient history")
         in_pos = _signals(df, strategy, params)
         return _run(df, in_pos)
 
-    return await asyncio.wait_for(asyncio.to_thread(_work), timeout=20.0)
+    try:
+        return await asyncio.wait_for(asyncio.to_thread(_work), timeout=12.0)
+    except asyncio.TimeoutError:
+        logger.warning("backtest timed out for %s/%s/%s", symbol, strategy, per)
+        raise
+    except ValueError:
+        raise  # insufficient history / bad input — surfaced to the caller as 422
+    except Exception:
+        logger.exception("backtest failed for %s/%s/%s", symbol, strategy, per)
+        raise

--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -1473,7 +1473,8 @@ async def backtest(request: Request, body: BacktestRequest) -> Dict[str, Any]:
         json.dumps(
             {"s": sym, "st": body.strategy, "p": body.params, "pe": body.period},
             sort_keys=True,
-        ).encode()
+        ).encode(),
+        usedforsecurity=False,
     ).hexdigest()
     cached = await cache_get(key)
     if cached:

--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -18,6 +18,7 @@ from config import Config
 from dependencies import yf_svc, limiter, fred_svc, insider_svc
 from redis_cache import cache_get, cache_set
 from screener_service import build_universe_snapshot
+from backtester_service import run_backtest, STRATEGIES
 
 _SYMBOL_RE = re.compile(r"^[A-Za-z0-9.\-:]{1,15}$")
 
@@ -1445,3 +1446,44 @@ async def run_screener(request: Request, filters: ScreenerFilter) -> Dict[str, A
 
     limit = max(1, min(filters.limit, 50))
     return {"results": rows[:limit], "total": len(rows)}
+
+
+class BacktestRequest(BaseModel):
+    """Body for the rule-based strategy backtester (F28)."""
+    symbol: str
+    strategy: str = "sma_cross"
+    params: Dict[str, Any] = {}
+    period: str = "2y"   # 1y | 2y | 5y
+
+
+@router.post("/backtest")
+@limiter.limit(lambda: Config.RATE_LIMIT_BACKTEST, key_func=get_remote_address)
+async def backtest(request: Request, body: BacktestRequest) -> Dict[str, Any]:
+    """Run a curated long-only strategy over a yfinance window. On-demand,
+    no persistence. Redis-cached 1h by (symbol,strategy,params,period)."""
+    import hashlib
+    import json
+
+    sym = body.symbol.strip().upper()
+    if not _SYMBOL_RE.match(sym):
+        raise HTTPException(status_code=422, detail="Invalid symbol.")
+    if body.strategy not in STRATEGIES:
+        raise HTTPException(status_code=422, detail="Unknown strategy.")
+    key = "backtest:" + hashlib.md5(
+        json.dumps(
+            {"s": sym, "st": body.strategy, "p": body.params, "pe": body.period},
+            sort_keys=True,
+        ).encode()
+    ).hexdigest()
+    cached = await cache_get(key)
+    if cached:
+        return cached
+    try:
+        result = await run_backtest(sym, body.strategy, body.params, body.period)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    except Exception as e:
+        logger.error(f"backtest {sym}: {e}")
+        raise HTTPException(status_code=502, detail="Backtest failed")
+    await cache_set(key, result, ttl_seconds=3600)
+    return result

--- a/backend/tests/test_backtester.py
+++ b/backend/tests/test_backtester.py
@@ -1,0 +1,110 @@
+"""
+Rule-based strategy backtester tests (F28).
+
+Service functions (_signals / _run) are exercised directly on synthetic DataFrames
+(no network). The POST /backtest endpoint is tested with a mini app, run_backtest
+patched, and Redis inert.
+"""
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pandas as pd
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from fastapi.responses import JSONResponse
+from slowapi.errors import RateLimitExceeded
+
+from backend import backtester_service as bt
+from backend.routers import market
+
+
+def _df(closes: list[float]) -> pd.DataFrame:
+    idx = pd.date_range("2022-01-01", periods=len(closes), freq="D")
+    return pd.DataFrame({"Close": closes}, index=idx)
+
+
+# ── Service: simulation logic ─────────────────────────────────────────────────
+
+def test_sma_cross_uptrend_profitable() -> None:
+    closes = [100.0 + i for i in range(120)]  # monotonically rising
+    df = _df(closes)
+    in_pos = bt._signals(df, "sma_cross", {"fast": 20, "slow": 50})
+    result = bt._run(df, in_pos)
+    assert result["totalReturnPct"] > 0
+    assert len(result["equityCurve"]) == len(closes)
+
+
+def test_no_lookahead() -> None:
+    # A signal that only fires on the LAST bar must contribute zero return,
+    # because positions are entered on the bar AFTER the signal.
+    closes = [100.0 + i for i in range(40)]
+    df = _df(closes)
+    in_pos = pd.Series([False] * 40, index=df.index)
+    in_pos.iloc[-1] = True
+    result = bt._run(df, in_pos)
+    assert result["totalReturnPct"] == 0.0
+
+
+def test_max_drawdown_negative_or_zero() -> None:
+    closes = [100, 110, 95, 130, 80, 120, 105, 90, 140, 70] * 3
+    df = _df([float(c) for c in closes])
+    in_pos = pd.Series([True] * len(closes), index=df.index)
+    result = bt._run(df, in_pos)
+    assert result["maxDrawdownPct"] <= 0
+
+
+def test_win_rate_and_trade_count() -> None:
+    # in_pos shifts to held = [F,F,T,T,F,F,T,T,F,F] →
+    #   trade 1: entry@close[2]=100 exit@close[4]=120  (win)
+    #   trade 2: entry@close[6]=120 exit@close[8]=80   (loss)
+    in_pos_vals = [False, True, True, False, False, True, True, False, False, False]
+    closes = [100, 100, 100, 110, 120, 120, 120, 90, 80, 80]
+    df = _df([float(c) for c in closes])
+    in_pos = pd.Series(in_pos_vals, index=df.index)
+    result = bt._run(df, in_pos)
+    assert result["numTrades"] == 2
+    assert result["winRatePct"] == 50.0
+
+
+# ── Endpoint ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def _no_cache() -> Generator[None, None, None]:
+    """Inert Redis so the endpoint always runs the (mocked) backtest."""
+    with patch("redis_cache.get_redis", return_value=None):
+        yield
+
+
+def _build_app() -> TestClient:
+    app = FastAPI()
+    app.state.limiter = market.limiter
+
+    async def _handler(req: Request, exc: RateLimitExceeded) -> JSONResponse:
+        return JSONResponse(status_code=429, content={"detail": "rate limited"})
+
+    app.add_exception_handler(RateLimitExceeded, _handler)
+    app.include_router(market.router)
+    return TestClient(app)
+
+
+def test_unknown_strategy_422() -> None:
+    client = _build_app()
+    resp = client.post("/backtest", json={"symbol": "AAPL", "strategy": "bogus"})
+    assert resp.status_code == 422
+
+
+def test_insufficient_history_422() -> None:
+    client = _build_app()
+    with patch.object(market, "run_backtest",
+                      AsyncMock(side_effect=ValueError("insufficient history"))):
+        resp = client.post("/backtest",
+                           json={"symbol": "AAPL", "strategy": "sma_cross"})
+    assert resp.status_code == 422
+    assert "insufficient history" in resp.json()["detail"]
+
+
+def test_invalid_symbol_422() -> None:
+    client = _build_app()
+    resp = client.post("/backtest", json={"symbol": "@@@@", "strategy": "sma_cross"})
+    assert resp.status_code == 422

--- a/backend/tests/test_backtester.py
+++ b/backend/tests/test_backtester.py
@@ -88,6 +88,23 @@ def _build_app() -> TestClient:
     return TestClient(app)
 
 
+def test_backtest_success_200() -> None:
+    client = _build_app()
+    payload = {
+        "totalReturnPct": 12.34, "buyHoldReturnPct": 8.0, "cagrPct": 5.6,
+        "winRatePct": 60.0, "numTrades": 5, "maxDrawdownPct": -10.0,
+        "sharpe": 1.1, "equityCurve": [{"date": "2024-01-01", "strategy": 1.0, "buyHold": 1.0}],
+    }
+    with patch.object(market, "run_backtest", AsyncMock(return_value=payload)):
+        resp = client.post("/backtest",
+                           json={"symbol": "AAPL", "strategy": "sma_cross",
+                                 "params": {"fast": 20, "slow": 50}, "period": "2y"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body == payload
+    assert set(body) >= {"totalReturnPct", "numTrades", "sharpe", "equityCurve"}
+
+
 def test_unknown_strategy_422() -> None:
     client = _build_app()
     resp = client.post("/backtest", json={"symbol": "AAPL", "strategy": "bogus"})

--- a/frontend/app/(app)/backtest/page.tsx
+++ b/frontend/app/(app)/backtest/page.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import React, { useState } from 'react';
+import axios from 'axios';
+import {
+  Box, Container, Typography, TextField, Button, Card, CardContent,
+  Grid, Alert, Paper, Stack, Skeleton, MenuItem, Select, InputLabel,
+  FormControl, ToggleButton, ToggleButtonGroup, useMediaQuery,
+} from '@mui/material';
+import {
+  LineChart, Line, XAxis, YAxis, CartesianGrid,
+  ResponsiveContainer, Tooltip, Legend,
+} from 'recharts';
+import { FlaskConical } from 'lucide-react';
+import { useAppShell } from '../../../contexts/AppShellContext';
+import type { BacktestResult } from '../../../types';
+
+// ── Strategy metadata ────────────────────────────────────────────────────────
+
+type ParamField = { key: string; label: string; default: number };
+
+const STRATEGIES: { value: string; label: string; params: ParamField[] }[] = [
+  {
+    value: 'sma_cross',
+    label: 'SMA Cross',
+    params: [
+      { key: 'fast', label: 'Fast SMA', default: 20 },
+      { key: 'slow', label: 'Slow SMA', default: 50 },
+    ],
+  },
+  {
+    value: 'rsi_reversion',
+    label: 'RSI Reversion',
+    params: [
+      { key: 'oversold', label: 'Oversold', default: 30 },
+      { key: 'overbought', label: 'Overbought', default: 70 },
+    ],
+  },
+  { value: 'macd_cross', label: 'MACD Cross', params: [] },
+  { value: 'bollinger_bounce', label: 'Bollinger Bounce', params: [] },
+];
+
+const PERIODS = ['1y', '2y', '5y'] as const;
+
+function fmtPct(v: number | null | undefined): string {
+  if (v === null || v === undefined) return '—';
+  return `${v > 0 ? '+' : ''}${v.toFixed(2)}%`;
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────────
+
+export default function BacktestPage() {
+  const { isDark, primaryColor } = useAppShell();
+  const isMobile = useMediaQuery('(max-width:768px)');
+  const isTablet = useMediaQuery('(max-width:1280px)');
+  const chartHeight = isMobile ? 220 : isTablet ? 300 : 400;
+
+  const [ticker, setTicker] = useState('');
+  const [strategy, setStrategy] = useState('sma_cross');
+  const [period, setPeriod] = useState<(typeof PERIODS)[number]>('2y');
+  const [params, setParams] = useState<Record<string, number>>({ fast: 20, slow: 50 });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<BacktestResult | null>(null);
+
+  const gridColor = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';
+  const axisColor = isDark ? '#94a3b8' : '#64748b';
+  const greenColor = isDark ? '#00ffa3' : '#16a34a';
+  const redColor = isDark ? '#ff0055' : '#dc2626';
+
+  const activeStrategy = STRATEGIES.find((s) => s.value === strategy)!;
+
+  const handleStrategyChange = (value: string) => {
+    setStrategy(value);
+    const next = STRATEGIES.find((s) => s.value === value)!;
+    const seeded: Record<string, number> = {};
+    next.params.forEach((p) => { seeded[p.key] = p.default; });
+    setParams(seeded);
+  };
+
+  const runBacktest = async () => {
+    const sym = ticker.trim().toUpperCase();
+    if (!sym) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await axios.post('/api/backtest', {
+        symbol: sym, strategy, params, period,
+      });
+      setResult(res.data as BacktestResult);
+    } catch (err: any) {
+      setError(err.response?.data?.error || 'Backtest failed. Try another ticker.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const beatBuyHold = result ? result.totalReturnPct > result.buyHoldReturnPct : false;
+
+  const statCards: { label: string; value: string; color?: string }[] = result
+    ? [
+        { label: 'Total Return', value: fmtPct(result.totalReturnPct),
+          color: result.totalReturnPct >= 0 ? greenColor : redColor },
+        { label: 'vs Buy & Hold', value: fmtPct(result.buyHoldReturnPct),
+          color: beatBuyHold ? greenColor : redColor },
+        { label: 'CAGR', value: fmtPct(result.cagrPct) },
+        { label: 'Win Rate', value: result.winRatePct === null ? '—' : `${result.winRatePct.toFixed(1)}%` },
+        { label: '# Trades', value: String(result.numTrades) },
+        { label: 'Max Drawdown', value: fmtPct(result.maxDrawdownPct), color: redColor },
+        { label: 'Sharpe', value: result.sharpe.toFixed(2) },
+      ]
+    : [];
+
+  return (
+    <Container maxWidth="lg" sx={{ py: { xs: 2, md: 4 } }}>
+      <Stack direction="row" spacing={1.5} alignItems="center" mb={1}>
+        <FlaskConical size={26} color={primaryColor} />
+        <Typography variant="h4" fontWeight={700}>Strategy Backtester</Typography>
+      </Stack>
+      <Typography variant="body2" color="text.secondary" mb={3}>
+        Simulate a curated long-only strategy over historical data and compare it to buy &amp; hold.
+        Single full position, no leverage, no costs.
+      </Typography>
+
+      {/* ── Rule builder ── */}
+      <Paper variant="outlined" sx={{ p: { xs: 2, md: 3 }, mb: 3 }}>
+        <Grid container spacing={2} alignItems="flex-end">
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+            <TextField
+              label="Ticker" fullWidth size="small" value={ticker}
+              onChange={(e) => setTicker(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') runBacktest(); }}
+              placeholder="AAPL"
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+            <FormControl fullWidth size="small">
+              <InputLabel id="strategy-label">Strategy</InputLabel>
+              <Select
+                labelId="strategy-label" label="Strategy" value={strategy}
+                onChange={(e) => handleStrategyChange(e.target.value)}
+              >
+                {STRATEGIES.map((s) => (
+                  <MenuItem key={s.value} value={s.value}>{s.label}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
+          {activeStrategy.params.map((p) => (
+            <Grid size={{ xs: 6, sm: 3, md: 1.5 }} key={p.key}>
+              <TextField
+                label={p.label} type="number" fullWidth size="small"
+                value={params[p.key] ?? p.default}
+                onChange={(e) => setParams((prev) => ({ ...prev, [p.key]: Number(e.target.value) }))}
+              />
+            </Grid>
+          ))}
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+            <ToggleButtonGroup
+              exclusive size="small" value={period} fullWidth
+              onChange={(_, v) => { if (v) setPeriod(v); }}
+            >
+              {PERIODS.map((p) => (
+                <ToggleButton key={p} value={p}>{p.toUpperCase()}</ToggleButton>
+              ))}
+            </ToggleButtonGroup>
+          </Grid>
+          <Grid size={{ xs: 12, md: 'auto' }}>
+            <Button
+              variant="contained" onClick={runBacktest}
+              disabled={loading || !ticker.trim()} sx={{ height: 40 }}
+            >
+              {loading ? 'Running…' : 'Run Backtest'}
+            </Button>
+          </Grid>
+        </Grid>
+      </Paper>
+
+      {error && <Alert severity="warning" sx={{ mb: 3 }}>{error}</Alert>}
+
+      {loading && (
+        <Box>
+          <Grid container spacing={2} mb={3}>
+            {Array.from({ length: 7 }).map((_, i) => (
+              <Grid size={{ xs: 6, sm: 4, md: 3 }} key={i}>
+                <Skeleton variant="rounded" height={88} />
+              </Grid>
+            ))}
+          </Grid>
+          <Skeleton variant="rounded" height={chartHeight} />
+        </Box>
+      )}
+
+      {result && !loading && (
+        <Box>
+          {/* ── Stat cards ── */}
+          <Grid container spacing={2} mb={3}>
+            {statCards.map((c) => (
+              <Grid size={{ xs: 6, sm: 4, md: 3 }} key={c.label}>
+                <Card variant="outlined" sx={{ height: '100%' }}>
+                  <CardContent sx={{ py: 2 }}>
+                    <Typography variant="caption" color="text.secondary">{c.label}</Typography>
+                    <Typography variant="h6" fontWeight={700} sx={{ color: c.color }}>
+                      {c.value}
+                    </Typography>
+                  </CardContent>
+                </Card>
+              </Grid>
+            ))}
+          </Grid>
+
+          {beatBuyHold ? (
+            <Alert severity="success" sx={{ mb: 3 }}>
+              This strategy beat buy &amp; hold by {(result.totalReturnPct - result.buyHoldReturnPct).toFixed(2)} pts.
+            </Alert>
+          ) : (
+            <Alert severity="info" sx={{ mb: 3 }}>
+              Buy &amp; hold outperformed this strategy by {(result.buyHoldReturnPct - result.totalReturnPct).toFixed(2)} pts.
+            </Alert>
+          )}
+
+          {/* ── Equity curve ── */}
+          <Paper variant="outlined" sx={{ p: { xs: 1.5, md: 3 } }}>
+            <Typography variant="subtitle1" fontWeight={600} mb={1}>
+              Equity Curve (growth of $1)
+            </Typography>
+            <ResponsiveContainer width="100%" height={chartHeight}>
+              <LineChart data={result.equityCurve} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+                <CartesianGrid stroke={gridColor} vertical={false} />
+                <XAxis
+                  dataKey="date" tick={{ fill: axisColor, fontSize: 11 }}
+                  minTickGap={48} stroke={gridColor}
+                />
+                <YAxis
+                  tick={{ fill: axisColor, fontSize: 11 }} stroke={gridColor}
+                  tickFormatter={(v) => `${v.toFixed(2)}×`} width={48}
+                />
+                <Tooltip
+                  contentStyle={{
+                    background: isDark ? '#0f172a' : '#fff',
+                    border: `1px solid ${gridColor}`, borderRadius: 8,
+                  }}
+                  formatter={(v: number) => `${v.toFixed(3)}×`}
+                />
+                <Legend />
+                <Line
+                  type="monotone" dataKey="strategy" name="Strategy"
+                  stroke={primaryColor} dot={false} strokeWidth={2}
+                />
+                <Line
+                  type="monotone" dataKey="buyHold" name="Buy & Hold"
+                  stroke={axisColor} dot={false} strokeWidth={1.5} strokeDasharray="5 4"
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </Paper>
+        </Box>
+      )}
+    </Container>
+  );
+}

--- a/frontend/app/(app)/layout.tsx
+++ b/frontend/app/(app)/layout.tsx
@@ -11,7 +11,7 @@ import {
   BrainCircuit, Home, Search, BarChart2, Calendar, Rocket, LineChart,
   Activity, Wallet, Bell, ChevronLeft, ChevronRight, Sun, Moon, LogIn, LogOut,
   Star, ChevronDown, ChevronUp, MoreHorizontal, Globe, Grid2X2, SlidersHorizontal,
-  RefreshCw,
+  RefreshCw, FlaskConical,
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { AppShellProvider, useAppShell } from '../../contexts/AppShellContext';
@@ -41,6 +41,7 @@ const NAV_ITEMS: NavItem[] = [
   { label: 'Sectors',      href: '/sectors',    icon: Grid2X2,   mobile: false },
   { label: 'Rotation',     href: '/rotation',   icon: RefreshCw, mobile: false },
   { label: 'Screener',     href: '/screener',   icon: SlidersHorizontal, mobile: false },
+  { label: 'Backtest',     href: '/backtest',   icon: FlaskConical, mobile: false },
   { label: 'Watchlist',    href: '/watchlist',  icon: Star,      mobile: false },
   { label: 'Insights',     href: '/insights',   icon: Activity,  mobile: false },
   { label: 'Simulator',    href: '/simulation', icon: LineChart, mobile: false },

--- a/frontend/app/api/backtest/route.ts
+++ b/frontend/app/api/backtest/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import axios from 'axios';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const auth = request.headers.get('authorization') || '';
+
+    const response = await axios.post(
+      `${BACKEND_URL}/backtest`,
+      body,
+      { headers: { ...(auth ? { Authorization: auth } : {}) } },
+    );
+    return NextResponse.json(response.data);
+  } catch (error: any) {
+    const status = error.response?.status || 500;
+    const detail = error.response?.data?.detail || 'Backtest failed';
+    return NextResponse.json({ error: detail }, { status });
+  }
+}

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -1,3 +1,10 @@
+export interface BacktestPoint { date: string; strategy: number; buyHold: number; }
+export interface BacktestResult {
+  totalReturnPct: number; buyHoldReturnPct: number; cagrPct: number;
+  winRatePct: number | null; numTrades: number; maxDrawdownPct: number;
+  sharpe: number; equityCurve: BacktestPoint[];
+}
+
 export interface ForecastDay {
   date:           string;
   predicted:      number;


### PR DESCRIPTION
## Feature 28 — Rule-Based Strategy Backtester

A `/backtest` page + `POST /backtest` endpoint that simulates a curated long-only strategy over a yfinance window and compares it to buy-&-hold.

### Backend
- **`backend/backtester_service.py`** — pure-pandas, long-only, single full position (all-in/all-out) simulation. Reuses the `models.py` indicator helpers (`calculate_sma_series` / `calculate_rsi_series` / `calculate_macd` / `calculate_bollinger_bands`) — no reimplementation. Positions enter on the **next bar** (`shift(1)`) to avoid lookahead. 20s bound, graceful failure.
- **`routers/market.py`** — `POST /backtest` (`BacktestRequest` body), symbol + strategy validation → 422, read-only rate limiter, Redis 1h cache keyed by `(symbol, strategy, params, period)`.
- Curated strategy set: `sma_cross`, `rsi_reversion`, `macd_cross`, `bollinger_bounce`.

### Frontend
- **`/backtest` page** — rule-builder form (ticker, strategy select, 1Y/2Y/5Y toggle, strategy-specific param fields), 7 color-coded stat cards (Total Return, vs Buy & Hold, CAGR, Win Rate, # Trades, Max Drawdown, Sharpe), beat/lag alert, and a Recharts equity curve (strategy vs buy-&-hold) with responsive height.
- API proxy, `BacktestResult`/`BacktestPoint` types, Backtest nav item (More drawer).

### Stats returned
total return, CAGR, win rate, # trades, max drawdown, Sharpe + equity curve vs buy-&-hold.

### Out-of-scope (v1)
shorting, leverage, commissions/slippage, position sizing.

### Tests / verification
- `test_backtester.py`: 7/7 (incl. **no-lookahead** + exact win-rate/trade-count).
- Full backend suite: 358 passed, 1 skipped; `ruff` clean.
- `pnpm run lint` 0 errors; `pnpm run build` passes.
- Live E2E confirmed (real AAPL curve, 422 on bad input, page renders + runs in-browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Strategy Backtester page and navigation entry.
  * Users can run long-only backtests for supported strategies, view performance metrics, and compare results against buy-and-hold.
  * Added a backtest API endpoint with caching for faster repeat requests.

* **Bug Fixes**
  * Improved request validation and error handling for invalid symbols, unknown strategies, and insufficient data.
  * Added tests to verify backtest calculations and endpoint responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->