### PR TITLE
ci: server-side Dependabot auto-merge + minor/patch grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,33 +2,62 @@
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Each ecosystem groups its minor + patch bumps into a single combined PR
+# ("minor-and-patch") so one approval + one CI run + one merge clears them all.
+# Major bumps still open as individual PRs (left out of the group) for manual review.
 
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directories: 
+    directories:
       - "/"
       - "/frontend"
     schedule:
       interval: "daily"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "pip"
-    directories: 
+    directories:
       - "/backend"
     schedule:
       interval: "daily"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
-    directories: 
+    directories:
       - "/"
     schedule:
       interval: "daily"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "docker"
-    directories: 
+    directories:
       - "/"
     schedule:
       interval: "daily"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "terraform"
-    directories: 
+    directories:
       - "/terraform"
       - "/terraform-preview"
     schedule:
       interval: "daily"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,33 @@
+name: Dependabot auto-merge
+
+# Arms GitHub auto-merge on Dependabot PRs that are patch- or minor-level bumps.
+# The server then squash-merges them once all required checks pass AND a human
+# code-owner has approved (the branch ruleset still requires that approval — this
+# workflow only enables auto-merge, it never approves). Major bumps are left
+# untouched for manual review. Runs 24/7, independent of any local machine.
+
+on:
+  pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    # Only act on Dependabot's own PRs.
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable squash auto-merge for patch and minor updates
+        if: ${{ steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why
The Claude scheduled task that arms auto-merge is **client-side** — it only fires while the app is open, so in practice it runs ~once/day and approved Dependabot PRs (e.g. #295/#296/#297, which were green + approved but just never visited) sit in the backlog. This moves the "arm auto-merge" job **server-side** so it runs 24/7 regardless of any local machine.

## What
- **`.github/workflows/dependabot-automerge.yml`** — on every Dependabot PR (`pull_request_target`), reads the bump level via `dependabot/fetch-metadata` and runs `gh pr merge --auto --squash` for **patch/minor only**. Majors are left untouched for manual review.
  - It **only enables auto-merge** — the `main` ruleset still requires a human code-owner approval and all required checks green before anything merges. No approvals are bypassed; `--admin` is never used.
  - Uses the built-in `GITHUB_TOKEN` with `contents: write` + `pull-requests: write`.
- **`.github/dependabot.yml`** — groups each ecosystem's **minor + patch** bumps into one combined PR (`minor-and-patch`) so one approval / one CI run / one merge clears them all. Major bumps still open individually.

## Effect
Approved patch/minor Dependabot PRs now merge within minutes of CI passing, whether or not a PC is online. The existing Claude daily sweep remains as a backstop to flag majors / unusual diffs the workflow intentionally skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)