### PR TITLE
test(responsive): Playwright responsive QA harness (Infra)

### DIFF
--- a/.claude/FiForesight_Roadmap.md
+++ b/.claude/FiForesight_Roadmap.md
@@ -114,6 +114,7 @@ Beyond the five docs above, every feature/fix PR must also satisfy:
 - HTTPS, Docker multi-stage, Koyeb + Oracle Cloud deploys
 - GitHub Actions: PR preview + prod deploy; Alpaca API keys wired through deploy pipeline (#209 + workflow updates)
 - FastMCP server (`mcp_server.py`)
+- Responsive QA harness — Playwright smoke test (`frontend/tests/e2e/responsive.spec.ts`, `pnpm run test:responsive`) loading every app route at 320/768/1280/2560 and failing on horizontal overflow or a missing app shell; enforces the "multi-screen responsive" build standard. Layout-only (tolerates empty/error states), runs logged-out so AuthGates are covered.
 
 ---
 
@@ -297,8 +298,8 @@ Beyond the five docs above, every feature/fix PR must also satisfy:
 > yfinance fundamentals-service expansion); J/K/M = portfolio/holdings; G = `/macro`; I = options chain.
 
 **Tier 0 — infra (do first; enforces the responsive build standard)**
-- **Responsive QA harness** *(NEXT UP)* — Playwright smoke test: load every route at 320/768/1280/2560,
-  fail CI on horizontal overflow or a missing key element. · `[Value: High]` `[Effort: Med]`
+- **Responsive QA harness** — ✅ **Shipped** (see Shipped → Infra). Playwright smoke test loading every
+  route at 320/768/1280/2560, failing on horizontal overflow or a missing app shell. `pnpm run test:responsive`.
 
 **Tier 1 — quick, high-value wins**
 - **H · Stock Report Card** *(NEXT UP)* — one-glance grade (Value / Growth / Profitability / Momentum /

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -81,6 +81,54 @@ jobs:
           NEXT_PUBLIC_APP_ENV: preview
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+  responsive-qa:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        working-directory: frontend
+        shell: bash
+        run: npm install --global pnpm
+
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'latest'
+
+      - name: Install Dependencies
+        working-directory: frontend
+        shell: bash
+        run: pnpm install --lockfile
+
+      - name: Install Playwright Chromium
+        working-directory: frontend
+        shell: bash
+        run: pnpm exec playwright install --with-deps chromium
+
+      # Layout-only smoke test: loads every route at 320/768/1280/2560 and
+      # fails on horizontal overflow or a missing app shell. Tolerates empty/
+      # error states, so it never depends on live yfinance/Groq success. The
+      # webServer block builds the prod bundle itself.
+      - name: Run Responsive QA Harness
+        working-directory: frontend
+        shell: bash
+        run: pnpm run test:responsive
+        env:
+          CI: 'true'
+          NEXT_PUBLIC_APP_ENV: preview
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 7
+
   build-backend:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,10 @@ __pycache__/
 # OS
 .DS_Store
 Thumbs.db
+
+# Playwright (responsive QA harness)
+test-results/
+playwright-report/
+frontend/test-results/
+frontend/playwright-report/
+frontend/playwright/.cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,23 @@ ruff check backend/                   # linter
 # Frontend
 pnpm run lint    # ESLint
 pnpm run build   # Next.js production build
+
+# Responsive QA harness (Playwright) — builds a prod bundle + smoke-tests every route
+cd frontend && pnpm run test:responsive
 ```
+
+### Responsive QA
+`pnpm run test:responsive` (`frontend/tests/e2e/responsive.spec.ts`, `frontend/playwright.config.ts`) is the
+enforcement mechanism for the "multi-screen responsive" build standard. It loads **every** app route at four
+viewports — **320 (phone) / 768 (tablet) / 1280 (desktop) / 2560 (4K)** — and, per route×viewport, asserts
+(a) the app shell (`data-testid="app-shell"`) is visible and (b) **no horizontal overflow** at both the document
+level *and* the `<main>` content container (the layout gives `<main>` `overflowY:auto` → computed `overflow-x:auto`,
+so content overflow is absorbed by main's own scrollbar and would escape a document-only check). It's **layout-only**
+— tolerates empty/error states, never asserts fetched content — and runs **logged-out**, so the AuthGates on
+`/portfolio` `/alerts` `/simulation` are covered too. The `webServer` block runs `pnpm run build && pnpm run start`.
+**New pages must pass it:** add the route to `ROUTES` (kept in sync with `NAV_ITEMS`); if you introduce a new
+top-level shell area outside the `(app)` layout, give its root `data-testid="app-shell"`. Artifacts
+(`test-results/`, `playwright-report/`, `playwright/.cache/`) are gitignored.
 
 ---
 

--- a/frontend/app/(app)/layout.tsx
+++ b/frontend/app/(app)/layout.tsx
@@ -493,7 +493,7 @@ function Shell({ children }: { children: React.ReactNode }) {
   const { watchlist } = useWatchlistContext();
 
   return (
-    <Box sx={{ display: 'flex', minHeight: '100vh' }}>
+    <Box data-testid="app-shell" sx={{ display: 'flex', minHeight: '100vh' }}>
       <Sidebar />
       <Box
         component="main"

--- a/frontend/app/simulation/page.tsx
+++ b/frontend/app/simulation/page.tsx
@@ -1245,7 +1245,7 @@ export default function SimulationPage() {
   return (
     <ThemeProvider theme={darkTheme}>
       <CssBaseline />
-      <Box sx={{ minHeight: '100vh', bgcolor: 'background.default' }}>
+      <Box data-testid="app-shell" sx={{ minHeight: '100vh', bgcolor: 'background.default' }}>
         {/* Top bar */}
         <Box sx={{
           borderBottom: '1px solid rgba(255,255,255,0.06)',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test:responsive": "playwright test"
   },
   "dependencies": {
     "@emotion/cache": "^11.14.0",
@@ -29,6 +30,7 @@
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^16.2.9",
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.3.1",
     "@types/node": "^25.9.3",
     "@types/react": "^19.2.17",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Responsive QA harness — see tests/e2e/responsive.spec.ts.
+ *
+ * Loads every app route at four viewports (phone/tablet/desktop/4K) and fails on
+ * horizontal overflow or a missing app shell. This is the enforcement mechanism
+ * for FiForesight's "multi-screen responsive" build standard.
+ *
+ * The webServer runs a production build (`pnpm run build && pnpm run start`) so the
+ * harness exercises the same bundle that ships. Pages fetch live yfinance/Groq data
+ * that may be slow or empty — the harness tests LAYOUT only, tolerating empty/error
+ * states, so it never depends on live network success.
+ */
+export default defineConfig({
+  testDir: './tests/e2e',
+  // Per-test budget must exceed the 30s goto timeout so the layout assertions
+  // still run after a data-heavy page (e.g. /earnings) never reaches networkidle
+  // and the goto times out.
+  timeout: 60_000,
+  // Fail the build on an accidental test.only left in source.
+  forbidOnly: !!process.env.CI,
+  // A single prod server is the bottleneck — keep concurrency modest so slow,
+  // data-heavy pages don't time out fighting each other for resources.
+  workers: process.env.CI ? 2 : 4,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    command: 'pnpm run build && pnpm run start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+});

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 1.18.0(react@19.2.7)
       next:
         specifier: 16.2.9
-        version: 16.2.9(@babel/core@7.29.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@babel/core@7.29.0)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       plotly.js:
         specifier: ^3.6.0
         version: 3.6.0(mapbox-gl@1.13.3)
@@ -63,6 +63,9 @@ importers:
       '@next/eslint-plugin-next':
         specifier: ^16.2.9
         version: 16.2.9
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@tailwindcss/postcss':
         specifier: ^4.3.1
         version: 4.3.1
@@ -680,6 +683,11 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@plotly/d3-sankey-circular@0.33.1':
     resolution: {integrity: sha512-FgBV1HEvCr3DV7RHhDsPXyryknucxtfnLwPtCKKxdolKyTFYoLX/ibEfX39iFYIL7DYbVeRtP43dbFcrHNE+KQ==}
@@ -1969,6 +1977,11 @@ packages:
   from2@2.3.0:
     resolution: {integrity: sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -2776,6 +2789,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plotly.js@3.6.0:
     resolution: {integrity: sha512-Fu5IaetcuxaeQPULk4wfIik0MnvIsEb5ynOsPAMfhAnjkPOEDFG7eSb/3ZZq1DW5MwYvZFXaTFHpal4U1Q5Yig==}
@@ -3947,6 +3970,10 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
 
   '@plotly/d3-sankey-circular@0.33.1':
     dependencies:
@@ -5460,6 +5487,9 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 2.3.8
 
+  fsevents@2.3.2:
+    optional: true
+
   function-bind@1.1.2: {}
 
   function.prototype.name@1.1.8:
@@ -6149,7 +6179,7 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@16.2.9(@babel/core@7.29.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.9(@babel/core@7.29.0)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
@@ -6168,6 +6198,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.9
       '@next/swc-win32-arm64-msvc': 16.2.9
       '@next/swc-win32-x64-msvc': 16.2.9
+      '@playwright/test': 1.61.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -6308,6 +6339,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plotly.js@3.6.0(mapbox-gl@1.13.3):
     dependencies:

--- a/frontend/tests/e2e/responsive.spec.ts
+++ b/frontend/tests/e2e/responsive.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Responsive QA harness.
+ *
+ * For every app route × every supported viewport this asserts two things:
+ *   1. NO HORIZONTAL OVERFLOW — the page never grows wider than the viewport
+ *      (1px slack for sub-pixel rounding). This is the core enforcement of the
+ *      "multi-screen responsive" build standard.
+ *   2. KEY ELEMENT VISIBLE — the app shell rendered, i.e. the page actually
+ *      mounted rather than crashing into a blank/error boundary.
+ *
+ * Layout-only: pages fetch live yfinance/Groq data that may be slow or empty.
+ * We tolerate empty/error states and never assert on fetched content, so the
+ * harness can't flake on a third-party outage. Auth-gated routes (/portfolio,
+ * /alerts, /simulation) are tested LOGGED OUT — the AuthGate they render must
+ * also be responsive.
+ *
+ * Keeping ROUTES in sync: every entry below must exist as a page under
+ * frontend/app — the list mirrors the NAV_ITEMS array in
+ * frontend/app/(app)/layout.tsx (plus '/simulation', which lives outside the
+ * (app) route group but is still a nav item). If a route is added/removed in
+ * NAV_ITEMS, update this list so the harness can't silently drift.
+ */
+const ROUTES = [
+  '/',           // Home
+  '/analysis',   // Analysis
+  '/options',    // Options
+  '/earnings',   // Earnings
+  '/ipo',        // IPO Tracker
+  '/macro',      // Macro
+  '/sectors',    // Sectors
+  '/rotation',   // Rotation
+  '/screener',   // Screener
+  '/backtest',   // Backtest
+  '/watchlist',  // Watchlist
+  '/insights',   // Insights
+  '/simulation', // Simulator (auth-gated; outside the (app) group)
+  '/portfolio',  // My Portfolio (auth-gated)
+  '/alerts',     // Alerts (auth-gated)
+] as const;
+
+const VIEWPORTS = [
+  { w: 320,  h: 740,  name: 'phone'   },
+  { w: 768,  h: 1024, name: 'tablet'  },
+  { w: 1280, h: 900,  name: 'desktop' },
+  { w: 2560, h: 1440, name: '4k'      },
+] as const;
+
+for (const route of ROUTES) {
+  for (const vp of VIEWPORTS) {
+    test(`${route} @ ${vp.name} (${vp.w}px)`, async ({ page }, testInfo) => {
+      await page.setViewportSize({ width: vp.w, height: vp.h });
+
+      // networkidle can never settle on pages with polling/long-poll fetches;
+      // treat a timeout as "loaded enough" and proceed to the layout assertions.
+      try {
+        await page.goto(route, { waitUntil: 'networkidle', timeout: 30_000 });
+      } catch {
+        // proceed — we test layout, not load completion.
+      }
+
+      // Optional debug artifact (not asserted).
+      await page
+        .screenshot({
+          path: testInfo.outputPath(`${route.replace(/\W+/g, '_') || 'home'}-${vp.name}.png`),
+          fullPage: false,
+        })
+        .catch(() => { /* screenshots are best-effort */ });
+
+      // 1. KEY ELEMENT VISIBLE — the shell mounted.
+      await expect(
+        page.getByTestId('app-shell'),
+        `app-shell should be visible on ${route} @ ${vp.name}`,
+      ).toBeVisible({ timeout: 15_000 });
+
+      // 2. NO HORIZONTAL OVERFLOW.
+      //
+      // Two complementary checks (1px slack for sub-pixel rounding):
+      //   a. document level — the page never grows wider than the viewport.
+      //      Catches overflow that escapes to the page (e.g. a fixed-position
+      //      mobile bar wider than the screen).
+      //   b. content container — the app shell's <main> scroll region is not
+      //      wider than its own client box. The (app) layout gives <main>
+      //      `overflowY: auto`, which CSS resolves to `overflow-x: auto` too, so
+      //      content overflow is absorbed by main's own scrollbar and never
+      //      reaches documentElement — check (a) alone would miss it. Intentional
+      //      `overflowX: auto` sub-panels (option chains, heatmaps) clip inside
+      //      themselves and don't widen <main>, so they don't false-positive.
+      const metrics = await page.evaluate(() => {
+        const main = document.querySelector('main');
+        return {
+          docScrollWidth: document.documentElement.scrollWidth,
+          innerWidth: window.innerWidth,
+          mainScrollWidth: main?.scrollWidth ?? null,
+          mainClientWidth: main?.clientWidth ?? null,
+        };
+      });
+
+      expect(
+        metrics.docScrollWidth,
+        `Horizontal overflow (document) on ${route} @ ${vp.name} (${vp.w}px): ` +
+          `scrollWidth=${metrics.docScrollWidth} > innerWidth=${metrics.innerWidth}`,
+      ).toBeLessThanOrEqual(metrics.innerWidth + 1);
+
+      if (metrics.mainScrollWidth !== null && metrics.mainClientWidth !== null) {
+        expect(
+          metrics.mainScrollWidth,
+          `Horizontal overflow (content) on ${route} @ ${vp.name} (${vp.w}px): ` +
+            `main.scrollWidth=${metrics.mainScrollWidth} > main.clientWidth=${metrics.mainClientWidth}`,
+        ).toBeLessThanOrEqual(metrics.mainClientWidth + 1);
+      }
+    });
+  }
+}


### PR DESCRIPTION
## What & why

An automated **Playwright** smoke test that loads **every app route** at four viewports and **fails on horizontal overflow or a missing app shell** — the enforcement mechanism for the project's "multi-screen responsive" build standard.

- **Routes** (`ROUTES` in `frontend/tests/e2e/responsive.spec.ts`) are cross-checked against `NAV_ITEMS` in `frontend/app/(app)/layout.tsx` so the list can't silently drift. Covers all 14 `(app)` pages + the standalone `/simulation`.
- **Viewports**: `320` (phone) / `768` (tablet) / `1280` (desktop) / `2560` (4K) → **60 tests**.
- Per route×viewport it asserts:
  1. **App shell visible** — `data-testid="app-shell"` (added to the `(app)` layout Shell and the standalone `/simulation` root).
  2. **No horizontal overflow** — at **both** the document level (`documentElement.scrollWidth <= innerWidth + 1`) **and** the `<main>` content container. The layout gives `<main>` `overflowY:auto`, which CSS resolves to `overflow-x:auto` too, so content overflow is absorbed by main's own scrollbar and would **escape a document-only check** — the content-container assertion is what actually catches it.

## Guardrails against flakiness
- **Layout-only**: never asserts fetched content, so a slow/empty yfinance/Groq response can't fail it. `networkidle` goto timeouts are caught and the test proceeds; per-test timeout is 60s so a data-heavy page (e.g. `/earnings`, up to 30s cold) still has budget for the assertions.
- **Logged-out**: auth-gated routes (`/portfolio`, `/alerts`, `/simulation`) render their AuthGate — which must also be responsive — and are asserted no-overflow.
- Workers capped so the single prod server isn't a bottleneck.

## Verification
- ✅ All **60** tests pass locally (`pnpm run test:responsive`) at all 4 viewports.
- ✅ **Failure verified**: a temporary 5000px element made `/` fail with `main.scrollWidth=5024 > main.clientWidth=1060` (only that route), then reverted. This also confirmed the content-container check is the meaningful one.
- ✅ `pnpm run lint` clean (pre-existing warnings only); prod build exercised by the harness webServer.

## Run it
```bash
cd frontend && pnpm run test:responsive
```

## CI
The second commit (`ci(responsive): …`) adds a `responsive-qa` job to `pull-request.yml` (installs chromium, runs the harness, uploads the HTML report). Kept in its own commit so it's trivial to revert if a CI run flakes.

## Docs
- `.claude/FiForesight_Roadmap.md`: Responsive QA harness → **Shipped / Infra** (NEXT UP removed).
- `CLAUDE.md`: new **Responsive QA** note (how to run, viewport list, how to keep new pages passing).

Artifacts (`test-results/`, `playwright-report/`, `playwright/.cache/`) are gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)