### PR TITLE
fix(earnings): cover MU + missing semis, add earnings-date fallback

### DIFF
--- a/.claude/FiForesight_Roadmap.md
+++ b/.claude/FiForesight_Roadmap.md
@@ -80,7 +80,7 @@ Documentation is part of the feature, not an afterthought. A feature PR is **not
 - App Shell sidebar — collapsible, mobile bottom nav, `AppShellContext`, theme + auth in footer (#223)
 - Landing page — lightweight: MorningBriefingPanel + SectorHeatmap + TrendingSparklines + search (#223)
 - Standalone Options Chain tab (`/options`) — self-fetching `OptionsChainPanel`, symbol search (#225)
-- Earnings Calendar tab (`/earnings`) — top 60 S&P 500, top 8/day, Redis 6h TTL (#225)
+- Earnings Calendar tab (`/earnings`) — top ~65 S&P 500, top 12/day, Redis 6h TTL (#225; coverage fix #283)
 - Options Greeks (Δ, Θ) + aggregate stats (IV, put/call ratio, IV skew) (#225)
 - Expiry selector on options chain (#225)
 

--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -374,9 +374,35 @@ EARNINGS_NAMES: Dict[str, str] = {
     "IBM": "IBM", "SBUX": "Starbucks", "CAT": "Caterpillar", "GS": "Goldman Sachs",
     "BLK": "BlackRock", "SPGI": "S&P Global", "AXP": "American Express",
     "NOW": "ServiceNow", "ISRG": "Intuitive Surgical",
+    # Semis / large caps the team tracks but were missing (issue #283).
+    "MU": "Micron Technology", "LRCX": "Lam Research", "KLAC": "KLA Corp",
+    "ADI": "Analog Devices", "PANW": "Palo Alto Networks", "SNPS": "Synopsys",
+    "CDNS": "Cadence Design",
 }
 
 EARNINGS_WATCHLIST = list(EARNINGS_NAMES.keys())
+
+
+def _next_future_earnings_date(t: "yf.Ticker") -> Optional[str]:
+    """Fallback when ``t.calendar`` has no date: pull the next future date from
+    ``t.get_earnings_dates`` (a DataFrame indexed by Timestamp). Returns an ISO
+    ``YYYY-MM-DD`` string or None. Never raises — caller's try/except still
+    guards, but a bad ticker here degrades to None rather than aborting."""
+    try:
+        df = t.get_earnings_dates(limit=8)
+    except Exception:  # noqa: BLE001 — yfinance can raise on a missing ticker
+        try:
+            df = getattr(t, "earnings_dates", None)
+        except Exception:  # noqa: BLE001
+            return None
+    if df is None or not hasattr(df, "index") or len(df) == 0:
+        return None
+    now = pd.Timestamp.now(tz=getattr(df.index, "tz", None))
+    future = [ts for ts in df.index if pd.notna(ts) and ts >= now]
+    pick = min(future) if future else max(df.index)
+    if pd.isna(pick):
+        return None
+    return str(pick)[:10]
 
 
 @router.get("/earnings/calendar")
@@ -395,25 +421,26 @@ async def earnings_calendar(request: Request):
             try:
                 t = yf.Ticker(ticker)
                 cal = t.calendar  # dict or DataFrame depending on yfinance version
-                if cal is None:
-                    continue
-                if hasattr(cal, "loc"):  # DataFrame
+                date_val: Optional[str] = None
+                if cal is not None and hasattr(cal, "loc"):  # DataFrame
                     if "Earnings Date" in cal.index:
                         dates = cal.loc["Earnings Date"]
                         date_val = (
                             str(dates.iloc[0])[:10]
                             if hasattr(dates, "iloc") else str(dates)[:10]
                         )
-                    else:
-                        continue
                 elif isinstance(cal, dict):
-                    date_val = cal.get("Earnings Date", [None])
-                    if isinstance(date_val, list):
-                        date_val = str(date_val[0])[:10] if date_val else None
+                    raw = cal.get("Earnings Date", [None])
+                    if isinstance(raw, list):
+                        date_val = str(raw[0])[:10] if raw else None
                     else:
-                        date_val = str(date_val)[:10]
-                else:
-                    continue
+                        date_val = str(raw)[:10]
+
+                # Fallback: yfinance sometimes returns calendar=None for a name
+                # that still has a known earnings date (issue #283). Pull it from
+                # get_earnings_dates so coverage doesn't silently drop the ticker.
+                if not date_val or date_val == "None":
+                    date_val = _next_future_earnings_date(t)
                 if not date_val or date_val == "None":
                     continue
 
@@ -433,11 +460,12 @@ async def earnings_calendar(request: Request):
                 logger.debug("[EARNINGS] skipping ticker %s: %s", ticker, _exc)
                 continue
 
-        # Sort each day's entries by market cap desc, keep top 8.
+        # Sort each day's entries by market cap desc, keep top 12 so a busy
+        # earnings day doesn't silently drop mid-caps (issue #283).
         calendar: Dict[str, List[Dict[str, Any]]] = {}
         for date_str, entries in results.items():
             entries.sort(key=lambda x: x["market_cap"], reverse=True)
-            calendar[date_str] = entries[:8]
+            calendar[date_str] = entries[:12]
         return calendar
 
     try:

--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -398,11 +398,12 @@ def _next_future_earnings_date(t: "yf.Ticker") -> Optional[str]:
     if df is None or not hasattr(df, "index") or len(df) == 0:
         return None
     now = pd.Timestamp.now(tz=getattr(df.index, "tz", None))
+    # Drop NaT/None sentinels and keep only upcoming dates — never surface a
+    # past earnings date as "upcoming" by falling back to max(index).
     future = [ts for ts in df.index if pd.notna(ts) and ts >= now]
-    pick = min(future) if future else max(df.index)
-    if pd.isna(pick):
+    if not future:
         return None
-    return str(pick)[:10]
+    return str(min(future))[:10]
 
 
 @router.get("/earnings/calendar")

--- a/backend/tests/test_earnings.py
+++ b/backend/tests/test_earnings.py
@@ -1,0 +1,115 @@
+"""
+Earnings Calendar endpoint tests (issue #283) — GET /earnings/calendar.
+
+yfinance is fully mocked (no network). Covers:
+  - MU (and other added semis) is in the watchlist.
+  - calendar=None falls back to get_earnings_dates → ticker still appears.
+  - one bad ticker is skipped, the rest of the batch still returns.
+"""
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from fastapi.responses import JSONResponse
+from slowapi.errors import RateLimitExceeded
+
+from backend.routers import market
+
+
+class _FakeFastInfo:
+    def __init__(self, market_cap: float = 1_000e9) -> None:
+        self.market_cap = market_cap
+
+
+class _FakeTicker:
+    """Mimics the slice of yf.Ticker the endpoint touches."""
+
+    def __init__(self, calendar=None, earnings_dates=None, raise_on=None):
+        self._calendar = calendar
+        self._earnings_dates = earnings_dates
+        self._raise_on = raise_on
+        self.fast_info = _FakeFastInfo()
+
+    @property
+    def calendar(self):
+        if self._raise_on == "calendar":
+            raise RuntimeError("yfinance boom")
+        return self._calendar
+
+    def get_earnings_dates(self, limit: int = 8):
+        if self._earnings_dates is None:
+            raise RuntimeError("no earnings dates for this ticker")
+        return self._earnings_dates
+
+
+@pytest.fixture(autouse=True)
+def _no_cache() -> Generator[None, None, None]:
+    """Inert Redis so the endpoint always runs the (mocked) fetch."""
+    with patch("redis_cache.get_redis", return_value=None):
+        yield
+
+
+def _build_app() -> TestClient:
+    app = FastAPI()
+    app.state.limiter = market.limiter
+
+    async def _handler(req: Request, exc: RateLimitExceeded) -> JSONResponse:
+        return JSONResponse(status_code=429, content={"detail": "rate limited"})
+
+    app.add_exception_handler(RateLimitExceeded, _handler)
+    app.include_router(market.router)
+    return TestClient(app)
+
+
+def _symbols_in(payload: dict) -> set[str]:
+    out: set[str] = set()
+    for entries in payload["calendar"].values():
+        for e in entries:
+            out.add(e["symbol"])
+    return out
+
+
+def test_mu_in_watchlist() -> None:
+    # Issue #283: MU (and the added semis) must be fetched.
+    assert "MU" in market.EARNINGS_NAMES
+    assert "MU" in market.EARNINGS_WATCHLIST
+    for sym in ("LRCX", "KLAC", "ADI", "PANW", "SNPS", "CDNS"):
+        assert sym in market.EARNINGS_NAMES
+
+
+def test_calendar_fallback_to_earnings_dates() -> None:
+    future = pd.Timestamp.now().normalize() + pd.Timedelta(days=10)
+    df = pd.DataFrame(index=pd.DatetimeIndex([future]), data={"EPS Estimate": [1.23]})
+    # calendar is None, but get_earnings_dates carries a future date.
+    fake = _FakeTicker(calendar=None, earnings_dates=df)
+
+    client = _build_app()
+    with patch.object(market, "EARNINGS_WATCHLIST", ["MU"]), \
+            patch.object(market.yf, "Ticker", return_value=fake):
+        resp = client.get("/earnings/calendar")
+
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert "MU" in _symbols_in(payload)
+    assert future.strftime("%Y-%m-%d") in payload["calendar"]
+
+
+def test_bad_ticker_skipped() -> None:
+    good = _FakeTicker(calendar={"Earnings Date": ["2026-07-15"]})
+    bad = _FakeTicker(raise_on="calendar")
+
+    def _factory(symbol: str) -> _FakeTicker:
+        return bad if symbol == "BADX" else good
+
+    client = _build_app()
+    with patch.object(market, "EARNINGS_WATCHLIST", ["GOODX", "BADX"]), \
+            patch.object(market.yf, "Ticker", side_effect=_factory):
+        resp = client.get("/earnings/calendar")
+
+    assert resp.status_code == 200, resp.text
+    symbols = _symbols_in(resp.json())
+    assert "GOODX" in symbols      # batch survived the bad ticker
+    assert "BADX" not in symbols

--- a/backend/tests/test_earnings.py
+++ b/backend/tests/test_earnings.py
@@ -97,6 +97,22 @@ def test_calendar_fallback_to_earnings_dates() -> None:
     assert future.strftime("%Y-%m-%d") in payload["calendar"]
 
 
+def test_fallback_ignores_past_only_dates() -> None:
+    # earnings_dates carries only past dates → no upcoming date → ticker dropped,
+    # never surfaced under a stale date key.
+    past = pd.Timestamp.now().normalize() - pd.Timedelta(days=30)
+    df = pd.DataFrame(index=pd.DatetimeIndex([past]), data={"EPS Estimate": [1.0]})
+    fake = _FakeTicker(calendar=None, earnings_dates=df)
+
+    client = _build_app()
+    with patch.object(market, "EARNINGS_WATCHLIST", ["MU"]), \
+            patch.object(market.yf, "Ticker", return_value=fake):
+        resp = client.get("/earnings/calendar")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["calendar"] == {}
+
+
 def test_bad_ticker_skipped() -> None:
     good = _FakeTicker(calendar={"Earnings Date": ["2026-07-15"]})
     bad = _FakeTicker(raise_on="calendar")

--- a/backend/tests/test_earnings.py
+++ b/backend/tests/test_earnings.py
@@ -27,19 +27,24 @@ class _FakeFastInfo:
 class _FakeTicker:
     """Mimics the slice of yf.Ticker the endpoint touches."""
 
-    def __init__(self, calendar=None, earnings_dates=None, raise_on=None):
+    def __init__(
+        self,
+        calendar: object | None = None,
+        earnings_dates: "pd.DataFrame | None" = None,
+        raise_on: str | None = None,
+    ) -> None:
         self._calendar = calendar
         self._earnings_dates = earnings_dates
         self._raise_on = raise_on
         self.fast_info = _FakeFastInfo()
 
     @property
-    def calendar(self):
+    def calendar(self) -> object | None:
         if self._raise_on == "calendar":
             raise RuntimeError("yfinance boom")
         return self._calendar
 
-    def get_earnings_dates(self, limit: int = 8):
+    def get_earnings_dates(self, limit: int = 8) -> "pd.DataFrame":
         if self._earnings_dates is None:
             raise RuntimeError("no earnings dates for this ticker")
         return self._earnings_dates

--- a/backend/tests/test_routers.py
+++ b/backend/tests/test_routers.py
@@ -709,8 +709,8 @@ def test_earnings_calendar_groups_and_caps() -> None:
     assert "calendar" in payload and "generated_at" in payload
     cal = payload["calendar"]
     assert "2026-06-20" in cal
-    # All watchlist tickers share one date → capped to 8 per day.
-    assert len(cal["2026-06-20"]) <= 8
+    # All watchlist tickers share one date → capped to 12 per day (issue #283).
+    assert len(cal["2026-06-20"]) <= 12
     entry = cal["2026-06-20"][0]
     for key in ("symbol", "name", "market_cap", "date"):
         assert key in entry


### PR DESCRIPTION
## Summary
Fixes the Earnings Calendar tab (`/earnings`) not showing Micron (MU) and other liquid S&P 500 semis.

**Root cause:** `GET /earnings/calendar` iterates `EARNINGS_WATCHLIST = list(EARNINGS_NAMES.keys())`, a curated ~57-ticker map. MU and several semis simply weren't in `EARNINGS_NAMES`, so they were never fetched. A secondary risk: each day was capped at the top 8 by market cap, which could also hide mid-caps on a busy day.

## Changes
- **Watchlist coverage** — add `MU`, `LRCX`, `KLAC`, `ADI`, `PANW`, `SNPS`, `CDNS` to `EARNINGS_NAMES` (kept curated, ~65 total).
- **Fallback path** — in `_fetch_earnings`, when `t.calendar` yields no usable date, fall back to `t.get_earnings_dates(limit=8)` and take the next future date. Guarded in the same try/except so one bad ticker still never aborts the batch — robust to yfinance returning `calendar=None` for a name that does have a known earnings date.
- **Per-day cap** — raised 8 → 12 so large earnings days don't silently drop names. Roadmap note updated.

## Tests
- New `backend/tests/test_earnings.py` (yfinance fully mocked, no network):
  - `test_mu_in_watchlist` — MU + added semis present.
  - `test_calendar_fallback_to_earnings_dates` — `calendar=None` → fallback surfaces the future date.
  - `test_bad_ticker_skipped` — one ticker raises, batch still returns the rest.
- Updated the existing cap assertion in `test_routers.py` (8 → 12).
- Full backend suite green (362 passed, 1 skipped); ruff clean.

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded earnings calendar coverage to include more large-cap and semiconductor names.
  * Improved earnings date handling so missing calendar data can still surface a future estimated date.
  * Increased the number of entries shown per earnings date from 8 to 12.

* **Bug Fixes**
  * Better handles varied data formats from market data sources.
  * Skips individual ticker failures without breaking the full earnings calendar response.

* **Tests**
  * Added coverage for watchlist inclusion, fallback behavior, and ticker error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->